### PR TITLE
Apply profile dependencies only once.

### DIFF
--- a/Products/GenericSetup/events.py
+++ b/Products/GenericSetup/events.py
@@ -50,5 +50,6 @@ def handleProfileImportedEvent(event):
 
     version = event.tool.getVersionForProfile(profile_id)
     if version and version != 'unknown':
-        profile_id = profile_id[len('profile-'):]
+        prefix = 'profile-'
+        profile_id = profile_id[len(prefix):]
         event.tool.setLastVersionForProfile(profile_id, version)

--- a/Products/GenericSetup/registry.py
+++ b/Products/GenericSetup/registry.py
@@ -644,10 +644,12 @@ class ProfileRegistry(Implicit):
     def getProfileInfo(self, profile_id, for_=None):
         """ See IProfileRegistry.
         """
-        if profile_id.startswith("profile-"):
-            profile_id = profile_id[len('profile-'):]
-        elif profile_id.startswith("snapshot-"):
-            profile_id = profile_id[len('snapshot-'):]
+        prefixes = ('profile-', 'snapshot-')
+        for prefix in prefixes:
+            if profile_id.startswith(prefix):
+                profile_id = profile_id[len(prefix):]
+                break
+
         result = self._registered.get(profile_id)
         if result is None:
             raise KeyError(profile_id)

--- a/Products/GenericSetup/registry.py
+++ b/Products/GenericSetup/registry.py
@@ -644,6 +644,10 @@ class ProfileRegistry(Implicit):
     def getProfileInfo(self, profile_id, for_=None):
         """ See IProfileRegistry.
         """
+        if profile_id.startswith("profile-"):
+            profile_id = profile_id[len('profile-'):]
+        elif profile_id.startswith("snapshot-"):
+            profile_id = profile_id[len('snapshot-'):]
         result = self._registered.get(profile_id)
         if result is None:
             raise KeyError(profile_id)

--- a/Products/GenericSetup/tests/test_registry.py
+++ b/Products/GenericSetup/tests/test_registry.py
@@ -1056,6 +1056,13 @@ class ProfileRegistryTests( BaseRegistryTests
         self.assertEqual( info[ 'type' ], PROFILE_TYPE )
         self.assertEqual( info[ 'for' ], None )
 
+        # We strip off any 'profile-' or 'snapshot-' at the beginning
+        # of the profile id.
+        info2 = registry.getProfileInfo( 'profile-' + PROFILE_ID )
+        self.assertEqual(info, info2)
+        info3 = registry.getProfileInfo( 'snapshot-' + PROFILE_ID )
+        self.assertEqual(info, info3)
+
     def test_registerProfile_duplicate( self ):
 
         NAME = 'one'

--- a/Products/GenericSetup/tests/test_tool.py
+++ b/Products/GenericSetup/tests/test_tool.py
@@ -1069,6 +1069,21 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self.assertEqual(tool.getLastVersionForProfile(profile_id),
                          ('1', '1'))
 
+    def test_get_and_setLastVersionForProfile(self):
+        site = self._makeSite()
+        site.setup_tool = self._makeOne('setup_tool')
+        tool = site.setup_tool
+        self.assertEqual(tool._profile_upgrade_versions, {})
+        # Any 'profile-' is stripped off in these calls.
+        self.assertEqual(tool.getLastVersionForProfile('foo'), 'unknown')
+        self.assertEqual(tool.getLastVersionForProfile('profile-foo'), 'unknown')
+        tool.setLastVersionForProfile('foo', '1.0')
+        self.assertEqual(tool.getLastVersionForProfile('foo'), ('1', '0'))
+        self.assertEqual(tool.getLastVersionForProfile('profile-foo'), ('1', '0'))
+        tool.setLastVersionForProfile('profile-foo', '2.0')
+        self.assertEqual(tool.getLastVersionForProfile('foo'), ('2', '0'))
+        self.assertEqual(tool.getLastVersionForProfile('profile-foo'), ('2', '0'))
+
     def test_manage_doUpgrades_no_profile_id_or_updates(self):
         site = self._makeSite()
         site.setup_tool = self._makeOne('setup_tool')

--- a/Products/GenericSetup/tests/test_zcml.py
+++ b/Products/GenericSetup/tests/test_zcml.py
@@ -166,6 +166,24 @@ def test_registerUpgradeStep(self):
       ('1', '1')
       >>> step.handler
       <function dummy_upgrade at ...>
+      >>> step_id = step.id
+      >>> step_id == keys[0]
+      True
+
+    Get the step in a different way::
+
+      >>> step2 = _ur.getUpgradeStep('default', step_id)
+      >>> step == step2
+      True
+
+    We strip off any 'profile-' at the beginning of the profile id::
+
+      >>> profile_steps2 = _ur.getUpgradeStepsForProfile('profile-default')
+      >>> profile_steps == profile_steps2
+      True
+      >>> step3 = _ur.getUpgradeStep('profile-default', step_id)
+      >>> step == step3
+      True
 
     Clean up and make sure the cleanup works::
 

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -807,8 +807,9 @@ class SetupTool(Folder):
     def getLastVersionForProfile(self, profile_id):
         """Return the last upgraded version for the specified profile.
         """
-        if profile_id.startswith("profile-"):
-            profile_id = profile_id[len('profile-'):]
+        prefix = 'profile-'
+        if profile_id.startswith(prefix):
+            profile_id = profile_id[len(prefix):]
         version = self._profile_upgrade_versions.get(profile_id, 'unknown')
         return version
 
@@ -816,8 +817,9 @@ class SetupTool(Folder):
     def setLastVersionForProfile(self, profile_id, version):
         """Set the last upgraded version for the specified profile.
         """
-        if profile_id.startswith("profile-"):
-            profile_id = profile_id[len('profile-'):]
+        prefix = 'profile-'
+        if profile_id.startswith(prefix):
+            profile_id = profile_id[len(prefix):]
         if isinstance(version, basestring):
             version = tuple(version.split('.'))
         prof_versions = self._profile_upgrade_versions.copy()
@@ -1003,14 +1005,16 @@ class SetupTool(Folder):
         encoding = self.getEncoding()
 
         if context_id is not None:
-            if context_id.startswith('snapshot-'):
-                context_id = context_id[len('snapshot-'):]
+            prefix = 'snapshot-'
+            if context_id.startswith(prefix):
+                context_id = context_id[len(prefix):]
                 if should_purge is None:
                     should_purge = True
                 return SnapshotImportContext(self, context_id, should_purge,
                                              encoding)
-            if context_id.startswith('profile-'):
-                context_id = context_id[len('profile-'):]
+            prefix = 'profile-'
+            if context_id.startswith(prefix):
+                context_id = context_id[len(prefix):]
             info = _profile_registry.getProfileInfo(context_id)
             if info.get('product'):
                 path = os.path.join(_getProductPath(info['product']),

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -1182,16 +1182,24 @@ class SetupTool(Folder):
 
         detect_steps = steps is None
 
+        # The chain is: first all dependency profiles ( recursively if
+        # applicable), and as last one the main profile for which we
+        # got passed the profile_id.
         last_index = len(chain) - 1
         for index, profile_id in enumerate(chain):
             if not always_apply_profiles and index != last_index:
-                # Check if dependency profile was already applied.
+                # If index is not the last index, then this is a
+                # dependency profile.  Check if this profile was
+                # already applied.
                 if self.getLastVersionForProfile(profile_id) != 'unknown':
                     # Profile was already applied.
                     # Maybe apply upgrade steps, if any, otherwise continue.
                     if upgrade_dependencies:
                         self.upgradeProfile(profile_id)
                     continue
+            # The next lines are done at least for the main profile.
+            # Possibly also for dependency profiles, depending on the
+            # condition above.
             context = self._getImportContext(profile_id, purge_old, archive)
             self.applyContext(context)
 

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -1157,7 +1157,6 @@ class SetupTool(Folder):
                                    profile_id=None,
                                    archive=None,
                                    ignore_dependencies=False,
-                                   seen=None,
                                    blacklisted_steps=None,
                                    always_apply_profiles=False,
                                    upgrade_dependencies=True):
@@ -1174,9 +1173,6 @@ class SetupTool(Folder):
                 raise
         else:
             chain = [profile_id]
-            if seen is None:
-                seen = set()
-            seen.add(profile_id)
 
         results = []
 

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -1185,9 +1185,9 @@ class SetupTool(Folder):
         # The chain is: first all dependency profiles ( recursively if
         # applicable), and as last one the main profile for which we
         # got passed the profile_id.
-        last_index = len(chain) - 1
-        for index, profile_id in enumerate(chain):
-            if not always_apply_profiles and index != last_index:
+        last_num = len(chain)
+        for num, profile_id in enumerate(chain, 1):
+            if not always_apply_profiles and num != last_num:
                 # If index is not the last index, then this is a
                 # dependency profile.  Check if this profile was
                 # already applied.

--- a/Products/GenericSetup/upgrade.py
+++ b/Products/GenericSetup/upgrade.py
@@ -81,6 +81,8 @@ class UpgradeRegistry(object):
         None if there are no steps registered for a profile matching
         that id.
         """
+        if profile_id.startswith("profile-"):
+            profile_id = profile_id[len('profile-'):]
         profile_steps = self._registry.get(profile_id)
         if profile_steps is None:
             self._registry[profile_id] = OOBTree()
@@ -91,6 +93,8 @@ class UpgradeRegistry(object):
         """Returns the specified upgrade step for the specified
         profile, or None if it doesn't exist.
         """
+        if profile_id.startswith("profile-"):
+            profile_id = profile_id[len('profile-'):]
         profile_steps = self._registry.get(profile_id)
         if profile_steps is not None:
             step = profile_steps.get(step_id, None)

--- a/Products/GenericSetup/upgrade.py
+++ b/Products/GenericSetup/upgrade.py
@@ -81,8 +81,9 @@ class UpgradeRegistry(object):
         None if there are no steps registered for a profile matching
         that id.
         """
-        if profile_id.startswith("profile-"):
-            profile_id = profile_id[len('profile-'):]
+        prefix = 'profile-'
+        if profile_id.startswith(prefix):
+            profile_id = profile_id[len(prefix):]
         profile_steps = self._registry.get(profile_id)
         if profile_steps is None:
             self._registry[profile_id] = OOBTree()
@@ -93,8 +94,9 @@ class UpgradeRegistry(object):
         """Returns the specified upgrade step for the specified
         profile, or None if it doesn't exist.
         """
-        if profile_id.startswith("profile-"):
-            profile_id = profile_id[len('profile-'):]
+        prefix = 'profile-'
+        if profile_id.startswith(prefix):
+            profile_id = profile_id[len(prefix):]
         profile_steps = self._registry.get(profile_id)
         if profile_steps is not None:
             step = profile_steps.get(step_id, None)

--- a/Products/GenericSetup/www/sutImportSteps.zpt
+++ b/Products/GenericSetup/www/sutImportSteps.zpt
@@ -83,29 +83,90 @@ procedure, in order to pick up changes since the site was created.
   </tr>
   </tal:loop>
 
+
   <tr valign="top" class="list-header">
-   <td colspan="4">&nbsp;</td>
+   <td colspan="4"><h3>Choose an action</h3></td>
+  </tr>
+
+  <tr valign="top" class="list-header">
+   <td colspan="4"><strong>Import selected steps</strong></td>
   </tr>
 
   <tr valign="top">
    <td />
    <td colspan="3">
-
     <input type="hidden" name="context_id" value="" tal:attributes="value context_id"/>
     <input type="hidden" name="run_dependencies:int:default" value="0" />
     <input class="form-element" type="checkbox" id="run_dependencies"
            name="run_dependencies:boolean" value="1" checked="checked" />
-    <label for="run_dependencies">Include dependencies?</label>
-    &nbsp; &nbsp;
-
+    <label for="run_dependencies">Include dependencies of steps?</label>
     <input class="form-element" type="submit"
            name="manage_importSelectedSteps:method"
            value=" Import selected steps " />
 
+   </td>
+  </tr>
+
+  <tr valign="top" class="list-header">
+   <td colspan="4"><strong>Import all steps</strong></td>
+  </tr>
+
+  <tr valign="top">
+   <td />
+   <td colspan="3">
+    <span>What do you want to do with dependency profiles (listed in the <code>metadata.xml</code> of the chosen profile)?</span>
+   </td>
+  </tr>
+  <tr valign="top">
+   <td />
+   <td colspan="3">
+    <input class="form-element" type="radio" id="dependency_strategy_upgrade"
+           name="dependency_strategy" value="upgrade" checked="checked" />
+    <label for="dependency_strategy_upgrade">Apply new profiles. Run <strong>upgrade</strong> steps for already applied profiles. <strong>Recommended.</strong></label>
+   </td>
+  </tr>
+  <tr valign="top">
+   <td />
+   <td colspan="3">
+    <input class="form-element" type="radio" id="dependency_strategy_reapply"
+           name="dependency_strategy" value="reapply" />
+    <label for="dependency_strategy_reapply"><strong>Apply</strong> all profiles. Already applied profiles are reapplied.</label>
+   </td>
+  </tr>
+  <tr valign="top">
+   <td />
+   <td colspan="3">
+    <input class="form-element" type="radio" id="dependency_strategy_new"
+           name="dependency_strategy" value="new" />
+    <label for="dependency_strategy_new">Apply <strong>only new</strong> profiles. Already applied profiles are left as is.</label>
+   </td>
+  </tr>
+  <tr valign="top">
+   <td />
+   <td colspan="3">
+    <input class="form-element" type="radio" id="dependency_strategy_ignore"
+           name="dependency_strategy" value="ignore" />
+    <label for="dependency_strategy_ignore"><strong>Ignore</strong> dependency profiles.</label>
+   </td>
+  </tr>
+  <tr valign="top">
+   <td />
+   <td colspan="3">
     <input class="form-element" type="submit"
            name="manage_importAllSteps:method"
            value=" Import all steps " />
+   </td>
+  </tr>
 
+  <tr valign="top" class="list-header">
+   <td colspan="4">
+   <strong>Import uploaded tarball</strong>
+   All options above are ignored.
+   </td>
+  </tr>
+  <tr valign="top">
+   <td />
+   <td colspan="3">
     <input class="form-element" type="file"
            name="tarball" />
     <input class="form-element" type="submit"
@@ -113,6 +174,8 @@ procedure, in order to pick up changes since the site was created.
            value=" Import uploaded tarball " />
    </td>
   </tr>
+
+
  </tbody>
 </table>
 

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -15,10 +15,8 @@ Changelog
   are not applied again.  Instead, its upgrade steps, if any, are
   applied.  In code you can choose the old behavior of always applying
   the dependencies, by calling ``runAllImportStepsFromProfile`` with
-  ``always_apply_profiles=True``.  Or you can choose to be happy with
-  any applied version and ignore any upgrade steps, by using
-  ``upgrade_dependencies=False``.  Note that these arguments cannot
-  both be ``True``.
+  ``dependency_strategy=DEPENDENCY_STRATEGY_REAPPLY``.  There are four
+  strategies, which you can choose in the ZMI.
 
 
 1.7.7 (2015-08-11)

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,14 @@ Changelog
 1.7.8 (unreleased)
 ------------------
 
-- TBD
+- Dependency profiles from ``metadata.xml`` that are already applied,
+  are not applied again.  Instead, its upgrade steps, if any, are
+  applied.  In code you can choose the old behavior of always applying
+  the dependencies, by calling ``runAllImportStepsFromProfile`` with
+  ``always_apply_profiles=True``.  Or you can choose to be happy with
+  any applied version and ignore any upgrade steps, by using
+  ``upgrade_dependencies=False``.  Note that these arguments cannot
+  both be ``True``.
 
 
 1.7.7 (2015-08-11)

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,13 @@ Changelog
 1.7.8 (unreleased)
 ------------------
 
+- Be more forgiving when dealing with profile ids with or without
+  ``profile-`` at the start.  All functions that accept a profile id
+  argument and only work when the id does *not* have this string at
+  the start, will now strip it off if it is there.  For example,
+  ``getLastVersionForProfile`` will give the same answer whether you
+  ask it for the version of profile id ``foo`` or ``profile-foo``.
+
 - Dependency profiles from ``metadata.xml`` that are already applied,
   are not applied again.  Instead, its upgrade steps, if any, are
   applied.  In code you can choose the old behavior of always applying


### PR DESCRIPTION
Example scenario:

1. Create a Plone 5 beta site. This applies a profile from plone.app.contenttypes.
2. Install add-on Mosaic. This lists plone.app.contenttypes in its metadata.xml, so the profile gets applied a second time.

Problems with this scenario:

1. This profile needlessly gets applied twice. Takes extra time. Oh well.
2. If before installing Mosaic you made some manual changes to the plone.app.contenttypes settings, or installed another add-on that did this, then those changes will be undone. Well, this depends on the exact changes, but I think you can imagine.
3. Theoretically, plone.app.contenttypes might do something stupid in an import step that gives an exception when run a second time, or that now creates twice as many sample content or whatever.

I would like to prevent this. So this is the change:

Dependency profiles from `metadata.xml` that are already applied, are not applied again.  Instead, its upgrade steps, if any, are applied.  In code you can choose the old behavior of always applying the dependencies, by calling `runAllImportStepsFromProfile` with `always_apply_profiles=True`.  Or you can choose to be happy with any applied version and ignore any upgrade steps, by using `upgrade_dependencies=False`.  Note that these arguments cannot both be `True`.

Note: I could theoretically enhance `metadata.xml` so you can tweak the behavior:

```
<metadata>
  <version>1.0</version>
  <dependencies upgrade_dependencies="False">
    <dependency>profile-other:foo</dependency>
    <dependency always_apply_profiles="True">profile-other:bar</dependency>
    <dependency upgrade_dependencies="True">profile-other:quux</dependency>
  </dependencies>
</metadata>
```

But this would require changing the output of `getDependenciesForProfile` and `getProfileInfo`, so probably best not to do that.

While doing this, I got confused about which GenericSetup method needs a profile id *with* `profile-` at the start, and which needs a profile id *without* it. So I added a second change:

Be more forgiving when dealing with profile ids with or without `profile-` at the start.  All functions that accept a profile id argument and only work when the id does *not* have this string at the start, will now strip it off if it is there.  For example, `getLastVersionForProfile` will give the same answer whether you ask it for the version of profile id `foo` or `profile-foo`.

These two changes of this pull request are in two commits, with minimal overlap, so if needed it should be fairly easy to cherry-pick only one.