### PR TITLE
Add unsetLastVersionForProfile and purgeProfileVersions. Call purgeProfileVersions for base profiles.

### DIFF
--- a/Products/GenericSetup/tests/test_tool.py
+++ b/Products/GenericSetup/tests/test_tool.py
@@ -1139,6 +1139,17 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         tool.unsetLastVersionForProfile('bar')
         self.assertEqual(tool._profile_upgrade_versions, {})
 
+    def test_purgeProfileVersions(self):
+        site = self._makeSite()
+        site.setup_tool = self._makeOne('setup_tool')
+        tool = site.setup_tool
+        tool.setLastVersionForProfile('foo', '1.0')
+        tool.setLastVersionForProfile('bar', '2.0')
+        self.assertEqual(tool._profile_upgrade_versions,
+                         {'foo': ('1', '0'), 'bar': ('2', '0')})
+        tool.purgeProfileVersions()
+        self.assertEqual(tool._profile_upgrade_versions, {})
+
     def test_manage_doUpgrades_no_profile_id_or_updates(self):
         site = self._makeSite()
         site.setup_tool = self._makeOne('setup_tool')

--- a/Products/GenericSetup/tests/test_tool.py
+++ b/Products/GenericSetup/tests/test_tool.py
@@ -1118,6 +1118,27 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self.assertEqual(tool.getLastVersionForProfile(
             'profile-foo'), ('2', '0'))
 
+        # Setting the profile to unknown, removes it from the versions.
+        self.assertEqual(tool._profile_upgrade_versions, {'foo': ('2', '0')})
+        tool.setLastVersionForProfile('profile-foo', 'unknown')
+        self.assertEqual(tool._profile_upgrade_versions, {})
+
+    def test_unsetLastVersionForProfile(self):
+        site = self._makeSite()
+        site.setup_tool = self._makeOne('setup_tool')
+        tool = site.setup_tool
+        tool.setLastVersionForProfile('foo', '1.0')
+        tool.setLastVersionForProfile('bar', '2.0')
+        self.assertEqual(tool._profile_upgrade_versions,
+                         {'foo': ('1', '0'), 'bar': ('2', '0')})
+
+        # Any 'profile-' is stripped off in these calls.
+        tool.unsetLastVersionForProfile('profile-foo')
+        self.assertEqual(tool._profile_upgrade_versions,
+                         {'bar': ('2', '0')})
+        tool.unsetLastVersionForProfile('bar')
+        self.assertEqual(tool._profile_upgrade_versions, {})
+
     def test_manage_doUpgrades_no_profile_id_or_updates(self):
         site = self._makeSite()
         site.setup_tool = self._makeOne('setup_tool')

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -1270,7 +1270,8 @@ class SetupTool(Folder):
             except KeyError:
                 # this will be a snapshot profile
                 profile_type = None
-            if profile_type == BASE:
+            if profile_type == BASE and (purge_old is None or purge_old):
+                # purge_old should be None or explicitly true
                 self.purgeProfileVersions()
             if num == last_num:
                 generic_logger.info('Applying main profile %s', profile_id)

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -1264,15 +1264,11 @@ class SetupTool(Folder):
         # got passed the profile_id.
         last_num = len(chain)
         for num, profile_id in enumerate(chain, 1):
-            # Purge profile versions when this is a base profile.
             try:
                 profile_type = self.getProfileInfo(profile_id).get('type')
             except KeyError:
                 # this will be a snapshot profile
                 profile_type = None
-            if profile_type == BASE and (purge_old is None or purge_old):
-                # purge_old should be None or explicitly true
-                self.purgeProfileVersions()
             if num == last_num:
                 generic_logger.info('Applying main profile %s', profile_id)
             else:
@@ -1303,6 +1299,10 @@ class SetupTool(Folder):
             messages = {}
             event.notify(
                 BeforeProfileImportEvent(self, profile_id, steps, True))
+            # Maybe purge all profile upgrade versions.
+            if profile_type == BASE and (purge_old is None or purge_old):
+                # purge_old should be None or explicitly true
+                self.purgeProfileVersions()
             for step in steps:
                 if blacklisted_steps and step in blacklisted_steps:
                     message = 'step skipped'

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -866,6 +866,13 @@ class SetupTool(Folder):
         """
         return self.getProfileInfo(profile_id).get('version', UNKNOWN)
 
+    security.declareProtected(ManagePortal, 'purgeProfileVersions')
+    def purgeProfileVersions(self):
+        """Purge the profile upgrade versions.
+        """
+        self._profile_upgrade_versions = {}
+        generic_logger.info('Profile upgrade versions purged.')
+
     security.declareProtected(ManagePortal, 'profileExists')
     def profileExists(self, profile_id):
         """Check if a profile exists."""

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -1264,6 +1264,14 @@ class SetupTool(Folder):
         # got passed the profile_id.
         last_num = len(chain)
         for num, profile_id in enumerate(chain, 1):
+            # Purge profile versions when this is a base profile.
+            try:
+                profile_type = self.getProfileInfo(profile_id).get('type')
+            except KeyError:
+                # this will be a snapshot profile
+                profile_type = None
+            if profile_type == BASE:
+                self.purgeProfileVersions()
             if num == last_num:
                 generic_logger.info('Applying main profile %s', profile_id)
             else:

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added ``unsetLastVersionForProfile`` method to ``portal_setup``.  This
+  removes the profile id from the profile upgrade versions.  Calling
+  ``setLastVersionForProfile`` with ``unknown`` as version now has the
+  same effect.
 
 
 1.8.0 (2015-09-21)

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
+- Added ``purgeProfileVersions`` method to ``portal_setup``.  This
+  removes the all profiles profile upgrade versions.  The suggestion
+  is to call this before you apply a base profile.
+
 - Added ``unsetLastVersionForProfile`` method to ``portal_setup``.  This
   removes the profile id from the profile upgrade versions.  Calling
   ``setLastVersionForProfile`` with ``unknown`` as version now has the

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,9 +4,11 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
+- Purge the profile upgrade versions before applying a base profile.
+  [maurits]
+
 - Added ``purgeProfileVersions`` method to ``portal_setup``.  This
-  removes the all profiles profile upgrade versions.  The suggestion
-  is to call this before you apply a base profile.
+  removes the all profiles profile upgrade versions.
 
 - Added ``unsetLastVersionForProfile`` method to ``portal_setup``.  This
   removes the profile id from the profile upgrade versions.  Calling


### PR DESCRIPTION
This started out as one change, but now contains three related ones after discussion on the cmf list. They are still in separate commits, so it could be split if needed.

- Added ``unsetLastVersionForProfile`` method to ``portal_setup``.  This removes the profile id from the profile upgrade versions.  Calling ``setLastVersionForProfile`` with ``unknown`` as version now has the same effect. Note that without this, a call to `setLastVersionForProfile('unknown')` would result in a version tuple:  `('unknown',)`.

- Added ``purgeProfileVersions`` method to ``portal_setup``.  This removes the all profiles profile upgrade versions.

- Purge the profile upgrade versions before applying a base profile.
