### PR TITLE
Bugfix for TarballImportContext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,11 @@ eggs
 local.cfg
 parts
 var
+
+# VirtualEnv on Windows:
+Include/
+Lib/
+Scripts/
+
+# Editor Backups:
+*~

--- a/Products/GenericSetup/context.py
+++ b/Products/GenericSetup/context.py
@@ -377,7 +377,7 @@ class TarballImportContext( BaseContext ):
             if not self.isDirectory(path):
                 return None
 
-            if path[-1] != '/':
+            if not path.endswith('/'):
                 path = path + '/'
 
         pfx_len = len(path)
@@ -406,7 +406,7 @@ class TarballImportContext( BaseContext ):
         return self._should_purge
 
     def _getTarInfo( self, path ):
-        if path[-1] == '/':
+        if path.endswith('/'):
             path = path[:-1]
         try:
             return self._archive.getmember( path )


### PR DESCRIPTION
n Products/GenericSetup/context.py, there are two comparisons of path[-1] to ‘/’, which must fail for empty strings. IMO, here the endswith method must be used.

The empty string seems to be a known special case for tarballs.

See as well https://bugs.launchpad.net/zope2/+bug/1479268; this pull request includes the patch which I attached there.