### PR TITLE
Allow removing properties, and check remove value on objects

### DIFF
--- a/Products/GenericSetup/tests/test_utils.py
+++ b/Products/GenericSetup/tests/test_utils.py
@@ -205,6 +205,21 @@ _REMOVE_IMPORT = """\
 </dummy>
 """
 
+_ADD_PROPERTY_IMPORT = """\
+<?xml version="1.0"?>
+<dummy>
+ <property name="line1" type="string">Line 1</property>
+</dummy>
+"""
+
+_REMOVE_PROPERTY_IMPORT = """\
+<?xml version="1.0"?>
+<dummy>
+ <property name="line1" remove="True"/>
+</dummy>
+"""
+
+
 def _getDocumentElement(text):
     from xml.dom.minidom import parseString
     return parseString(text).documentElement
@@ -500,6 +515,30 @@ class PropertyManagerHelpersTests(unittest.TestCase):
 
         self.assertEquals(obj.getProperty('lines1'), ('Gee', 'Bar'))
         self.assertEquals(obj.getProperty('lines2'), ('Gee',))
+
+    def test_initProperties_remove_properties(self):
+        helpers = self._makeOne()
+        helpers.environ._should_purge = False # extension profile
+        obj = helpers.context
+        obj._properties = ()
+
+        # Add property
+        node = _getDocumentElement(_ADD_PROPERTY_IMPORT)
+        helpers._initProperties(node)
+        self.assertTrue(obj.hasProperty('line1'))
+        self.assertEquals(obj.getProperty('line1'), 'Line 1')
+
+        # Remove it again
+        node = _getDocumentElement(_REMOVE_PROPERTY_IMPORT)
+        helpers._initProperties(node)
+        self.assertFalse(obj.hasProperty('line1'))
+
+        # Removing it a second time should not throw an
+        # AttributeError.
+        node = _getDocumentElement(_REMOVE_PROPERTY_IMPORT)
+        helpers._initProperties(node)
+        self.assertFalse(obj.hasProperty('line1'))
+
 
 class PropertyManagerHelpersNonPMContextTests(PropertyManagerHelpersTests):
 

--- a/Products/GenericSetup/tests/test_utils.py
+++ b/Products/GenericSetup/tests/test_utils.py
@@ -177,7 +177,7 @@ _REMOVE_ELEMENT_IMPORT = """\
 <dummy>
  <property name="lines1" purge="False">
    <element value="Foo" remove="True" />
-   <element value="Bar" />
+   <element value="Bar" remove="False" />
   </property>
  <property name="lines2" purge="False">
    <element value="Foo" remove="True" />
@@ -196,12 +196,14 @@ _ADD_IMPORT = """\
 <?xml version="1.0"?>
 <dummy>
  <object name="history" meta_type="Generic Setup Tool"/>
+ <object name="future" meta_type="Generic Setup Tool"/>
 </dummy>
 """
 _REMOVE_IMPORT = """\
 <?xml version="1.0"?>
 <dummy>
  <object name="history" remove="True"/>
+ <object name="future" remove="False"/>
 </dummy>
 """
 
@@ -209,6 +211,7 @@ _ADD_PROPERTY_IMPORT = """\
 <?xml version="1.0"?>
 <dummy>
  <property name="line1" type="string">Line 1</property>
+ <property name="line2" type="string">Line 2</property>
 </dummy>
 """
 
@@ -216,6 +219,7 @@ _REMOVE_PROPERTY_IMPORT = """\
 <?xml version="1.0"?>
 <dummy>
  <property name="line1" remove="True"/>
+ <property name="line2" type="string" remove="False"/>
 </dummy>
 """
 
@@ -522,22 +526,25 @@ class PropertyManagerHelpersTests(unittest.TestCase):
         obj = helpers.context
         obj._properties = ()
 
-        # Add property
+        # Add two properties
         node = _getDocumentElement(_ADD_PROPERTY_IMPORT)
         helpers._initProperties(node)
         self.assertTrue(obj.hasProperty('line1'))
         self.assertEquals(obj.getProperty('line1'), 'Line 1')
+        self.assertTrue(obj.hasProperty('line2'))
 
-        # Remove it again
+        # Remove one.
         node = _getDocumentElement(_REMOVE_PROPERTY_IMPORT)
         helpers._initProperties(node)
         self.assertFalse(obj.hasProperty('line1'))
+        self.assertTrue(obj.hasProperty('line2'))
 
         # Removing it a second time should not throw an
         # AttributeError.
         node = _getDocumentElement(_REMOVE_PROPERTY_IMPORT)
         helpers._initProperties(node)
         self.assertFalse(obj.hasProperty('line1'))
+        self.assertTrue(obj.hasProperty('line2'))
 
 
 class PropertyManagerHelpersNonPMContextTests(PropertyManagerHelpersTests):
@@ -698,21 +705,24 @@ class ObjectManagerHelpersTests(ZopeTestCase):
         obj = helpers.context
         self.failIf('history' in obj.objectIds())
 
-        # Add object
+        # Add two objects
         node = _getDocumentElement(_ADD_IMPORT)
         helpers._initObjects(node)
         self.failUnless('history' in obj.objectIds())
+        self.failUnless('future' in obj.objectIds())
 
-        # Remove it again
+        # Remove one
         node = _getDocumentElement(_REMOVE_IMPORT)
         helpers._initObjects(node)
         self.failIf('history' in obj.objectIds())
+        self.failUnless('future' in obj.objectIds())
         
         # Removing it a second time should not throw an
         # AttributeError.
         node = _getDocumentElement(_REMOVE_IMPORT)
         helpers._initObjects(node)
         self.failIf('history' in obj.objectIds())
+        self.failUnless('future' in obj.objectIds())
         
 
 class PrettyDocumentTests(unittest.TestCase):

--- a/Products/GenericSetup/utils.py
+++ b/Products/GenericSetup/utils.py
@@ -554,7 +554,8 @@ class ObjectManagerHelpers(object):
             parent = self.context
 
             obj_id = str(child.getAttribute('name'))
-            if child.hasAttribute('remove'):
+            if self._convertToBoolean(
+                child.getAttribute('remove') or 'False'):
                 if obj_id in parent.objectIds():
                     parent._delObject(obj_id)
                 continue

--- a/Products/GenericSetup/utils.py
+++ b/Products/GenericSetup/utils.py
@@ -717,10 +717,14 @@ class PropertyManagerHelpers(object):
         for child in node.childNodes:
             if child.nodeName != 'property':
                 continue
+            remove = self._convertToBoolean(
+                child.getAttribute('remove') or 'False')
             prop_id = str(child.getAttribute('name'))
             prop_map = obj.propdict().get(prop_id, None)
 
             if prop_map is None:
+                if remove:
+                    continue
                 if child.hasAttribute('type'):
                     val = str(child.getAttribute('select_variable'))
                     prop_type = str(child.getAttribute('type'))
@@ -729,7 +733,13 @@ class PropertyManagerHelpers(object):
                 else:
                     raise ValueError("undefined property '%s'" % prop_id)
 
-            if not 'w' in prop_map.get('mode', 'wd'):
+            if remove:
+                if 'd' not in prop_map.get('mode', 'wd'):
+                    raise BadRequest('%s cannot be deleted' % prop_id)
+                obj._delProperty(prop_id)
+                continue
+
+            if 'w' not in prop_map.get('mode', 'wd'):
                 raise BadRequest('%s cannot be changed' % prop_id)
 
             new_elements = []

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 1.7.7 (unreleased)
 ------------------
 
+- Check the boolean value of the ``remove`` option when importing
+  objects.  Previously we only checked if the ``remove`` option was
+  given, regardless of its value.  Supported are ``True``, ``Yes``,
+  and ``1``, where case does not matter.  The syntax for removing
+  objects, properties, and elements is now the same.
+
 - Support ``remove="True"`` for properties.
 
 

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 1.7.7 (unreleased)
 ------------------
 
-- TBD
+- Support ``remove="True"`` for properties.
 
 
 1.7.6 (2015-07-15)


### PR DESCRIPTION
I cannot believe I did not fix this eight years or so ago... I wanted to use this today and was surprised it did not work.

This pull request has two related fixes:

1. Support `remove="True"` on properties. Today I tried `<property name="default_page" remove="True" />` in the `properties.xml` of a Plone Site and was surprised that the default_page property was still there afterwards, only empty.

2. When an object has `remove="False"` do not remove it...

Note that this pull request is based on my pull request #11 of about an hour ago. So please merge that one first. I can rebase it afterwards if needed. I wonder if this was a good idea, because I see that commits from that earlier pull request show up below as well... We'll see.