### PR TITLE
Add upgradeProfile method

### DIFF
--- a/Products/GenericSetup/tests/test_tool.py
+++ b/Products/GenericSetup/tests/test_tool.py
@@ -1043,12 +1043,10 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         # Upgrade the profile two steps to version 3.
         tool.upgradeProfile('foo', '3')
         self.assertEqual(tool.getLastVersionForProfile('foo'), ('3',))
-        # Upgrade the profile to a non existing version.
-        tool.upgradeProfile('foo', 'no-such-step')
-        self.assertEqual(tool.getLastVersionForProfile('foo'), ('4',))
-        # Reset.
-        tool.setLastVersionForProfile('foo', '0')
-        self.assertEqual(tool.getLastVersionForProfile('foo'), ('0',))
+        # Upgrade the profile to a non existing version.  Nothing
+        # should happen.
+        tool.upgradeProfile('foo', '5')
+        self.assertEqual(tool.getLastVersionForProfile('foo'), ('3',))
         # Upgrade the profile to the latest version.
         tool.upgradeProfile('foo')
         self.assertEqual(tool.getLastVersionForProfile('foo'), ('4',))

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -912,7 +912,7 @@ class SetupTool(Folder):
 
         # We update the profile version to the last one we have reached
         # with running an upgrade step.
-        if step and step.dest is not None and step.checker is None:
+        if step and step.dest is not None:
             self.setLastVersionForProfile(profile_id, step.dest)
 
         url = self.absolute_url()
@@ -973,7 +973,7 @@ class SetupTool(Folder):
                 step.doStep(self)
             # We update the profile version to the last one we have
             # reached with running an upgrade step.
-            if step and step.dest is not None and step.checker is None:
+            if step and step.dest is not None:
                 self.setLastVersionForProfile(profile_id, step.dest)
                 generic_logger.info(
                     'Profile %s upgraded to version %r.',

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,13 @@ Changelog
 1.7.7 (unreleased)
 ------------------
 
+- Fixed: when the last applied upgrade step had a checker, the profile
+  version was not updated.  Now we no longer look at the checker of
+  the last applied step when deciding whether to set the profile
+  version.  The checker, if any is set, normally returns True before
+  running the step (it can be applied), and False afterwards (it
+  was already applied).
+
 - Added upgradeProfile method to setup tool.  This applies all
   upgrades steps for the given profile, or updates it to the optional
   given version.  If the profile does not exist, we warn and do

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 1.7.7 (unreleased)
 ------------------
 
+- Added upgradeProfile method to setup tool.  This applies all
+  upgrades steps for the gibven profile, or updates it to the given
+  version.  If the profile does not exist, we warn and do nothing.  If
+  the there is no upgrade step to go to the specified version, we warn
+  and upgrade to the latest version.
+
 - Check the boolean value of the ``remove`` option when importing
   objects.  Previously we only checked if the ``remove`` option was
   given, regardless of its value.  Supported are ``True``, ``Yes``,

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -5,10 +5,10 @@ Changelog
 ------------------
 
 - Added upgradeProfile method to setup tool.  This applies all
-  upgrades steps for the gibven profile, or updates it to the given
-  version.  If the profile does not exist, we warn and do nothing.  If
-  the there is no upgrade step to go to the specified version, we warn
-  and upgrade to the latest version.
+  upgrades steps for the given profile, or updates it to the optional
+  given version.  If the profile does not exist, we warn and do
+  nothing.  If there is no upgrade step to go to the specified
+  version, we warn and do nothing.
 
 - Check the boolean value of the ``remove`` option when importing
   objects.  Previously we only checked if the ``remove`` option was


### PR DESCRIPTION
Note: this is based on a few lines from the CMFQuickInstaller from Plone, plus some extra lines for which I had inspiration:
https://github.com/plone/Products.CMFPlone/blob/4.3.6/Products/CMFPlone/QuickInstallerTool.py#L85

I am briefly wondering if that has influence on the license, although it is really just code that is very similar to what is already in GenericSetup, like in manage_doUpgrades, just structured a bit differently.

Anyway, this adds an upgradeProfile method which is basically a programmatic alternative to the manage_doUpgrades method. Instead of an optional list of step ids, you pass an optional version to which you want to upgrade.

Goal is to make code like this from a pull request for plone.app.upgrade easier:
https://github.com/plone/plone.app.upgrade/commit/ecc62fc27910557673b2f61094cd0c4e97876eda
There I am now first checking if a profile was previously installed. If not, then I ask the Quick Installer to upgrade the product, which then itself checks the profile. With the difference between product and profile it is a bit of a hassle, and the new method would help here. And I wanted to be able to upgrade to a specific version.