### PR TITLE
Pep8

### DIFF
--- a/Products/GenericSetup/MailHost/exportimport.py
+++ b/Products/GenericSetup/MailHost/exportimport.py
@@ -48,7 +48,7 @@ class MailHostXMLAdapter(XMLAdapterBase):
             smtp_pwd = ''
         node.setAttribute('smtp_pwd', smtp_pwd)
 
-        #Older MH instances won't have 'smtp_queue' in instance dict
+        # Older MH instances won't have 'smtp_queue' in instance dict
         smtp_queue = bool(getattr(self.context, 'smtp_queue', False))
         node.setAttribute('smtp_queue', str(smtp_queue))
 
@@ -68,7 +68,7 @@ class MailHostXMLAdapter(XMLAdapterBase):
         self.context.smtp_uid = node.getAttribute('smtp_uid').encode('utf-8')
         self.context.smtp_pwd = node.getAttribute('smtp_pwd').encode('utf-8')
 
-        #Older MH instances won't have 'smtp_queue' in instance dict
+        # Older MH instances won't have 'smtp_queue' in instance dict
         if 'smtp_queue' in self.context.__dict__:
             if node.hasAttribute('smtp_queue'):
                 queue = node.getAttribute('smtp_queue')

--- a/Products/GenericSetup/MailHost/tests/test_exportimport.py
+++ b/Products/GenericSetup/MailHost/tests/test_exportimport.py
@@ -39,7 +39,7 @@ class MailHostXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
 
     def _getTargetClass(self):
         from Products.GenericSetup.MailHost.exportimport \
-                import MailHostXMLAdapter
+            import MailHostXMLAdapter
 
         return MailHostXMLAdapter
 
@@ -85,7 +85,7 @@ class MailHostXMLAdapterTestsWithQueue(BodyAdapterTestCase, unittest.TestCase):
 
     def _getTargetClass(self):
         from Products.GenericSetup.MailHost.exportimport \
-                import MailHostXMLAdapter
+            import MailHostXMLAdapter
 
         return MailHostXMLAdapter
 
@@ -94,9 +94,9 @@ class MailHostXMLAdapterTestsWithQueue(BodyAdapterTestCase, unittest.TestCase):
         self.assertEqual(obj.smtp_queue, True)
         self.assertEqual(type(obj.smtp_queue_directory), str)
         self.assertEqual(obj.smtp_queue_directory, '/tmp/mailqueue')
-        
+
     def test_body_get(self):
-        #Default Correctly Handled in MailHostXMLAdapterTests
+        # Default Correctly Handled in MailHostXMLAdapterTests
         pass
 
     def setUp(self):
@@ -132,4 +132,4 @@ def test_suite():
         unittest.makeSuite(MailHostXMLAdapterTestsWithoutQueue),
         unittest.makeSuite(MailHostXMLAdapterTestsWithQueue),
         unittest.makeSuite(MailHostXMLAdapterTestsWithNoneValue),
-        ))
+    ))

--- a/Products/GenericSetup/OFSP/exportimport.py
+++ b/Products/GenericSetup/OFSP/exportimport.py
@@ -58,7 +58,7 @@ class FolderXMLAdapter(XMLAdapterBase, ObjectManagerHelpers,
     def _exportBody(self):
         """Export the object as a file body.
         """
-        if not self.context.meta_type in ('Folder', 'Folder (Ordered)'):
+        if self.context.meta_type not in ('Folder', 'Folder (Ordered)'):
             return None
 
         return XMLAdapterBase._exportBody(self)

--- a/Products/GenericSetup/OFSP/tests/test_exportimport.py
+++ b/Products/GenericSetup/OFSP/tests/test_exportimport.py
@@ -52,4 +52,4 @@ class FolderXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
 def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(FolderXMLAdapterTests),
-        ))
+    ))

--- a/Products/GenericSetup/PageTemplates/tests/test_exportimport.py
+++ b/Products/GenericSetup/PageTemplates/tests/test_exportimport.py
@@ -31,7 +31,7 @@ class ZopePageTemplateBodyAdapterTests(BodyAdapterTestCase, unittest.TestCase):
 
     def _getTargetClass(self):
         from Products.GenericSetup.PageTemplates.exportimport \
-                import ZopePageTemplateBodyAdapter
+            import ZopePageTemplateBodyAdapter
 
         return ZopePageTemplateBodyAdapter
 
@@ -48,4 +48,4 @@ class ZopePageTemplateBodyAdapterTests(BodyAdapterTestCase, unittest.TestCase):
 def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(ZopePageTemplateBodyAdapterTests),
-        ))
+    ))

--- a/Products/GenericSetup/PluginIndexes/exportimport.py
+++ b/Products/GenericSetup/PluginIndexes/exportimport.py
@@ -54,7 +54,7 @@ class PluggableIndexNodeAdapter(NodeAdapterBase):
         for child in node.childNodes:
             if child.nodeName == 'indexed_attr':
                 indexed_attrs.append(
-                                  child.getAttribute('value').encode('utf-8'))
+                    child.getAttribute('value').encode('utf-8'))
         if _before != indexed_attrs:
             self.context.indexed_attrs = indexed_attrs
             self.context.clear()
@@ -81,14 +81,14 @@ class DateIndexNodeAdapter(NodeAdapterBase, PropertyManagerHelpers):
         """
         _before = {'map': self.context._properties,
                    'items': self.context.propertyItems(),
-                  }
+                   }
         if self.environ.shouldPurge():
             self._purgeProperties()
 
         self._initProperties(node)
         _after = {'map': self.context._properties,
                   'items': self.context.propertyItems(),
-                 }
+                  }
         if _before != _after:
             self.context.clear()
 
@@ -157,7 +157,7 @@ class FilteredSetNodeAdapter(NodeAdapterBase):
         """
         _before = self.context.expr
         self.context.setExpression(
-                              node.getAttribute('expression').encode('utf-8'))
+            node.getAttribute('expression').encode('utf-8'))
         _after = self.context.expr
         if _before != _after:
             self.context.clear()
@@ -194,6 +194,6 @@ class TopicIndexNodeAdapter(NodeAdapterBase):
                 importer = queryMultiAdapter((set, self.environ), INode)
                 importer.node = child
         # Let the filtered sets handle themselves:  we have no state
-        #self.context.clear()
+        # self.context.clear()
 
     node = property(_exportNode, _importNode)

--- a/Products/GenericSetup/PluginIndexes/tests/test_exportimport.py
+++ b/Products/GenericSetup/PluginIndexes/tests/test_exportimport.py
@@ -68,7 +68,7 @@ class DateIndexNodeAdapterTests(NodeAdapterTestCase, unittest.TestCase):
 
     def _getTargetClass(self):
         from Products.GenericSetup.PluginIndexes.exportimport \
-                import DateIndexNodeAdapter
+            import DateIndexNodeAdapter
         return DateIndexNodeAdapter
 
     def setUp(self):
@@ -83,7 +83,7 @@ class DateRangeIndexNodeAdapterTests(NodeAdapterTestCase, unittest.TestCase):
 
     def _getTargetClass(self):
         from Products.GenericSetup.PluginIndexes.exportimport \
-                import DateRangeIndexNodeAdapter
+            import DateRangeIndexNodeAdapter
         return DateRangeIndexNodeAdapter
 
     def _populate(self, obj):
@@ -91,7 +91,7 @@ class DateRangeIndexNodeAdapterTests(NodeAdapterTestCase, unittest.TestCase):
 
     def setUp(self):
         from Products.PluginIndexes.DateRangeIndex.DateRangeIndex \
-                import DateRangeIndex
+            import DateRangeIndex
         self._obj = DateRangeIndex('foo_daterange')
         self._XML = _DATERANGE_XML
 
@@ -102,7 +102,7 @@ class FieldIndexNodeAdapterTests(NodeAdapterTestCase, unittest.TestCase):
 
     def _getTargetClass(self):
         from Products.GenericSetup.PluginIndexes.exportimport \
-                import PluggableIndexNodeAdapter
+            import PluggableIndexNodeAdapter
         return PluggableIndexNodeAdapter
 
     def _populate(self, obj):
@@ -120,7 +120,7 @@ class KeywordIndexNodeAdapterTests(NodeAdapterTestCase, unittest.TestCase):
 
     def _getTargetClass(self):
         from Products.GenericSetup.PluginIndexes.exportimport \
-                import PluggableIndexNodeAdapter
+            import PluggableIndexNodeAdapter
         return PluggableIndexNodeAdapter
 
     def _populate(self, obj):
@@ -128,7 +128,7 @@ class KeywordIndexNodeAdapterTests(NodeAdapterTestCase, unittest.TestCase):
 
     def setUp(self):
         from Products.PluginIndexes.KeywordIndex.KeywordIndex \
-                import KeywordIndex
+            import KeywordIndex
         self._obj = KeywordIndex('foo_keyword')
         self._XML = _KEYWORD_XML
 
@@ -139,7 +139,7 @@ class PathIndexNodeAdapterTests(NodeAdapterTestCase, unittest.TestCase):
 
     def _getTargetClass(self):
         from Products.GenericSetup.PluginIndexes.exportimport \
-                import PathIndexNodeAdapter
+            import PathIndexNodeAdapter
         return PathIndexNodeAdapter
 
     def setUp(self):
@@ -154,7 +154,7 @@ class FilteredSetNodeAdapterTests(NodeAdapterTestCase, unittest.TestCase):
 
     def _getTargetClass(self):
         from Products.GenericSetup.PluginIndexes.exportimport \
-                import FilteredSetNodeAdapter
+            import FilteredSetNodeAdapter
         return FilteredSetNodeAdapter
 
     def _populate(self, obj):
@@ -162,7 +162,7 @@ class FilteredSetNodeAdapterTests(NodeAdapterTestCase, unittest.TestCase):
 
     def setUp(self):
         from Products.PluginIndexes.TopicIndex.FilteredSet \
-                import PythonFilteredSet
+            import PythonFilteredSet
         self._obj = PythonFilteredSet('bar', '')
         self._XML = _SET_XML
 
@@ -173,7 +173,7 @@ class TopicIndexNodeAdapterTests(NodeAdapterTestCase, unittest.TestCase):
 
     def _getTargetClass(self):
         from Products.GenericSetup.PluginIndexes.exportimport \
-                import TopicIndexNodeAdapter
+            import TopicIndexNodeAdapter
         return TopicIndexNodeAdapter
 
     def _populate(self, obj):
@@ -195,31 +195,33 @@ class UnchangedTests(unittest.TestCase):
         from Products.PluginIndexes.FieldIndex.FieldIndex import FieldIndex
         from Products.GenericSetup.testing import DummySetupEnviron
         from Products.GenericSetup.PluginIndexes.exportimport \
-                import PluggableIndexNodeAdapter
+            import PluggableIndexNodeAdapter
         environ = DummySetupEnviron()
+
         def _no_clear(*a):
             raise AssertionError("Don't clear me!")
         index = FieldIndex('foo_field')
         index.indexed_attrs = ['bar']
-        index.clear = _no_clear 
+        index.clear = _no_clear
         adapted = PluggableIndexNodeAdapter(index, environ)
-        adapted.node = parseString(_FIELD_XML).documentElement # no raise
+        adapted.node = parseString(_FIELD_XML).documentElement  # no raise
 
     def test_KeywordIndex(self):
         from xml.dom.minidom import parseString
         from Products.PluginIndexes.KeywordIndex.KeywordIndex \
-                import KeywordIndex
+            import KeywordIndex
         from Products.GenericSetup.testing import DummySetupEnviron
         from Products.GenericSetup.PluginIndexes.exportimport \
-                import PluggableIndexNodeAdapter
+            import PluggableIndexNodeAdapter
         environ = DummySetupEnviron()
+
         def _no_clear(*a):
             raise AssertionError("Don't clear me!")
         index = KeywordIndex('foo_keyword')
         index.indexed_attrs = ['bar']
-        index.clear = _no_clear 
+        index.clear = _no_clear
         adapted = PluggableIndexNodeAdapter(index, environ)
-        adapted.node = parseString(_KEYWORD_XML).documentElement # no raise
+        adapted.node = parseString(_KEYWORD_XML).documentElement  # no raise
 
     def test_OddballIndex(self):
         # Some indexes, e.g. Plone's 'GopipIndex', use ths adapter but don't
@@ -227,69 +229,74 @@ class UnchangedTests(unittest.TestCase):
         from xml.dom.minidom import parseString
         from Products.GenericSetup.testing import DummySetupEnviron
         from Products.GenericSetup.PluginIndexes.exportimport \
-                import PluggableIndexNodeAdapter
+            import PluggableIndexNodeAdapter
+
         class Oddball(object):
             def clear(*a):
                 raise AssertionError("Don't clear me!")
         index = Oddball()
         environ = DummySetupEnviron()
         adapted = PluggableIndexNodeAdapter(index, environ)
-        adapted.node = parseString(_ODDBALL_XML).documentElement # no raise
+        adapted.node = parseString(_ODDBALL_XML).documentElement  # no raise
 
     def test_DateIndex(self):
         from xml.dom.minidom import parseString
         from Products.PluginIndexes.DateIndex.DateIndex import DateIndex
         from Products.GenericSetup.testing import DummySetupEnviron
         from Products.GenericSetup.PluginIndexes.exportimport \
-                import DateIndexNodeAdapter
+            import DateIndexNodeAdapter
         environ = DummySetupEnviron()
+
         def _no_clear(*a):
             raise AssertionError("Don't clear me!")
         index = DateIndex('foo_date')
         index._setPropValue('index_naive_time_as_local', True)
-        index.clear = _no_clear 
+        index.clear = _no_clear
         adapted = DateIndexNodeAdapter(index, environ)
-        adapted.node = parseString(_DATE_XML).documentElement # no raise
+        adapted.node = parseString(_DATE_XML).documentElement  # no raise
 
     def test_DateRangeIndex(self):
         from xml.dom.minidom import parseString
         from Products.PluginIndexes.DateRangeIndex.DateRangeIndex \
-                import DateRangeIndex
+            import DateRangeIndex
         from Products.GenericSetup.testing import DummySetupEnviron
         from Products.GenericSetup.PluginIndexes.exportimport \
-                import DateRangeIndexNodeAdapter
+            import DateRangeIndexNodeAdapter
         environ = DummySetupEnviron()
+
         def _no_clear(*a):
             raise AssertionError("Don't clear me!")
         index = DateRangeIndex('foo_daterange')
         index._since_field = 'bar'
         index._until_field = 'baz'
-        index.clear = _no_clear 
+        index.clear = _no_clear
         adapted = DateRangeIndexNodeAdapter(index, environ)
-        adapted.node = parseString(_DATERANGE_XML).documentElement # no raise
+        adapted.node = parseString(_DATERANGE_XML).documentElement  # no raise
 
     def test_FilteredSet(self):
         from xml.dom.minidom import parseString
         from Products.PluginIndexes.TopicIndex.FilteredSet \
-                import PythonFilteredSet
+            import PythonFilteredSet
         from Products.GenericSetup.testing import DummySetupEnviron
         from Products.GenericSetup.PluginIndexes.exportimport \
-                import FilteredSetNodeAdapter
+            import FilteredSetNodeAdapter
         environ = DummySetupEnviron()
+
         def _no_clear(*a):
             raise AssertionError("Don't clear me!")
         index = PythonFilteredSet('bar', 'True')
-        index.clear = _no_clear 
+        index.clear = _no_clear
         adapted = FilteredSetNodeAdapter(index, environ)
-        adapted.node = parseString(_SET_XML).documentElement # no raise
+        adapted.node = parseString(_SET_XML).documentElement  # no raise
 
     def test_TopicIndex(self):
         from xml.dom.minidom import parseString
         from Products.PluginIndexes.TopicIndex.TopicIndex import TopicIndex
         from Products.GenericSetup.testing import DummySetupEnviron
         from Products.GenericSetup.PluginIndexes.exportimport \
-                import TopicIndexNodeAdapter
+            import TopicIndexNodeAdapter
         environ = DummySetupEnviron()
+
         def _no_clear(*a):
             raise AssertionError("Don't clear me!")
         index = TopicIndex('topics')
@@ -297,9 +304,9 @@ class UnchangedTests(unittest.TestCase):
         index.addFilteredSet('baz', 'PythonFilteredSet', 'False')
         bar = index.filteredSets['bar']
         baz = index.filteredSets['baz']
-        bar.clear = baz.clear = _no_clear 
+        bar.clear = baz.clear = _no_clear
         adapted = TopicIndexNodeAdapter(index, environ)
-        adapted.node = parseString(_SET_XML).documentElement # no raise
+        adapted.node = parseString(_SET_XML).documentElement  # no raise
 
 
 def test_suite():
@@ -312,4 +319,4 @@ def test_suite():
         unittest.makeSuite(FilteredSetNodeAdapterTests),
         unittest.makeSuite(TopicIndexNodeAdapterTests),
         unittest.makeSuite(UnchangedTests),
-        ))
+    ))

--- a/Products/GenericSetup/PythonScripts/tests/test_exportimport.py
+++ b/Products/GenericSetup/PythonScripts/tests/test_exportimport.py
@@ -37,7 +37,7 @@ class PythonScriptBodyAdapterTests(BodyAdapterTestCase, unittest.TestCase):
 
     def _getTargetClass(self):
         from Products.GenericSetup.PythonScripts.exportimport \
-                import PythonScriptBodyAdapter
+            import PythonScriptBodyAdapter
 
         return PythonScriptBodyAdapter
 
@@ -51,4 +51,4 @@ class PythonScriptBodyAdapterTests(BodyAdapterTestCase, unittest.TestCase):
 def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(PythonScriptBodyAdapterTests),
-        ))
+    ))

--- a/Products/GenericSetup/ZCTextIndex/exportimport.py
+++ b/Products/GenericSetup/ZCTextIndex/exportimport.py
@@ -52,13 +52,13 @@ class ZCLexiconNodeAdapter(NodeAdapterBase):
         for child in node.childNodes:
             if child.nodeName == 'element':
                 element = element_factory.instantiate(
-                      child.getAttribute('group').encode('utf-8'),
-                      child.getAttribute('name').encode('utf-8'))
+                    child.getAttribute('group').encode('utf-8'),
+                    child.getAttribute('name').encode('utf-8'))
                 pipeline.append(element)
         pipeline = tuple(pipeline)
         if self.context._pipeline != pipeline:
             self.context._pipeline = pipeline
-            #clear lexicon
+            # clear lexicon
             self.context._wids = OIBTree()
             self.context._words = IOBTree()
             self.context.length = Length()
@@ -108,7 +108,7 @@ class ZCTextIndexNodeAdapter(NodeAdapterBase):
         for child in node.childNodes:
             if child.nodeName == 'indexed_attr':
                 indexed_attrs.append(
-                                  child.getAttribute('value').encode('utf-8'))
+                    child.getAttribute('value').encode('utf-8'))
         if self.context._indexed_attrs != indexed_attrs:
             self.context._indexed_attrs = indexed_attrs
             self.context.clear()

--- a/Products/GenericSetup/ZCTextIndex/tests/test_exportimport.py
+++ b/Products/GenericSetup/ZCTextIndex/tests/test_exportimport.py
@@ -54,7 +54,7 @@ class ZCLexiconNodeAdapterTests(NodeAdapterTestCase, unittest.TestCase):
 
     def _getTargetClass(self):
         from Products.GenericSetup.ZCTextIndex.exportimport \
-                import ZCLexiconNodeAdapter
+            import ZCLexiconNodeAdapter
 
         return ZCLexiconNodeAdapter
 
@@ -77,7 +77,7 @@ class ZCTextIndexNodeAdapterTests(NodeAdapterTestCase, unittest.TestCase):
 
     def _getTargetClass(self):
         from Products.GenericSetup.ZCTextIndex.exportimport \
-                import ZCTextIndexNodeAdapter
+            import ZCTextIndexNodeAdapter
 
         return ZCTextIndexNodeAdapter
 
@@ -92,7 +92,7 @@ class ZCTextIndexNodeAdapterTests(NodeAdapterTestCase, unittest.TestCase):
         catalog.foo_plexicon = PLexicon('foo_plexicon')
         extra = _extra()
         extra.lexicon_id = 'foo_plexicon'
-        extra.index_type='Okapi BM25 Rank'
+        extra.index_type = 'Okapi BM25 Rank'
         self._obj = ZCTextIndex('foo_zctext', extra=extra,
                                 caller=catalog).__of__(catalog)
         self._XML = _ZCTEXT_XML
@@ -107,7 +107,7 @@ class UnchangedTests(unittest.TestCase):
         from Products.GenericSetup.testing import DummySetupEnviron
         from Products.ZCTextIndex.PipelineFactory import element_factory
         from Products.GenericSetup.ZCTextIndex.exportimport \
-                import ZCLexiconNodeAdapter
+            import ZCLexiconNodeAdapter
 
         _XML = """\
         <object name="foo_plexicon" meta_type="ZCTextIndex Lexicon">
@@ -117,6 +117,7 @@ class UnchangedTests(unittest.TestCase):
         """
         environ = DummySetupEnviron()
         _before = object(), object(), object()
+
         class DummyLexicon(object):
             _wids, _words, length = _before
         lex = DummyLexicon()
@@ -124,9 +125,9 @@ class UnchangedTests(unittest.TestCase):
         adapted = ZCLexiconNodeAdapter(lex, environ)
         element_factory._groups['gs'] = {'foo': lambda: foo,
                                          'bar': lambda: bar,
-                                        }
+                                         }
         try:
-            adapted.node = parseString(_XML).documentElement # no raise
+            adapted.node = parseString(_XML).documentElement  # no raise
         finally:
             del element_factory._groups['gs']
         self.assertTrue(lex._wids is _before[0])
@@ -139,7 +140,7 @@ class UnchangedTests(unittest.TestCase):
         from Products.ZCTextIndex.ZCTextIndex import ZCTextIndex
         from Products.GenericSetup.testing import DummySetupEnviron
         from Products.GenericSetup.ZCTextIndex.exportimport \
-                import ZCTextIndexNodeAdapter
+            import ZCTextIndexNodeAdapter
         _XML = """\
         <index name="foo_zctext" meta_type="ZCTextIndex">
         <indexed_attr value="bar"/>
@@ -148,18 +149,19 @@ class UnchangedTests(unittest.TestCase):
         </index>
         """
         environ = DummySetupEnviron()
+
         def _no_clear(*a):
             raise AssertionError("Don't clear me!")
         catalog = DummyCatalog()
         catalog.foo_plexicon = PLexicon('foo_plexicon')
         extra = _extra()
         extra.lexicon_id = 'foo_plexicon'
-        extra.index_type='Okapi BM25 Rank'
+        extra.index_type = 'Okapi BM25 Rank'
         index = ZCTextIndex('foo_field', extra=extra, field_name='bar',
                             caller=catalog).__of__(catalog)
-        index.clear = _no_clear 
+        index.clear = _no_clear
         adapted = ZCTextIndexNodeAdapter(index, environ)
-        adapted.node = parseString(_XML).documentElement # no raise
+        adapted.node = parseString(_XML).documentElement  # no raise
 
 
 def test_suite():

--- a/Products/GenericSetup/ZCatalog/exportimport.py
+++ b/Products/GenericSetup/ZCatalog/exportimport.py
@@ -73,7 +73,7 @@ class ZCatalogXMLAdapter(XMLAdapterBase, ObjectManagerHelpers,
     def _extractIndexes(self):
         fragment = self._doc.createDocumentFragment()
         indexes = self.context.getIndexObjects()[:]
-        indexes.sort(lambda x,y: cmp(x.getId(), y.getId()))
+        indexes.sort(lambda x, y: cmp(x.getId(), y.getId()))
         for idx in indexes:
             exporter = queryMultiAdapter((idx, self.environ), INode)
             if exporter:
@@ -120,8 +120,7 @@ class ZCatalogXMLAdapter(XMLAdapterBase, ObjectManagerHelpers,
 
     def _extractColumns(self):
         fragment = self._doc.createDocumentFragment()
-        schema = self.context.schema()[:]
-        schema.sort()
+        schema = sorted(self.context.schema()[:])
         for col in schema:
             child = self._doc.createElement('column')
             child.setAttribute('value', col)

--- a/Products/GenericSetup/ZCatalog/tests/test_exportimport.py
+++ b/Products/GenericSetup/ZCatalog/tests/test_exportimport.py
@@ -115,13 +115,14 @@ _ZCTEXT_XML = """\
  </index>
 """
 
+
 class ZCatalogXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
 
     layer = ExportImportZCMLLayer
 
     def _getTargetClass(self):
         from Products.GenericSetup.ZCatalog.exportimport \
-                import ZCatalogXMLAdapter
+            import ZCatalogXMLAdapter
 
         return ZCatalogXMLAdapter
 
@@ -189,7 +190,7 @@ class ZCatalogXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
         context = DummySetupEnviron()
         adapted = getMultiAdapter((self._obj, context), IBody)
         self.assertEqual(adapted.body,
-                       _CATALOG_BODY % (_LEXICON_XML, _TEXT_XML, _COLUMN_XML))
+                         _CATALOG_BODY % (_LEXICON_XML, _TEXT_XML, _COLUMN_XML))
 
     def test_body_set_update(self):
         # Assert that the catalog ends up the way we expect it to.
@@ -204,4 +205,4 @@ class ZCatalogXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
 def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(ZCatalogXMLAdapterTests),
-        ))
+    ))

--- a/Products/GenericSetup/__init__.py
+++ b/Products/GenericSetup/__init__.py
@@ -27,18 +27,19 @@ BASE, EXTENSION, profile_registry  # pyflakes
 security = ModuleSecurityInfo('Products.GenericSetup')
 security.declareProtected(ManagePortal, 'profile_registry')
 
+
 def initialize(context):
 
     import tool
 
     context.registerClass(tool.SetupTool,
-                          constructors=(#tool.addSetupToolForm,
-                                        tool.addSetupTool,
-                                        ),
+                          constructors=(  # tool.addSetupToolForm,
+                              tool.addSetupTool,
+                          ),
                           permissions=(ManagePortal,),
                           interfaces=None,
                           icon='www/tool.png',
-                         )
+                          )
 
 # BBB: for setup tools created with CMF 1.5 if CMFSetup isn't installed
 try:

--- a/Products/GenericSetup/browser/manage.py
+++ b/Products/GenericSetup/browser/manage.py
@@ -6,28 +6,25 @@ from Products.GenericSetup.registry import _export_step_registry
 class ImportStepsView(BrowserView):
     def __init__(self, context, request):
         BrowserView.__init__(self, context, request)
-        self.global_registry=_import_step_registry
-        self.tool_registry=context.getImportStepRegistry()
+        self.global_registry = _import_step_registry
+        self.tool_registry = context.getImportStepRegistry()
 
     def invalidSteps(self):
-        steps=self.tool_registry.listStepMetadata()
-        steps=[step for step in steps if step['invalid']]
+        steps = self.tool_registry.listStepMetadata()
+        steps = [step for step in steps if step['invalid']]
         return steps
-
 
     def doubleSteps(self):
-        steps=set(self.tool_registry.listSteps())
-        globals=set(self.global_registry.listSteps())
-        steps=steps.intersection(globals)
-        steps=[self.tool_registry.getStepMetadata(step) for step in steps]
-        steps.sort()
+        steps = set(self.tool_registry.listSteps())
+        globals = set(self.global_registry.listSteps())
+        steps = steps.intersection(globals)
+        steps = sorted([self.tool_registry.getStepMetadata(step)
+                        for step in steps])
         return steps
-
 
 
 class ExportStepsView(ImportStepsView):
     def __init__(self, context, request):
         BrowserView.__init__(self, context, request)
-        self.global_registry=_export_step_registry
-        self.tool_registry=context.getExportStepRegistry()
-
+        self.global_registry = _export_step_registry
+        self.tool_registry = context.getExportStepRegistry()

--- a/Products/GenericSetup/browser/utils.py
+++ b/Products/GenericSetup/browser/utils.py
@@ -13,6 +13,7 @@
 """GenericSetup browser view utils.
 """
 
+
 class AddWithPresettingsViewBase:
 
     """Base class for add views with selectable presettings.

--- a/Products/GenericSetup/components.py
+++ b/Products/GenericSetup/components.py
@@ -171,7 +171,8 @@ class ComponentRegistryXMLAdapter(XMLAdapterBase):
             provided = _resolveDottedName(provided)
             name = unicode(str(child.getAttribute('name')))
 
-            for_ = child.getAttribute('for') or child.getAttribute('for_') #BBB
+            for_ = child.getAttribute(
+                'for') or child.getAttribute('for_')  # BBB
             required = []
             for interface in for_.split():
                 required.append(_resolveDottedName(interface))
@@ -210,7 +211,8 @@ class ComponentRegistryXMLAdapter(XMLAdapterBase):
 
             provided = _resolveDottedName(provided)
 
-            for_ = child.getAttribute('for') or child.getAttribute('for_') #BBB
+            for_ = child.getAttribute(
+                'for') or child.getAttribute('for_')  # BBB
             required = []
             for interface in for_.split():
                 required.append(_resolveDottedName(interface))
@@ -248,7 +250,8 @@ class ComponentRegistryXMLAdapter(XMLAdapterBase):
 
             handler = _resolveDottedName(handler)
 
-            for_ = child.getAttribute('for') or child.getAttribute('for_') #BBB
+            for_ = child.getAttribute(
+                'for') or child.getAttribute('for_')  # BBB
             required = []
 
             for interface in for_.split():
@@ -329,9 +332,9 @@ class ComponentRegistryXMLAdapter(XMLAdapterBase):
             elif component:
                 self.context.registerUtility(component, provided, name)
             elif factory:
-                current = [ utility for utility in current_utilities
-                            if utility.provided == provided and
-                               utility.name == name ]
+                current = [utility for utility in current_utilities
+                           if utility.provided == provided and
+                           utility.name == name]
 
                 if current and getattr(current[0], "factory", None) == factory:
                     continue
@@ -340,7 +343,7 @@ class ComponentRegistryXMLAdapter(XMLAdapterBase):
                 ofs_id = self._ofs_id(child)
                 if ofs_id not in self.context.objectIds():
                     self.context._setObject(ofs_id, aq_base(obj),
-                        set_owner=False, suppress_events=True)
+                                            set_owner=False, suppress_events=True)
                 obj = self.context.get(ofs_id)
                 obj.__name__ = ofs_id
                 obj.__parent__ = aq_base(self.context)
@@ -364,11 +367,11 @@ class ComponentRegistryXMLAdapter(XMLAdapterBase):
     def _extractAdapters(self):
         fragment = self._doc.createDocumentFragment()
 
-        registrations = [ {'factory': _getDottedName(reg.factory),
-                           'provided': _getDottedName(reg.provided),
-                           'required': reg.required,
-                           'name': reg.name}
-                          for reg in self.context.registeredAdapters() ]
+        registrations = [{'factory': _getDottedName(reg.factory),
+                          'provided': _getDottedName(reg.provided),
+                          'required': reg.required,
+                          'name': reg.name}
+                         for reg in self.context.registeredAdapters()]
         registrations.sort(key=itemgetter('name'))
         registrations.sort(key=itemgetter('provided'))
         blacklist = self._constructBlacklist()
@@ -396,10 +399,10 @@ class ComponentRegistryXMLAdapter(XMLAdapterBase):
     def _extractSubscriptionAdapters(self):
         fragment = self._doc.createDocumentFragment()
 
-        registrations = [ {'factory': _getDottedName(reg.factory),
-                           'provided': _getDottedName(reg.provided),
-                           'required': reg.required} for reg
-                            in self.context.registeredSubscriptionAdapters() ]
+        registrations = [{'factory': _getDottedName(reg.factory),
+                          'provided': _getDottedName(reg.provided),
+                          'required': reg.required} for reg
+                         in self.context.registeredSubscriptionAdapters()]
         registrations.sort(key=itemgetter('factory'))
         registrations.sort(key=itemgetter('provided'))
         blacklist = self._constructBlacklist()
@@ -425,9 +428,9 @@ class ComponentRegistryXMLAdapter(XMLAdapterBase):
     def _extractHandlers(self):
         fragment = self._doc.createDocumentFragment()
 
-        registrations = [ {'factory': _getDottedName(reg.factory),
-                           'required': reg.required}
-                          for reg in self.context.registeredHandlers() ]
+        registrations = [{'factory': _getDottedName(reg.factory),
+                          'required': reg.required}
+                         for reg in self.context.registeredHandlers()]
         registrations.sort(key=itemgetter('factory'))
         registrations.sort(key=itemgetter('required'))
 
@@ -448,11 +451,11 @@ class ComponentRegistryXMLAdapter(XMLAdapterBase):
     def _extractUtilities(self):
         fragment = self._doc.createDocumentFragment()
 
-        registrations = [ {'component': reg.component,
-                           'factory' : getattr(reg, 'factory', None),
-                           'provided': _getDottedName(reg.provided),
-                           'name': reg.name}
-                           for reg in self.context.registeredUtilities() ]
+        registrations = [{'component': reg.component,
+                          'factory': getattr(reg, 'factory', None),
+                          'provided': _getDottedName(reg.provided),
+                          'name': reg.name}
+                         for reg in self.context.registeredUtilities()]
         registrations.sort(key=itemgetter('name'))
         registrations.sort(key=itemgetter('provided'))
         site = aq_base(self._getSite())
@@ -528,6 +531,7 @@ def importComponentRegistry(context):
         else:
             logger = context.getLogger('componentregistry')
             logger.debug("Nothing to import")
+
 
 def exportComponentRegistry(context):
     """Export local components.

--- a/Products/GenericSetup/content.py
+++ b/Products/GenericSetup/content.py
@@ -33,8 +33,11 @@ from Products.GenericSetup.utils import _resolveDottedName
 #
 #   setup_tool handlers
 #
+
+
 def exportSiteStructure(context):
     IFilesystemExporter(context.getSite()).export(context, 'structure', True)
+
 
 def importSiteStructure(context):
     IFilesystemImporter(context.getSite()).import_(context, 'structure', True)
@@ -70,9 +73,9 @@ class FolderishExporterImporter(object):
         """
         exportable = self.context.objectItems()
         exportable = [x for x in exportable
-                        if not ISetupTool.providedBy(x[1])]
+                      if not ISetupTool.providedBy(x[1])]
         exportable = [x + (IFilesystemExporter(x[1], None),)
-                        for x in exportable]
+                      for x in exportable]
         return exportable
 
     def export(self, export_context, subdir, root=False):
@@ -99,10 +102,10 @@ class FolderishExporterImporter(object):
             csv_writer.writerow((object_id, factory_name))
 
         export_context.writeDataFile('.objects',
-                                    text=stream.getvalue(),
-                                    content_type='text/comma-separated-values',
-                                    subdir=subdir,
-                                   )
+                                     text=stream.getvalue(),
+                                     content_type='text/comma-separated-values',
+                                     subdir=subdir,
+                                     )
 
         prop_adapter = IINIAware(context, None)
 
@@ -111,7 +114,7 @@ class FolderishExporterImporter(object):
                                          text=prop_adapter.as_ini(),
                                          content_type='text/plain',
                                          subdir=subdir,
-                                        )
+                                         )
 
         for object_id, object, adapter in exportable:
             if adapter is not None:
@@ -129,7 +132,7 @@ class FolderishExporterImporter(object):
         if prop_adapter is not None:
             prop_text = import_context.readDataFile('.properties',
                                                     subdir=subdir,
-                                                   )
+                                                    )
             if prop_text is not None:
                 prop_adapter.put_ini(prop_text)
 
@@ -181,6 +184,7 @@ class FolderishExporterImporter(object):
     def _makeInstance(self, instance_id, type_name, subdir, import_context):
 
         context = self.context
+
         class _OldStyleClass:
             pass
 
@@ -214,18 +218,18 @@ class FolderishExporterImporter(object):
 
         try:
             instance = factory(instance_id)
-        except ValueError: # invalid type
+        except ValueError:  # invalid type
             return None
 
         if context._getOb(instance_id, None) is None:
-            context._setObject(instance_id, instance) 
+            context._setObject(instance_id, instance)
 
         return context._getOb(instance_id)
 
     def _mustPreserve(self):
         return [x for x in self.context.objectItems()
-                        if ISetupTool.providedBy(x[1])]
- 
+                if ISetupTool.providedBy(x[1])]
+
 
 def _globtest(globpattern, namelist):
     """ Filter names in 'namelist', returning those which match 'globpattern'.
@@ -256,7 +260,7 @@ class CSVAwareFileAdapter(object):
                                      self.context.as_csv(),
                                      'text/comma-separated-values',
                                      subdir,
-                                    )
+                                     )
 
     def listExportableItems(self):
         """ See IFilesystemExporter.
@@ -275,6 +279,7 @@ class CSVAwareFileAdapter(object):
             stream = StringIO(data)
             self.context.put_csv(stream)
 
+
 class INIAwareFileAdapter(object):
     """ Exporter/importer for content whose "natural" representation is an
         '.ini' file.
@@ -291,7 +296,7 @@ class INIAwareFileAdapter(object):
                                      self.context.as_ini(),
                                      'text/plain',
                                      subdir,
-                                    )
+                                     )
 
     def listExportableItems(self):
         """ See IFilesystemExporter.
@@ -308,6 +313,7 @@ class INIAwareFileAdapter(object):
             logger.info('no .ini file for %s/%s' % (subdir, cid))
         else:
             self.context.put_ini(data)
+
 
 class SimpleINIAware(object):
     """ Exporter/importer for content which doesn't know from INI.
@@ -344,6 +350,7 @@ class SimpleINIAware(object):
             else:
                 context._updateProperty(option, value)
 
+
 class FauxDAVRequest:
 
     def __init__(self, **kw):
@@ -360,11 +367,14 @@ class FauxDAVRequest:
     def get_header(self, key, default=None):
         return self._headers.get(key, default)
 
+
 class FauxDAVResponse:
     def setHeader(self, key, value, lock=False):
         pass  # stub this out to mollify webdav.Resource
+
     def setStatus(self, value, reason=None):
         pass  # stub this out to mollify webdav.Resource
+
 
 class DAVAwareFileAdapter(object):
     """ Exporter/importer for content who handle their own FTP / DAV PUTs.
@@ -386,7 +396,7 @@ class DAVAwareFileAdapter(object):
                                      self.context.manage_FTPget(),
                                      'text/plain',
                                      subdir,
-                                    )
+                                     )
 
     def listExportableItems(self):
         """ See IFilesystemExporter.

--- a/Products/GenericSetup/context.py
+++ b/Products/GenericSetup/context.py
@@ -110,12 +110,14 @@ class SetupEnviron(Implicit):
         self._should_purge = True
 
     security.declareProtected(ManagePortal, 'getLogger')
+
     def getLogger(self, name):
         """Get a logger with the specified name, creating it if necessary.
         """
         return logging.getLogger('GenericSetup.%s' % name)
 
     security.declareProtected(ManagePortal, 'shouldPurge')
+
     def shouldPurge(self):
         """When installing, should the existing setup be purged?
         """
@@ -128,52 +130,53 @@ class BaseContext(SetupEnviron):
 
     security = ClassSecurityInfo()
 
-    def __init__( self, tool, encoding ):
+    def __init__(self, tool, encoding):
 
         self._tool = tool
-        self._site = aq_parent( aq_inner( tool ) )
+        self._site = aq_parent(aq_inner(tool))
         self._loggers = {}
         self._messages = []
         self._encoding = encoding
         self._should_purge = True
 
-    security.declareProtected( ManagePortal, 'getSite' )
-    def getSite( self ):
+    security.declareProtected(ManagePortal, 'getSite')
 
+    def getSite(self):
         """ See ISetupContext.
         """
         return aq_self(self._site)
 
-    security.declareProtected( ManagePortal, 'getSetupTool' )
-    def getSetupTool( self ):
+    security.declareProtected(ManagePortal, 'getSetupTool')
 
+    def getSetupTool(self):
         """ See ISetupContext.
         """
         return self._tool
 
-    security.declareProtected( ManagePortal, 'getEncoding' )
-    def getEncoding( self ):
+    security.declareProtected(ManagePortal, 'getEncoding')
 
+    def getEncoding(self):
         """ See ISetupContext.
         """
         return self._encoding
 
-    security.declareProtected( ManagePortal, 'getLogger' )
-    def getLogger( self, name ):
+    security.declareProtected(ManagePortal, 'getLogger')
+
+    def getLogger(self, name):
         """ See ISetupContext.
         """
         return self._loggers.setdefault(name, Logger(name, self._messages))
 
-    security.declareProtected( ManagePortal, 'listNotes' )
-    def listNotes(self):
+    security.declareProtected(ManagePortal, 'listNotes')
 
+    def listNotes(self):
         """ See ISetupContext.
         """
         return self._messages[:]
 
-    security.declareProtected( ManagePortal, 'clearNotes' )
-    def clearNotes(self):
+    security.declareProtected(ManagePortal, 'clearNotes')
 
+    def clearNotes(self):
         """ See ISetupContext.
         """
         self._messages[:] = []
@@ -181,86 +184,82 @@ class BaseContext(SetupEnviron):
 InitializeClass(BaseContext)
 
 
-class DirectoryImportContext( BaseContext ):
+class DirectoryImportContext(BaseContext):
 
     implements(IChunkableImportContext)
 
     security = ClassSecurityInfo()
 
-    def __init__( self
-                , tool
-                , profile_path
-                , should_purge=False
-                , encoding=None
-                ):
+    def __init__(self, tool, profile_path, should_purge=False, encoding=None
+                 ):
 
-        BaseContext.__init__( self, tool, encoding )
+        BaseContext.__init__(self, tool, encoding)
         self._profile_path = profile_path
-        self._should_purge = bool( should_purge )
+        self._should_purge = bool(should_purge)
 
-    security.declareProtected( ManagePortal, 'openDataFile' )
-    def openDataFile( self, filename, subdir=None ):
+    security.declareProtected(ManagePortal, 'openDataFile')
 
+    def openDataFile(self, filename, subdir=None):
         """ See IImportContext.
         """
         if subdir is None:
-            full_path = os.path.join( self._profile_path, filename )
+            full_path = os.path.join(self._profile_path, filename)
         else:
-            full_path = os.path.join( self._profile_path, subdir, filename )
+            full_path = os.path.join(self._profile_path, subdir, filename)
 
-        if not os.path.exists( full_path ):
+        if not os.path.exists(full_path):
             return None
 
-        return open( full_path, 'rb' )
+        return open(full_path, 'rb')
 
-    security.declareProtected( ManagePortal, 'readDataFile' )
-    def readDataFile( self, filename, subdir=None ):
+    security.declareProtected(ManagePortal, 'readDataFile')
 
+    def readDataFile(self, filename, subdir=None):
         """ See IImportContext.
         """
         result = None
-        file = self.openDataFile( filename, subdir )
+        file = self.openDataFile(filename, subdir)
         if file is not None:
             result = file.read()
             file.close()
         return result
 
-    security.declareProtected( ManagePortal, 'getLastModified' )
-    def getLastModified( self, path ):
+    security.declareProtected(ManagePortal, 'getLastModified')
 
+    def getLastModified(self, path):
         """ See IImportContext.
         """
-        full_path = os.path.join( self._profile_path, path )
+        full_path = os.path.join(self._profile_path, path)
 
-        if not os.path.exists( full_path ):
+        if not os.path.exists(full_path):
             return None
 
-        return DateTime( os.path.getmtime( full_path ) )
+        return DateTime(os.path.getmtime(full_path))
 
-    security.declareProtected( ManagePortal, 'isDirectory' )
-    def isDirectory( self, path ):
+    security.declareProtected(ManagePortal, 'isDirectory')
 
+    def isDirectory(self, path):
         """ See IImportContext.
         """
-        full_path = os.path.join( self._profile_path, path )
+        full_path = os.path.join(self._profile_path, path)
 
-        if not os.path.exists( full_path ):
+        if not os.path.exists(full_path):
             return None
 
-        return os.path.isdir( full_path )
+        return os.path.isdir(full_path)
 
-    security.declareProtected( ManagePortal, 'listDirectory' )
+    security.declareProtected(ManagePortal, 'listDirectory')
+
     def listDirectory(self, path, skip=SKIPPED_FILES,
                       skip_suffixes=SKIPPED_SUFFIXES):
-
         """ See IImportContext.
         """
         if path is None:
             path = ''
 
-        full_path = os.path.join( self._profile_path, path )
+        full_path = os.path.join(self._profile_path, path)
 
-        if not os.path.exists( full_path ) or not os.path.isdir( full_path ):
+        if not os.path.exists(full_path) or not os.path.isdir(full_path):
             return None
 
         names = []
@@ -276,99 +275,94 @@ class DirectoryImportContext( BaseContext ):
 InitializeClass(DirectoryImportContext)
 
 
-class DirectoryExportContext( BaseContext ):
+class DirectoryExportContext(BaseContext):
 
     implements(IChunkableExportContext)
 
     security = ClassSecurityInfo()
 
-    def __init__( self, tool, profile_path, encoding=None ):
+    def __init__(self, tool, profile_path, encoding=None):
 
-        BaseContext.__init__( self, tool, encoding )
+        BaseContext.__init__(self, tool, encoding)
         self._profile_path = profile_path
 
-    security.declareProtected( ManagePortal, 'openDataFile' )
-    def openDataFile( self, filename, content_type, subdir=None ):
+    security.declareProtected(ManagePortal, 'openDataFile')
 
+    def openDataFile(self, filename, content_type, subdir=None):
         """ See IChunkableExportContext.
         """
         if subdir is None:
             prefix = self._profile_path
         else:
-            prefix = os.path.join( self._profile_path, subdir )
+            prefix = os.path.join(self._profile_path, subdir)
 
-        full_path = os.path.join( prefix, filename )
+        full_path = os.path.join(prefix, filename)
 
-        if not os.path.exists( prefix ):
-            os.makedirs( prefix )
+        if not os.path.exists(prefix):
+            os.makedirs(prefix)
 
-        mode = content_type.startswith( 'text/' ) and 'w' or 'wb'
+        mode = content_type.startswith('text/') and 'w' or 'wb'
 
-        return open( full_path, mode )
+        return open(full_path, mode)
 
-    security.declareProtected( ManagePortal, 'writeDataFile' )
-    def writeDataFile( self, filename, text, content_type, subdir=None ):
+    security.declareProtected(ManagePortal, 'writeDataFile')
 
+    def writeDataFile(self, filename, text, content_type, subdir=None):
         """ See IExportContext.
         """
         if isinstance(text, unicode):
             raise ValueError("Unicode text is not supported, even if it only "
                              "contains ascii. Please encode your data. See "
                              "GS 1.7.0 changes for more")
-        file = self.openDataFile( filename, content_type, subdir )
-        file.write( text )
+        file = self.openDataFile(filename, content_type, subdir)
+        file.write(text)
         file.close()
 
 InitializeClass(DirectoryExportContext)
 
 
-class TarballImportContext( BaseContext ):
+class TarballImportContext(BaseContext):
 
     implements(IImportContext)
 
     security = ClassSecurityInfo()
 
-    def __init__( self, tool, archive_bits, encoding=None,
-                  should_purge=False ):
-        BaseContext.__init__( self, tool, encoding )
+    def __init__(self, tool, archive_bits, encoding=None,
+                 should_purge=False):
+        BaseContext.__init__(self, tool, encoding)
         self._archive_stream = StringIO(archive_bits)
-        self._archive = TarFile.open( 'foo.bar', 'r:gz'
-                                    , self._archive_stream )
-        self._should_purge = bool( should_purge )
+        self._archive = TarFile.open('foo.bar', 'r:gz', self._archive_stream)
+        self._should_purge = bool(should_purge)
 
-    def readDataFile( self, filename, subdir=None ):
-
+    def readDataFile(self, filename, subdir=None):
         """ See IImportContext.
         """
         if subdir is not None:
-            filename = '/'.join( ( subdir, filename ) )
+            filename = '/'.join((subdir, filename))
 
         try:
-            file = self._archive.extractfile( filename )
+            file = self._archive.extractfile(filename)
         except KeyError:
             return None
 
         return file.read()
 
-    def getLastModified( self, path ):
-
+    def getLastModified(self, path):
         """ See IImportContext.
         """
-        info = self._getTarInfo( path )
+        info = self._getTarInfo(path)
         return info and DateTime(info.mtime) or None
 
-    def isDirectory( self, path ):
-
+    def isDirectory(self, path):
         """ See IImportContext.
         """
-        info = self._getTarInfo( path )
+        info = self._getTarInfo(path)
 
         if info is not None:
             return info.isdir()
 
     def listDirectory(self, path, skip=SKIPPED_FILES,
                       skip_suffixes=SKIPPED_SUFFIXES):
-
         """ See IImportContext.
         """
         if path is None:  # root is special case:  no leading '/'
@@ -399,53 +393,52 @@ class TarballImportContext( BaseContext ):
 
         return names
 
-    def shouldPurge( self ):
-
+    def shouldPurge(self):
         """ See IImportContext.
         """
         return self._should_purge
 
-    def _getTarInfo( self, path ):
+    def _getTarInfo(self, path):
         if path.endswith('/'):
             path = path[:-1]
         try:
-            return self._archive.getmember( path )
+            return self._archive.getmember(path)
         except KeyError:
             pass
         try:
-            return self._archive.getmember( path + '/' )
+            return self._archive.getmember(path + '/')
         except KeyError:
             return None
 
 InitializeClass(TarballImportContext)
 
 
-class TarballExportContext( BaseContext ):
+class TarballExportContext(BaseContext):
 
     implements(IExportContext)
 
     security = ClassSecurityInfo()
 
-    def __init__( self, tool, encoding=None ):
+    def __init__(self, tool, encoding=None):
 
-        BaseContext.__init__( self, tool, encoding )
+        BaseContext.__init__(self, tool, encoding)
 
         timestamp = time.gmtime()
-        archive_name = ( 'setup_tool-%4d%02d%02d%02d%02d%02d.tar.gz'
-                       % timestamp[:6] )
+        archive_name = ('setup_tool-%4d%02d%02d%02d%02d%02d.tar.gz'
+                        % timestamp[:6])
 
         self._archive_stream = StringIO()
         self._archive_filename = archive_name
-        self._archive = TarFile.open( archive_name, 'w:gz'
-                                    , self._archive_stream )
+        self._archive = TarFile.open(
+            archive_name, 'w:gz', self._archive_stream)
 
-    security.declareProtected( ManagePortal, 'writeDataFile' )
-    def writeDataFile( self, filename, text, content_type, subdir=None ):
+    security.declareProtected(ManagePortal, 'writeDataFile')
 
+    def writeDataFile(self, filename, text, content_type, subdir=None):
         """ See IExportContext.
         """
         if subdir is not None:
-            filename = '/'.join( ( subdir, filename ) )
+            filename = '/'.join((subdir, filename))
 
         parents = filename.split('/')[:-1]
         while parents:
@@ -469,24 +462,24 @@ class TarballExportContext( BaseContext ):
                              "GS 1.7.0 changes for more")
         else:
             # Assume text is a an instance of a class like
-            # Products.Archetypes.WebDAVSupport.PdataStreamIterator, 
+            # Products.Archetypes.WebDAVSupport.PdataStreamIterator,
             # as in the case of ATFile
             stream = text.file
             info.size = text.size
         info.mtime = time.time()
-        self._archive.addfile( info, stream )
+        self._archive.addfile(info, stream)
 
-    security.declareProtected( ManagePortal, 'getArchive' )
-    def getArchive( self ):
+    security.declareProtected(ManagePortal, 'getArchive')
 
+    def getArchive(self):
         """ Close the archive, and return it as a big string.
         """
         self._archive.close()
         return self._archive_stream.getvalue()
 
-    security.declareProtected( ManagePortal, 'getArchiveFilename' )
-    def getArchiveFilename( self ):
+    security.declareProtected(ManagePortal, 'getArchiveFilename')
 
+    def getArchiveFilename(self):
         """ Close the archive, and return it as a big string.
         """
         return self._archive_filename
@@ -494,51 +487,51 @@ class TarballExportContext( BaseContext ):
 InitializeClass(TarballExportContext)
 
 
-class SnapshotExportContext( BaseContext ):
+class SnapshotExportContext(BaseContext):
 
     implements(IExportContext)
 
     security = ClassSecurityInfo()
 
-    def __init__( self, tool, snapshot_id, encoding=None ):
+    def __init__(self, tool, snapshot_id, encoding=None):
 
-        BaseContext.__init__( self, tool, encoding )
+        BaseContext.__init__(self, tool, encoding)
         self._snapshot_id = snapshot_id
 
-    security.declareProtected( ManagePortal, 'writeDataFile' )
-    def writeDataFile( self, filename, text, content_type, subdir=None ):
+    security.declareProtected(ManagePortal, 'writeDataFile')
 
+    def writeDataFile(self, filename, text, content_type, subdir=None):
         """ See IExportContext.
         """
         if subdir is not None:
-            filename = '/'.join( ( subdir, filename ) )
+            filename = '/'.join((subdir, filename))
 
         sep = filename.rfind('/')
         if sep != -1:
             subdir = filename[:sep]
-            filename = filename[sep+1:]
+            filename = filename[sep + 1:]
 
         if isinstance(text, unicode):
             raise ValueError("Unicode text is not supported, even if it only "
                              "contains ascii. Please encode your data. See "
                              "GS 1.7.0 changes for more")
 
-        folder = self._ensureSnapshotsFolder( subdir )
+        folder = self._ensureSnapshotsFolder(subdir)
 
         # TODO: switch on content_type
-        ob = self._createObjectByType( filename, text, content_type )
-        folder._setObject( str( filename ), ob ) # No Unicode IDs!
+        ob = self._createObjectByType(filename, text, content_type)
+        folder._setObject(str(filename), ob)  # No Unicode IDs!
 
-    security.declareProtected( ManagePortal, 'getSnapshotURL' )
-    def getSnapshotURL( self ):
+    security.declareProtected(ManagePortal, 'getSnapshotURL')
 
+    def getSnapshotURL(self):
         """ See IExportContext.
         """
-        return '%s/%s' % ( self._tool.absolute_url(), self._snapshot_id )
+        return '%s/%s' % (self._tool.absolute_url(), self._snapshot_id)
 
-    security.declareProtected( ManagePortal, 'getSnapshotFolder' )
-    def getSnapshotFolder( self ):
+    security.declareProtected(ManagePortal, 'getSnapshotFolder')
 
+    def getSnapshotFolder(self):
         """ See IExportContext.
         """
         return self._ensureSnapshotsFolder()
@@ -546,49 +539,49 @@ class SnapshotExportContext( BaseContext ):
     #
     #   Helper methods
     #
-    security.declarePrivate( '_createObjectByType' )
-    def _createObjectByType( self, name, body, content_type ):
+    security.declarePrivate('_createObjectByType')
 
-        if isinstance( body, unicode ):
+    def _createObjectByType(self, name, body, content_type):
+
+        if isinstance(body, unicode):
             encoding = self.getEncoding()
             if encoding is None:
                 body = body.encode()
             else:
-                body = body.encode( encoding )
+                body = body.encode(encoding)
 
         if name.endswith('.py'):
 
-            ob = PythonScript( name )
-            ob.write( body )
+            ob = PythonScript(name)
+            ob.write(body)
 
         elif name.endswith('.dtml'):
 
-            ob = DTMLDocument( '', __name__=name )
-            ob.munge( body )
+            ob = DTMLDocument('', __name__=name)
+            ob.munge(body)
 
-        elif content_type in ('text/html', 'text/xml' ):
+        elif content_type in ('text/html', 'text/xml'):
 
-            ob = ZopePageTemplate( name, body
-                                 , content_type=content_type )
+            ob = ZopePageTemplate(name, body, content_type=content_type)
 
-        elif content_type[:6]=='image/':
+        elif content_type[:6] == 'image/':
 
-            ob=Image( name, '', body, content_type=content_type )
+            ob = Image(name, '', body, content_type=content_type)
 
         else:
-            ob=File( name, '', body, content_type=content_type )
+            ob = File(name, '', body, content_type=content_type)
 
         return ob
 
-    security.declarePrivate( '_ensureSnapshotsFolder' )
-    def _ensureSnapshotsFolder( self, subdir=None ):
+    security.declarePrivate('_ensureSnapshotsFolder')
 
+    def _ensureSnapshotsFolder(self, subdir=None):
         """ Ensure that the appropriate snapshot folder exists.
         """
-        path = [ 'snapshots', self._snapshot_id ]
+        path = ['snapshots', self._snapshot_id]
 
         if subdir is not None:
-            path.extend( subdir.split( '/' ) )
+            path.extend(subdir.split('/'))
 
         current = self._tool
 
@@ -596,49 +589,45 @@ class SnapshotExportContext( BaseContext ):
 
             if element not in current.objectIds():
                 # No Unicode IDs!
-                current._setObject( str( element ), Folder( element ) )
+                current._setObject(str(element), Folder(element))
 
-            current = current._getOb( element )
+            current = current._getOb(element)
 
         return current
 
 InitializeClass(SnapshotExportContext)
 
 
-class SnapshotImportContext( BaseContext ):
+class SnapshotImportContext(BaseContext):
 
     implements(IImportContext)
 
     security = ClassSecurityInfo()
 
-    def __init__( self
-                , tool
-                , snapshot_id
-                , should_purge=False
-                , encoding=None
-                ):
+    def __init__(self, tool, snapshot_id, should_purge=False, encoding=None
+                 ):
 
-        BaseContext.__init__( self, tool, encoding )
+        BaseContext.__init__(self, tool, encoding)
         self._snapshot_id = snapshot_id
         self._encoding = encoding
-        self._should_purge = bool( should_purge )
+        self._should_purge = bool(should_purge)
 
-    security.declareProtected( ManagePortal, 'readDataFile' )
-    def readDataFile( self, filename, subdir=None ):
+    security.declareProtected(ManagePortal, 'readDataFile')
 
+    def readDataFile(self, filename, subdir=None):
         """ See IImportContext.
         """
         if subdir is not None:
-            filename = '/'.join( ( subdir, filename ) )
+            filename = '/'.join((subdir, filename))
 
         sep = filename.rfind('/')
         if sep != -1:
             subdir = filename[:sep]
-            filename = filename[sep+1:]
+            filename = filename[sep + 1:]
         try:
-            snapshot = self._getSnapshotFolder( subdir )
-            object = snapshot._getOb( filename )
-        except ( AttributeError, KeyError ):
+            snapshot = self._getSnapshotFolder(subdir)
+            object = snapshot._getOb(filename)
+        except (AttributeError, KeyError):
             return None
 
         if isinstance(object, File):
@@ -652,15 +641,15 @@ class SnapshotImportContext( BaseContext ):
             data = data.encode('utf-8')
         return data
 
-    security.declareProtected( ManagePortal, 'getLastModified' )
-    def getLastModified( self, path ):
+    security.declareProtected(ManagePortal, 'getLastModified')
 
+    def getLastModified(self, path):
         """ See IImportContext.
         """
         try:
             snapshot = self._getSnapshotFolder()
-            object = snapshot.restrictedTraverse( path )
-        except ( AttributeError, KeyError ):
+            object = snapshot.restrictedTraverse(path)
+        except (AttributeError, KeyError):
             return None
         else:
             mtime = getattr(object, '_p_mtime', None)
@@ -671,32 +660,32 @@ class SnapshotImportContext( BaseContext ):
                     return DateTime()
             return DateTime(mtime)
 
-    security.declareProtected( ManagePortal, 'isDirectory' )
-    def isDirectory( self, path ):
+    security.declareProtected(ManagePortal, 'isDirectory')
 
+    def isDirectory(self, path):
         """ See IImportContext.
         """
         try:
             snapshot = self._getSnapshotFolder()
-            object = snapshot.restrictedTraverse( str( path ) )
-        except ( AttributeError, KeyError ):
+            object = snapshot.restrictedTraverse(str(path))
+        except (AttributeError, KeyError):
             return None
         else:
-            folderish = getattr( object, 'isPrincipiaFolderish', False )
-            return bool( folderish )
+            folderish = getattr(object, 'isPrincipiaFolderish', False)
+            return bool(folderish)
 
-    security.declareProtected( ManagePortal, 'listDirectory' )
+    security.declareProtected(ManagePortal, 'listDirectory')
+
     def listDirectory(self, path, skip=(), skip_suffixes=()):
-
         """ See IImportContext.
         """
         try:
             snapshot = self._getSnapshotFolder()
-            subdir = snapshot.restrictedTraverse( path )
-        except ( AttributeError, KeyError ):
+            subdir = snapshot.restrictedTraverse(path)
+        except (AttributeError, KeyError):
             return None
         else:
-            if not getattr( subdir, 'isPrincipiaFolderish', False ):
+            if not getattr(subdir, 'isPrincipiaFolderish', False):
                 return None
 
             names = []
@@ -709,9 +698,9 @@ class SnapshotImportContext( BaseContext ):
 
             return names
 
-    security.declareProtected( ManagePortal, 'shouldPurge' )
-    def shouldPurge( self ):
+    security.declareProtected(ManagePortal, 'shouldPurge')
 
+    def shouldPurge(self):
         """ See IImportContext.
         """
         return self._should_purge
@@ -719,16 +708,16 @@ class SnapshotImportContext( BaseContext ):
     #
     #   Helper methods
     #
-    security.declarePrivate( '_getSnapshotFolder' )
-    def _getSnapshotFolder( self, subdir=None ):
+    security.declarePrivate('_getSnapshotFolder')
 
+    def _getSnapshotFolder(self, subdir=None):
         """ Return the appropriate snapshot (sub)folder.
         """
-        path = [ 'snapshots', self._snapshot_id ]
+        path = ['snapshots', self._snapshot_id]
 
         if subdir is not None:
-            path.extend( subdir.split( '/' ) )
+            path.extend(subdir.split('/'))
 
-        return self._tool.restrictedTraverse( path )
+        return self._tool.restrictedTraverse(path)
 
 InitializeClass(SnapshotImportContext)

--- a/Products/GenericSetup/interfaces.py
+++ b/Products/GenericSetup/interfaces.py
@@ -25,7 +25,7 @@ SKIPPED_FILES = ('CVS', '.svn', '_svn', '_darcs')
 SKIPPED_SUFFIXES = ('~',)
 
 
-class IPseudoInterface( Interface ):
+class IPseudoInterface(Interface):
 
     """ API documentation;  not testable / enforceable.
     """
@@ -50,17 +50,14 @@ class ISetupContext(ISetupEnviron):
     """ Context used for export / import plugins.
     """
     def getSite():
-
         """ Return the site object being configured / dumped.
         """
 
     def getSetupTool():
-
         """ Return the site object being configured / dumped.
         """
 
     def getEncoding():
-
         """ Get the encoding used for configuration data within the site.
 
         o Return None if the data should not be encoded.
@@ -76,10 +73,10 @@ class ISetupContext(ISetupEnviron):
         """ Clear all notes recorded by this context.
         """
 
-class IImportContext( ISetupContext ):
 
-    def readDataFile( filename, subdir=None ):
+class IImportContext(ISetupContext):
 
+    def readDataFile(filename, subdir=None):
         """ Search the current configuration for the requested file.
 
         o 'filename' is the name (without path elements) of the file.
@@ -91,8 +88,7 @@ class IImportContext( ISetupContext ):
           file cannot be found.
         """
 
-    def getLastModified( path ):
-
+    def getLastModified(path):
         """ Return the modification timestamp of the item at 'path'.
 
         o Result will be a DateTime instance.
@@ -108,8 +104,7 @@ class IImportContext( ISetupContext ):
         o Return None if 'path' does not point to any object.
         """
 
-    def isDirectory( path ):
-
+    def isDirectory(path):
         """ Test whether path points to a directory / folder.
 
         o If the context is filesystem based, check that 'path' points to
@@ -122,8 +117,7 @@ class IImportContext( ISetupContext ):
           bool.
         """
 
-    def listDirectory( path, skip=SKIPPED_FILES ):
-
+    def listDirectory(path, skip=SKIPPED_FILES):
         """ List IDs of the contents of a  directory / folder.
 
         o Omit names in 'skip'.
@@ -131,10 +125,10 @@ class IImportContext( ISetupContext ):
         o If 'path' does not point to a directory / folder, return None.
         """
 
-class IChunkableImportContext( IImportContext ):
 
-    def openDataFile( filename, subdir=None ):
+class IChunkableImportContext(IImportContext):
 
+    def openDataFile(filename, subdir=None):
         """ Open a datafile for reading from the specified location.
 
         o 'filename' is the unqualified name of the file.
@@ -147,12 +141,12 @@ class IChunkableImportContext( IImportContext ):
           for calling 'close' on it.
         """
 
-class IImportPlugin( IPseudoInterface ):
+
+class IImportPlugin(IPseudoInterface):
 
     """ Signature for callables used to import portions of site configuration.
     """
-    def __call__( context ):
-
+    def __call__(context):
         """ Perform the setup step.
 
         o Return a message describing the work done.
@@ -160,10 +154,10 @@ class IImportPlugin( IPseudoInterface ):
         o 'context' must implement IImportContext.
         """
 
-class IExportContext( ISetupContext ):
 
-    def writeDataFile( filename, text, content_type, subdir=None ):
+class IExportContext(ISetupContext):
 
+    def writeDataFile(filename, text, content_type, subdir=None):
         """ Write data into the specified location.
 
         o 'filename' is the unqualified name of the file.
@@ -177,10 +171,10 @@ class IExportContext( ISetupContext ):
           "root" of the target.
         """
 
-class IChunkableExportContext( IExportContext ):
 
-    def openDataFile( filename, content_type, subdir=None ):
+class IChunkableExportContext(IExportContext):
 
+    def openDataFile(filename, content_type, subdir=None):
         """ Open a datafile for writing into the specified location.
 
         o 'filename' is the unqualified name of the file.
@@ -195,12 +189,12 @@ class IChunkableExportContext( IExportContext ):
           for calling 'close' on it.
         """
 
-class IExportPlugin( IPseudoInterface ):
+
+class IExportPlugin(IPseudoInterface):
 
     """ Signature for callables used to export portions of site configuration.
     """
-    def __call__( context ):
-
+    def __call__(context):
         """ Write export data for the site wrapped by context.
 
         o Return a message describing the work done.
@@ -209,26 +203,24 @@ class IExportPlugin( IPseudoInterface ):
           its 'writeDataFile' method for each file to be exported.
         """
 
-class IStepRegistry( Interface ):
+
+class IStepRegistry(Interface):
 
     """ Base interface for step registries.
     """
     def listSteps():
-
         """ Return a sequence of IDs of registered steps.
 
         o Order is not significant.
         """
 
     def listStepMetadata():
-
         """ Return a sequence of mappings describing registered steps.
 
         o Mappings will be ordered alphabetically.
         """
 
-    def getStepMetadata( key, default=None ):
-
+    def getStepMetadata(key, default=None):
         """ Return a mapping of metadata for the step identified by 'key'.
 
         o Return 'default' if no such step is registered.
@@ -237,23 +229,21 @@ class IStepRegistry( Interface ):
         """
 
     def generateXML():
-
         """ Return a round-trippable XML representation of the registry.
 
         o 'handler' values are serialized using their dotted names.
         """
 
-    def parseXML( text ):
-
+    def parseXML(text):
         """ Parse 'text'.
         """
 
-class IImportStepRegistry( IStepRegistry ):
+
+class IImportStepRegistry(IStepRegistry):
 
     """ API for import step registry.
     """
     def sortSteps():
-
         """ Return a sequence of registered step IDs
 
         o Sequence is sorted topologically by dependency, with the dependent
@@ -261,24 +251,17 @@ class IImportStepRegistry( IStepRegistry ):
         """
 
     def checkComplete():
-
         """ Return a sequence of ( node, edge ) tuples for unsatisifed deps.
         """
 
-    def getStep( key, default=None ):
-
+    def getStep(key, default=None):
         """ Return the IImportPlugin registered for 'key'.
 
         o Return 'default' if no such step is registered.
         """
 
-    def registerStep( id
-                    , version=None
-                    , handler=None
-                    , dependencies=()
-                    , title=None
-                    , description=None
-                    ):
+    def registerStep(id, version=None, handler=None, dependencies=(), title=None, description=None
+                     ):
         """ Register a setup step.
 
         o 'id' is a unique name for this step,
@@ -311,19 +294,18 @@ class IImportStepRegistry( IStepRegistry ):
           the handler is used, or default to ''.
         """
 
-class IExportStepRegistry( IStepRegistry ):
+
+class IExportStepRegistry(IStepRegistry):
 
     """ API for export step registry.
     """
-    def getStep( key, default=None ):
-
+    def getStep(key, default=None):
         """ Return the IExportPlugin registered for 'key'.
 
         o Return 'default' if no such step is registered.
         """
 
-    def registerStep( id, handler, title=None, description=None ):
-
+    def registerStep(id, handler, title=None, description=None):
         """ Register an export step.
 
         o 'id' is the unique identifier for this step
@@ -339,17 +321,16 @@ class IExportStepRegistry( IStepRegistry ):
           the step is used, or default to ''.
         """
 
-class IToolsetRegistry( Interface ):
+
+class IToolsetRegistry(Interface):
 
     """ API for toolset registry.
     """
     def listForbiddenTools():
-
         """ Return a list of IDs of tools which must be removed, if present.
         """
 
-    def addForbiddenTool(tool_id ):
-
+    def addForbiddenTool(tool_id):
         """ Add 'tool_id' to the list of forbidden tools.
 
         o Raise KeyError if 'tool_id' is already in the list.
@@ -358,12 +339,10 @@ class IToolsetRegistry( Interface ):
         """
 
     def listRequiredTools():
-
         """ Return a list of IDs of tools which must be present.
         """
 
-    def getRequiredToolInfo( tool_id ):
-
+    def getRequiredToolInfo(tool_id):
         """ Return a mapping describing a partiuclar required tool.
 
         o Keys include:
@@ -376,12 +355,10 @@ class IToolsetRegistry( Interface ):
         """
 
     def listRequiredToolInfo():
-
         """ Return a list of IDs of tools which must be present.
         """
 
-    def addRequiredTool( tool_id, dotted_name ):
-
+    def addRequiredTool(tool_id, dotted_name):
         """ Add a tool to our "required" list.
 
         o 'tool_id' is the tool's ID.
@@ -393,12 +370,12 @@ class IToolsetRegistry( Interface ):
         o Raise ValueError if 'tool_id' is in the "forbidden" list.
         """
 
-class IProfileRegistry( Interface ):
+
+class IProfileRegistry(Interface):
 
     """ API for profile registry.
     """
-    def getProfileInfo( profile_id, for_=None ):
-
+    def getProfileInfo(profile_id, for_=None):
         """ Return a mapping describing a registered filesystem profile.
 
         o Keys include:
@@ -423,8 +400,7 @@ class IProfileRegistry( Interface ):
             If 'None', list all profiles.
         """
 
-    def listProfiles( for_=None ):
-
+    def listProfiles(for_=None):
         """ Return a list of IDs for registered profiles.
 
         o 'for_', if passed, should be the interface specifying the "site
@@ -434,8 +410,7 @@ class IProfileRegistry( Interface ):
             If 'None', list all profiles.
         """
 
-    def listProfileInfo( for_=None ):
-
+    def listProfileInfo(for_=None):
         """ Return a list of mappings describing registered profiles.
 
         o See 'getProfileInfo' for a description of the mappings' keys.
@@ -447,14 +422,8 @@ class IProfileRegistry( Interface ):
             If 'None', list all profiles.
         """
 
-    def registerProfile( name
-                       , title
-                       , description
-                       , path
-                       , product=None
-                       , profile_type=BASE
-                       , for_=None
-                       ):
+    def registerProfile(name, title, description, path, product=None, profile_type=BASE, for_=None
+                        ):
         """ Add a new profile to the registry.
 
         o If an existing profile is already registered for 'product:name',
@@ -470,13 +439,13 @@ class IProfileRegistry( Interface ):
           If 'None', the profile might be used in any site.
         """
 
-class ISetupTool( Interface ):
+
+class ISetupTool(Interface):
 
     """ API for SetupTool.
     """
 
     def getEncoding():
-
         """ Get the encoding used for configuration data within the site.
 
         o Return None if the data should not be encoded.
@@ -486,7 +455,7 @@ class ISetupTool( Interface ):
         """ Get the ID of the base profile for this configuration.
         """
 
-    def setBaselineContext( context_id, encoding=None):
+    def setBaselineContext(context_id, encoding=None):
         """ Specify the base profile for this configuration.
         """
 
@@ -500,29 +469,24 @@ class ISetupTool( Interface ):
         'value' must be a boolean.
         """
 
-    def applyContext( context, encoding=None ):
-
+    def applyContext(context, encoding=None):
         """ Update the tool from the supplied context, without modifying its
             "permanent" ID.
         """
 
     def getImportStepRegistry():
-
         """ Return the IImportStepRegistry for the tool.
         """
 
     def getExportStepRegistry():
-
         """ Return the IExportStepRegistry for the tool.
         """
 
     def getToolsetRegistry():
-
         """ Return the IToolsetRegistry for the tool.
         """
 
-    def getProfileDependencyChain( profile_id ):
-
+    def getProfileDependencyChain(profile_id):
         """Return a list of dependencies for a profile.
 
         The list is ordered by install order, with the requested profile as
@@ -531,7 +495,6 @@ class ISetupTool( Interface ):
 
     def runImportStepFromProfile(profile_id, step_id,
                                  run_dependencies=True, purge_old=None):
-
         """ Execute a given setup step from the given profile.
 
         o 'profile_id' must be a valid ID of a registered profile;
@@ -557,7 +520,6 @@ class ISetupTool( Interface ):
     def runAllImportStepsFromProfile(profile_id, purge_old=None,
                                      ignore_dependencies=False,
                                      blacklisted_steps=None):
-
         """ Run all setup steps for the given profile in dependency order.
 
         o 'profile_id' must be a valid ID of a registered profile;
@@ -582,8 +544,7 @@ class ISetupTool( Interface ):
             step
         """
 
-    def runExportStep( step_id ):
-
+    def runExportStep(step_id):
         """ Generate a tarball containing artifacts from one export step.
 
         o 'step_id' identifies the export step.
@@ -599,7 +560,6 @@ class ISetupTool( Interface ):
         """
 
     def runAllExportSteps():
-
         """ Generate a tarball containing artifacts from all export steps.
 
         o Return a mapping, with keys:
@@ -612,18 +572,14 @@ class ISetupTool( Interface ):
           'tarball' -- the stringified tar-gz data.
         """
 
-    def createSnapshot( snapshot_id ):
-
+    def createSnapshot(snapshot_id):
         """ Create a snapshot folder using all steps.
 
         o 'snapshot_id' is the ID of the new folder.
         """
 
-    def compareConfigurations( lhs_context
-                             , rhs_context
-                             , missing_as_empty=False
-                             , ignore_whitespace=False
-                             ):
+    def compareConfigurations(lhs_context, rhs_context, missing_as_empty=False, ignore_whitespace=False
+                              ):
         """ Compare two configurations.
 
         o 'lhs_context' and 'rhs_context' must implement IImportContext.
@@ -735,6 +691,7 @@ class IFilesystemExporter(Interface):
           IFilesystemExporter.
         """
 
+
 class IFilesystemImporter(Interface):
     """ Plugin interface for site structure export.
     """
@@ -752,12 +709,14 @@ class IFilesystemImporter(Interface):
           interacting with the context).
         """
 
+
 class IContentFactory(Interface):
     """ Adapter interface for factories specific to a container.
     """
     def __call__(id):
         """ Return a new instance, seated in the context under 'id'.
         """
+
 
 class IContentFactoryName(Interface):
     """ Adapter interface for finding the name of the ICF for an object.
@@ -769,6 +728,7 @@ class IContentFactoryName(Interface):
           container which would create an "empty" instance of the same
           type as our context.
         """
+
 
 class ICSVAware(Interface):
     """ Interface for objects which dump / load 'text/comma-separated-values'.
@@ -788,6 +748,7 @@ class ICSVAware(Interface):
           CSV text parseable by the 'csv.reader'.
         """
 
+
 class IINIAware(Interface):
     """ Interface for objects which dump / load INI-format files..
     """
@@ -805,6 +766,7 @@ class IINIAware(Interface):
         o 'stream_or_text' must be either a string, or else a stream
           directly parseable by ConfigParser.
         """
+
 
 class IDAVAware(Interface):
     """ Interface for objects which handle their own FTP / DAV operations.
@@ -825,6 +787,7 @@ class IDAVAware(Interface):
           method, whose headers (e.g., "Content-Type") may affect the
           processing of the body.
         """
+
 
 class IBeforeProfileImportEvent(Interface):
     """ An event which is fired before (part of) a profile is imported.
@@ -863,17 +826,21 @@ class IComponentsHandlerBlacklist(Interface):
         the export and import handlers.
         """
 
+
 class IProfile(Interface):
     """ Named profile.
     """
+
 
 class IImportStep(Interface):
     """ Named import step.
     """
 
+
 class IExportStep(Interface):
     """ Named export step.
     """
+
 
 class IUpgradeSteps(Interface):
     """ Named upgrade steps.

--- a/Products/GenericSetup/metadata.py
+++ b/Products/GenericSetup/metadata.py
@@ -24,12 +24,12 @@ from Products.GenericSetup.utils import KEY
 METADATA_XML = 'metadata.xml'
 
 
-class ProfileMetadata( ImportConfiguratorBase ):
+class ProfileMetadata(ImportConfiguratorBase):
 
     """ Extracts profile metadata from metadata.xml file.
     """
 
-    def __init__( self, path, encoding=None, product=None ):
+    def __init__(self, path, encoding=None, product=None):
 
         # don't call the base class __init__ b/c we don't have (or need)
         # a site
@@ -46,32 +46,32 @@ class ProfileMetadata( ImportConfiguratorBase ):
 
         self._encoding = encoding
 
-    def __call__( self ):
-        
-        full_path = os.path.join( self._path, METADATA_XML )
-        if not os.path.exists( full_path ):
+    def __call__(self):
+
+        full_path = os.path.join(self._path, METADATA_XML)
+        if not os.path.exists(full_path):
             return {}
 
-        file = open( full_path, 'r' )
-        return self.parseXML( file.read() )
+        file = open(full_path, 'r')
+        return self.parseXML(file.read())
 
-    def _getImportMapping( self ):
+    def _getImportMapping(self):
 
         return {
             'metadata':
-            {'description': { CONVERTER: self._convertToUnique },
-             'version': { CONVERTER: self._convertToUnique },
-             'dependencies': { CONVERTER: self._convertToUnique },
+            {'description': {CONVERTER: self._convertToUnique},
+             'version': {CONVERTER: self._convertToUnique},
+             'dependencies': {CONVERTER: self._convertToUnique},
              },
             'description':
-            { '#text': { KEY: None, DEFAULT: '' },
-              },
+            {'#text': {KEY: None, DEFAULT: ''},
+             },
             'version':
-            { '#text': { KEY: None },
-              },
+            {'#text': {KEY: None},
+             },
             'dependencies':
-            {'dependency': { KEY: None, DEFAULT: () },},
+            {'dependency': {KEY: None, DEFAULT: ()}, },
             'dependency':
-            { '#text': { KEY: None },
-              },
-            }
+            {'#text': {KEY: None},
+             },
+        }

--- a/Products/GenericSetup/registry.py
+++ b/Products/GenericSetup/registry.py
@@ -118,8 +118,8 @@ class _ImportStepRegistryParser(_HandlerBase):
             if self._pending is not None:
                 raise ValueError('Cannot nest setup-step elements')
 
-            self._pending = dict([ (k, self._extract(attrs, k))
-                                   for k in attrs.keys() ])
+            self._pending = dict([(k, self._extract(attrs, k))
+                                  for k in attrs.keys()])
 
             self._pending['dependencies'] = []
 
@@ -181,8 +181,8 @@ class _ExportStepRegistryParser(_HandlerBase):
             if self._pending is not None:
                 raise ValueError('Cannot nest export-step elements')
 
-            self._pending = dict([ (k, self._extract(attrs, k))
-                                   for k in attrs.keys() ])
+            self._pending = dict([(k, self._extract(attrs, k))
+                                  for k in attrs.keys()])
 
         else:
             raise ValueError('Unknown element %s' % name)
@@ -216,11 +216,11 @@ class GlobalRegistryStorage(object):
 
     def keys(self):
         sm = getGlobalSiteManager()
-        return [ n for n, _i in sm.getUtilitiesFor(self.interfaceClass) ]
+        return [n for n, _i in sm.getUtilitiesFor(self.interfaceClass)]
 
     def values(self):
         sm = getGlobalSiteManager()
-        return [ i for _n, i in sm.getUtilitiesFor(self.interfaceClass) ]
+        return [i for _n, i in sm.getUtilitiesFor(self.interfaceClass)]
 
     def get(self, key):
         sm = getGlobalSiteManager()
@@ -250,12 +250,14 @@ class BaseStepRegistry(Implicit):
         self.clear()
 
     security.declareProtected(ManagePortal, 'listSteps')
+
     def listSteps(self):
         """ Return a list of registered step IDs.
         """
         return self._registered.keys()
 
     security.declareProtected(ManagePortal, 'getStepMetadata')
+
     def getStepMetadata(self, key, default=None):
         """ Return a mapping of metadata for the step identified by 'key'.
 
@@ -274,16 +276,17 @@ class BaseStepRegistry(Implicit):
         return result
 
     security.declareProtected(ManagePortal, 'listStepMetadata')
+
     def listStepMetadata(self):
         """ Return a sequence of mappings describing registered steps.
 
         o Mappings will be ordered alphabetically.
         """
-        step_ids = self.listSteps()
-        step_ids.sort()
-        return [ self.getStepMetadata(x) for x in step_ids ]
+        step_ids = sorted(self.listSteps())
+        return [self.getStepMetadata(x) for x in step_ids]
 
     security.declareProtected(ManagePortal, 'generateXML')
+
     def generateXML(self, encoding='utf-8'):
         """ Return a round-trippable XML representation of the registry.
 
@@ -292,6 +295,7 @@ class BaseStepRegistry(Implicit):
         return self._exportTemplate().encode('utf-8')
 
     security.declarePrivate('getStep')
+
     def getStep(self, key, default=None):
         """ Return the I(Export|Import)Plugin registered for 'key'.
 
@@ -305,14 +309,17 @@ class BaseStepRegistry(Implicit):
         return _resolveDottedName(info['handler'])
 
     security.declarePrivate('unregisterStep')
+
     def unregisterStep(self, id):
         del self._registered[id]
 
     security.declarePrivate('clear')
+
     def clear(self):
         self._registered.clear()
 
     security.declarePrivate('parseXML')
+
     def parseXML(self, text, encoding='utf-8'):
         """ Parse 'text'.
         """
@@ -341,6 +348,7 @@ class ImportStepRegistry(BaseStepRegistry):
     RegistryParser = _ImportStepRegistryParser
 
     security.declareProtected(ManagePortal, 'sortSteps')
+
     def sortSteps(self):
         """ Return a sequence of registered step IDs
 
@@ -350,6 +358,7 @@ class ImportStepRegistry(BaseStepRegistry):
         return self._computeTopologicalSort()
 
     security.declareProtected(ManagePortal, 'checkComplete')
+
     def checkComplete(self):
         """ Return a sequence of ( node, edge ) tuples for unsatisifed deps.
         """
@@ -372,6 +381,7 @@ class ImportStepRegistry(BaseStepRegistry):
         return result
 
     security.declarePrivate('registerStep')
+
     def registerStep(self, id, version=None, handler=None, dependencies=(),
                      title=None, description=None):
         """ Register a setup step.
@@ -440,6 +450,7 @@ class ImportStepRegistry(BaseStepRegistry):
     #   Helper methods
     #
     security.declarePrivate('_computeTopologicalSort')
+
     def _computeTopologicalSort(self):
         return _computeTopologicalSort(self._registered.values())
 
@@ -475,6 +486,7 @@ class ExportStepRegistry(BaseStepRegistry):
     RegistryParser = _ExportStepRegistryParser
 
     security.declarePrivate('registerStep')
+
     def registerStep(self, id, handler, title=None, description=None):
         """ Register an export step.
 
@@ -539,14 +551,15 @@ class ToolsetRegistry(Implicit):
     #   Toolset API
     #
     security.declareProtected(ManagePortal, 'listForbiddenTools')
+
     def listForbiddenTools(self):
         """ See IToolsetRegistry.
         """
-        result = list(self._forbidden)
-        result.sort()
+        result = sorted(self._forbidden)
         return result
 
     security.declareProtected(ManagePortal, 'addForbiddenTool')
+
     def addForbiddenTool(self, tool_id):
         """ See IToolsetRegistry.
         """
@@ -559,27 +572,30 @@ class ToolsetRegistry(Implicit):
         self._forbidden.append(tool_id)
 
     security.declareProtected(ManagePortal, 'listRequiredTools')
+
     def listRequiredTools(self):
         """ See IToolsetRegistry.
         """
-        result = list(self._required.keys())
-        result.sort()
+        result = sorted(self._required.keys())
         return result
 
     security.declareProtected(ManagePortal, 'getRequiredToolInfo')
+
     def getRequiredToolInfo(self, tool_id):
         """ See IToolsetRegistry.
         """
         return self._required[tool_id]
 
     security.declareProtected(ManagePortal, 'listRequiredToolInfo')
+
     def listRequiredToolInfo(self):
         """ See IToolsetRegistry.
         """
-        return [ self.getRequiredToolInfo(x)
-                 for x in self.listRequiredTools() ]
+        return [self.getRequiredToolInfo(x)
+                for x in self.listRequiredTools()]
 
     security.declareProtected(ManagePortal, 'addRequiredTool')
+
     def addRequiredTool(self, tool_id, dotted_name):
         """ See IToolsetRegistry.
         """
@@ -589,12 +605,14 @@ class ToolsetRegistry(Implicit):
         self._required[tool_id] = {'id': tool_id, 'class': dotted_name}
 
     security.declareProtected(ManagePortal, 'generateXML')
+
     def generateXML(self, encoding='utf-8'):
         """ Pseudo API.
         """
         return self._toolsetConfig().encode('utf-8')
 
     security.declareProtected(ManagePortal, 'parseXML')
+
     def parseXML(self, text, encoding='utf-8'):
         """ Pseudo-API
         """
@@ -613,6 +631,7 @@ class ToolsetRegistry(Implicit):
             self.addRequiredTool(tool_id, dotted_name)
 
     security.declarePrivate('clear')
+
     def clear(self):
         self._forbidden = []
         self._required = {}
@@ -641,6 +660,7 @@ class ProfileRegistry(Implicit):
         self.clear()
 
     security.declareProtected(ManagePortal, 'getProfileInfo')
+
     def getProfileInfo(self, profile_id, for_=None):
         """ See IProfileRegistry.
         """
@@ -659,6 +679,7 @@ class ProfileRegistry(Implicit):
         return result.copy()
 
     security.declareProtected(ManagePortal, 'listProfiles')
+
     def listProfiles(self, for_=None):
         """ See IProfileRegistry.
         """
@@ -670,15 +691,17 @@ class ProfileRegistry(Implicit):
         return tuple(result)
 
     security.declareProtected(ManagePortal, 'listProfileInfo')
+
     def listProfileInfo(self, for_=None):
         """ See IProfileRegistry.
         """
-        candidates = [ self.getProfileInfo(id)
-                       for id in self.listProfiles() ]
-        return [ x for x in candidates if for_ is None or x['for'] is None or
-                 issubclass(for_, x['for']) ]
+        candidates = [self.getProfileInfo(id)
+                      for id in self.listProfiles()]
+        return [x for x in candidates if for_ is None or x['for'] is None or
+                issubclass(for_, x['for'])]
 
     security.declareProtected(ManagePortal, 'registerProfile')
+
     def registerProfile(self, name, title, description, path, product=None,
                         profile_type=BASE, for_=None):
         """ See IProfileRegistry.
@@ -707,11 +730,13 @@ class ProfileRegistry(Implicit):
         return profile_id
 
     security.declareProtected(ManagePortal, 'unregisterProfile')
+
     def unregisterProfile(self, name, product=None):
         profile_id = self._computeProfileId(name, product)
         del self._registered[profile_id]
 
     security.declarePrivate('clear')
+
     def clear(self):
         self._registered.clear()
 

--- a/Products/GenericSetup/rolemap.py
+++ b/Products/GenericSetup/rolemap.py
@@ -30,8 +30,8 @@ from Products.GenericSetup.utils import CONVERTER, DEFAULT, KEY
 #
 _FILENAME = 'rolemap.xml'
 
-def importRolemap( context ):
 
+def importRolemap(context):
     """ Import roles / permission map from an XML file.
 
     o 'context' must implement IImportContext.
@@ -61,7 +61,7 @@ def importRolemap( context ):
     encoding = context.getEncoding()
     logger = context.getLogger('rolemap')
 
-    text = context.readDataFile( _FILENAME )
+    text = context.readDataFile(_FILENAME)
 
     if text is not None:
 
@@ -69,44 +69,41 @@ def importRolemap( context ):
 
             items = site.__dict__.items()
 
-            for k, v in items: # XXX: WAAA
+            for k, v in items:  # XXX: WAAA
 
                 if k == '__ac_roles__':
-                    delattr( site, k )
+                    delattr(site, k)
 
-                if k.startswith( '_' ) and k.endswith( '_Permission' ):
-                    delattr( site, k )
+                if k.startswith('_') and k.endswith('_Permission'):
+                    delattr(site, k)
 
         rc = RolemapImportConfigurator(site, encoding)
-        rolemap_info = rc.parseXML( text )
+        rolemap_info = rc.parseXML(text)
 
-        immediate_roles = list( getattr(site, '__ac_roles__', []) )
+        immediate_roles = list(getattr(site, '__ac_roles__', []))
         already = {}
 
         for role in site.valid_roles():
-            already[ role ] = 1
+            already[role] = 1
 
-        for role in rolemap_info[ 'roles' ]:
+        for role in rolemap_info['roles']:
 
-            if already.get( role ) is None:
-                immediate_roles.append( role )
-                already[ role ] = 1
+            if already.get(role) is None:
+                immediate_roles.append(role)
+                already[role] = 1
 
         immediate_roles.sort()
-        site.__ac_roles__ = tuple( immediate_roles )
+        site.__ac_roles__ = tuple(immediate_roles)
 
-        for permission in rolemap_info[ 'permissions' ]:
+        for permission in rolemap_info['permissions']:
 
-            site.manage_permission( permission[ 'name' ]
-                                  , permission.get('roles', [])
-                                  , permission[ 'acquire' ]
-                                  )
+            site.manage_permission(permission['name'], permission.get('roles', []), permission['acquire']
+                                   )
 
     logger.info('Role / permission map imported.')
 
 
-def exportRolemap( context ):
-
+def exportRolemap(context):
     """ Export roles / permission map as an XML file
 
     o 'context' must implement IExportContext.
@@ -136,7 +133,7 @@ def exportRolemap( context ):
     rc = RolemapExportConfigurator(site).__of__(site)
     text = rc.generateXML()
 
-    context.writeDataFile( _FILENAME, text, 'text/xml' )
+    context.writeDataFile(_FILENAME, text, 'text/xml')
 
     logger.info('Role / permission map exported.')
 
@@ -147,16 +144,16 @@ class RolemapExportConfigurator(ExportConfiguratorBase):
     """
     security = ClassSecurityInfo()
 
-    security.declareProtected( ManagePortal, 'listRoles' )
-    def listRoles( self ):
+    security.declareProtected(ManagePortal, 'listRoles')
 
+    def listRoles(self):
         """ List the valid role IDs for our site.
         """
         return self._site.valid_roles()
 
-    security.declareProtected( ManagePortal, 'listPermissions' )
-    def listPermissions( self ):
+    security.declareProtected(ManagePortal, 'listPermissions')
 
+    def listPermissions(self):
         """ List permissions for export.
 
         o Returns a sqeuence of mappings describing locally-modified
@@ -175,20 +172,17 @@ class RolemapExportConfigurator(ExportConfiguratorBase):
         permissions = []
         valid_roles = self.listRoles()
 
-        for perm in self._site.ac_inherited_permissions( 1 ):
+        for perm in self._site.ac_inherited_permissions(1):
 
-            name = perm[ 0 ]
-            p = Permission( name, perm[ 1 ], self._site )
-            roles = p.getRoles( default=[] )
-            acquire = isinstance( roles, list )  # tuple means don't acquire
-            roles = [ r for r in roles if r in valid_roles ]
-            roles.sort()
+            name = perm[0]
+            p = Permission(name, perm[1], self._site)
+            roles = p.getRoles(default=[])
+            acquire = isinstance(roles, list)  # tuple means don't acquire
+            roles = sorted([r for r in roles if r in valid_roles])
 
             if roles or not acquire:
-                permissions.append( { 'name'    : name
-                                    , 'acquire' : acquire
-                                    , 'roles'   : roles
-                                    } )
+                permissions.append({'name': name, 'acquire': acquire, 'roles': roles
+                                    })
 
         return permissions
 
@@ -208,18 +202,18 @@ class RolemapImportConfigurator(ImportConfiguratorBase):
     def _getImportMapping(self):
 
         return {
-          'rolemap':
-            { 'roles':       {CONVERTER: self._convertToUnique, DEFAULT: ()},
-              'permissions': {CONVERTER: self._convertToUnique} },
-          'roles':
-            { 'role':        {KEY: None} },
-          'role':
-            { 'name':        {KEY: None} },
-          'permissions':
-            { 'permission':  {KEY: None, DEFAULT: ()} },
-          'permission':
-            { 'name':        {},
-              'role':        {KEY: 'roles'},
-              'acquire':     {CONVERTER: self._convertToBoolean} } }
+            'rolemap':
+            {'roles': {CONVERTER: self._convertToUnique, DEFAULT: ()},
+             'permissions': {CONVERTER: self._convertToUnique}},
+            'roles':
+            {'role': {KEY: None}},
+            'role':
+            {'name': {KEY: None}},
+            'permissions':
+            {'permission': {KEY: None, DEFAULT: ()}},
+            'permission':
+            {'name': {},
+             'role': {KEY: 'roles'},
+             'acquire': {CONVERTER: self._convertToBoolean}}}
 
 InitializeClass(RolemapImportConfigurator)

--- a/Products/GenericSetup/tests/common.py
+++ b/Products/GenericSetup/tests/common.py
@@ -29,28 +29,28 @@ from Products.GenericSetup.testing import DummyLogger
 
 class DOMComparator:
 
-    def _compareDOM( self, found_text, expected_text, debug=False ):
+    def _compareDOM(self, found_text, expected_text, debug=False):
 
-        found_lines = [ x.strip() for x in found_text.splitlines() ]
-        found_text = '\n'.join( filter( None, found_lines ) )
+        found_lines = [x.strip() for x in found_text.splitlines()]
+        found_text = '\n'.join(filter(None, found_lines))
 
-        expected_lines = [ x.strip() for x in expected_text.splitlines() ]
-        expected_text = '\n'.join( filter( None, expected_lines ) )
+        expected_lines = [x.strip() for x in expected_text.splitlines()]
+        expected_text = '\n'.join(filter(None, expected_lines))
 
         from xml.dom.minidom import parseString
-        found = parseString( found_text )
-        expected = parseString( expected_text )
+        found = parseString(found_text)
+        expected = parseString(expected_text)
         fxml = found.toxml()
         exml = expected.toxml()
 
         if fxml != exml:
 
             if debug:
-                zipped = zip( fxml, exml )
-                diff = [ ( i, zipped[i][0], zipped[i][1] )
-                        for i in range( len( zipped ) )
+                zipped = zip(fxml, exml)
+                diff = [(i, zipped[i][0], zipped[i][1])
+                        for i in range(len(zipped))
                         if zipped[i][0] != zipped[i][1]
-                    ]
+                        ]
                 # Ugly, but it will do.
                 print 'Diff:'
                 print diff
@@ -63,7 +63,7 @@ class DOMComparator:
             print exml
             print
 
-        self.assertEqual( found.toxml(), expected.toxml() )
+        self.assertEqual(found.toxml(), expected.toxml())
 
 
 class BaseRegistryTests(ZopeTestCase, DOMComparator):
@@ -72,29 +72,30 @@ class BaseRegistryTests(ZopeTestCase, DOMComparator):
         self.root = self.app
         newSecurityManager(None, UnrestrictedUser('god', '', ['Manager'], ''))
 
-    def _makeOne( self, *args, **kw ):
+    def _makeOne(self, *args, **kw):
         # Derived classes must implement _getTargetClass
-        return self._getTargetClass()( *args, **kw )
+        return self._getTargetClass()(*args, **kw)
 
 
-def _clearTestDirectory( root_path ):
+def _clearTestDirectory(root_path):
 
-    if os.path.exists( root_path ):
-        shutil.rmtree( root_path )
+    if os.path.exists(root_path):
+        shutil.rmtree(root_path)
 
-def _makeTestFile( filename, root_path, contents ):
 
-    path, filename = os.path.split( filename )
+def _makeTestFile(filename, root_path, contents):
 
-    subdir = os.path.join( root_path, path )
+    path, filename = os.path.split(filename)
 
-    if not os.path.exists( subdir ):
-        os.makedirs( subdir )
+    subdir = os.path.join(root_path, path)
 
-    fqpath = os.path.join( subdir, filename )
+    if not os.path.exists(subdir):
+        os.makedirs(subdir)
 
-    file = open( fqpath, 'wb' )
-    file.write( contents )
+    fqpath = os.path.join(subdir, filename)
+
+    file = open(fqpath, 'wb')
+    file.write(contents)
     file.close()
     return fqpath
 
@@ -111,71 +112,70 @@ class FilesystemTestBase(ZopeTestCase):
         return _makeTestFile(filename, self._PROFILE_PATH, contents)
 
 
-class TarballTester( DOMComparator ):
+class TarballTester(DOMComparator):
 
-    def _verifyTarballContents( self, fileish, toc_list, when=None ):
+    def _verifyTarballContents(self, fileish, toc_list, when=None):
 
-        fileish.seek( 0L )
-        tarfile = TarFile.open( 'foo.tar.gz', fileobj=fileish, mode='r:gz' )
-        items = tarfile.getnames()
-        items.sort()
+        fileish.seek(0L)
+        tarfile = TarFile.open('foo.tar.gz', fileobj=fileish, mode='r:gz')
+        items = sorted(tarfile.getnames())
         toc_list.sort()
 
-        self.assertEqual( len( items ), len( toc_list ) )
-        for i in range( len( items ) ):
-            self.assertEqual( items[ i ].rstrip('/'), toc_list[ i ] )
+        self.assertEqual(len(items), len(toc_list))
+        for i in range(len(items)):
+            self.assertEqual(items[i].rstrip('/'), toc_list[i])
 
         if when is not None:
             for tarinfo in tarfile:
-                self.failIf( tarinfo.mtime < when )
+                self.failIf(tarinfo.mtime < when)
 
-    def _verifyTarballEntry( self, fileish, entry_name, data ):
+    def _verifyTarballEntry(self, fileish, entry_name, data):
 
-        fileish.seek( 0L )
-        tarfile = TarFile.open( 'foo.tar.gz', fileobj=fileish, mode='r:gz' )
-        extract = tarfile.extractfile( entry_name )
+        fileish.seek(0L)
+        tarfile = TarFile.open('foo.tar.gz', fileobj=fileish, mode='r:gz')
+        extract = tarfile.extractfile(entry_name)
         found = extract.read()
-        self.assertEqual( found, data )
+        self.assertEqual(found, data)
 
-    def _verifyTarballEntryXML( self, fileish, entry_name, data ):
+    def _verifyTarballEntryXML(self, fileish, entry_name, data):
 
-        fileish.seek( 0L )
-        tarfile = TarFile.open( 'foo.tar.gz', fileobj=fileish, mode='r:gz' )
-        extract = tarfile.extractfile( entry_name )
+        fileish.seek(0L)
+        tarfile = TarFile.open('foo.tar.gz', fileobj=fileish, mode='r:gz')
+        extract = tarfile.extractfile(entry_name)
         found = extract.read()
-        self._compareDOM( found, data )
+        self._compareDOM(found, data)
 
 
 class DummyExportContext:
 
     implements(IExportContext)
 
-    def __init__( self, site, tool=None ):
+    def __init__(self, site, tool=None):
         self._site = site
         self._tool = tool
         self._wrote = []
         self._notes = []
 
-    def getSite( self ):
+    def getSite(self):
         return self._site
 
-    def getSetupTool( self ):
+    def getSetupTool(self):
         return self._tool
 
     def getLogger(self, name):
         return DummyLogger(name, self._notes)
 
-    def writeDataFile( self, filename, text, content_type, subdir=None ):
+    def writeDataFile(self, filename, text, content_type, subdir=None):
         if subdir is not None:
-            filename = '%s/%s' % ( subdir, filename )
-        self._wrote.append( ( filename, text, content_type ) )
+            filename = '%s/%s' % (subdir, filename)
+        self._wrote.append((filename, text, content_type))
 
 
 class DummyImportContext:
 
     implements(IImportContext)
 
-    def __init__( self, site, purge=True, encoding=None, tool=None ):
+    def __init__(self, site, purge=True, encoding=None, tool=None):
         self._site = site
         self._tool = tool
         self._purge = purge
@@ -183,31 +183,31 @@ class DummyImportContext:
         self._files = {}
         self._notes = []
 
-    def getSite( self ):
+    def getSite(self):
         return self._site
 
-    def getSetupTool( self ):
+    def getSetupTool(self):
         return self._tool
 
-    def getEncoding( self ):
+    def getEncoding(self):
         return self._encoding
 
     def getLogger(self, name):
         return DummyLogger(name, self._notes)
 
-    def readDataFile( self, filename, subdir=None ):
+    def readDataFile(self, filename, subdir=None):
 
         if subdir is not None:
-            filename = '/'.join( (subdir, filename) )
+            filename = '/'.join((subdir, filename))
 
-        return self._files.get( filename )
+        return self._files.get(filename)
 
-    def shouldPurge( self ):
+    def shouldPurge(self):
 
         return self._purge
 
 
-def dummy_handler( context ):
+def dummy_handler(context):
 
     pass
 
@@ -218,4 +218,3 @@ class SecurityRequestTest(ZopeTestCase):
     def setUp(self):
         ZopeTestCase.setUp(self)
         self.root = self.app
-

--- a/Products/GenericSetup/tests/conformance.py
+++ b/Products/GenericSetup/tests/conformance.py
@@ -16,104 +16,116 @@ Derived testcase classes should define '_getTargetClass()', which must
 return the class being tested for conformance.
 """
 
+
 class ConformsToISetupContext:
 
-    def test_ISetupContext_conformance( self ):
+    def test_ISetupContext_conformance(self):
 
         from Products.GenericSetup.interfaces import ISetupContext
         from zope.interface.verify import verifyClass
 
-        verifyClass( ISetupContext, self._getTargetClass() )
+        verifyClass(ISetupContext, self._getTargetClass())
+
 
 class ConformsToIImportContext:
 
-    def test_IImportContext_conformance( self ):
+    def test_IImportContext_conformance(self):
 
         from Products.GenericSetup.interfaces import IImportContext
         from zope.interface.verify import verifyClass
 
-        verifyClass( IImportContext, self._getTargetClass() )
+        verifyClass(IImportContext, self._getTargetClass())
+
 
 class ConformsToIExportContext:
 
-    def test_IExportContext_conformance( self ):
+    def test_IExportContext_conformance(self):
 
         from Products.GenericSetup.interfaces import IExportContext
         from zope.interface.verify import verifyClass
 
-        verifyClass( IExportContext, self._getTargetClass() )
+        verifyClass(IExportContext, self._getTargetClass())
+
 
 class ConformsToIChunkableExportContext:
 
-    def test_IChunkableExportContext_conformance( self ):
+    def test_IChunkableExportContext_conformance(self):
 
         from Products.GenericSetup.interfaces import IChunkableExportContext
         from zope.interface.verify import verifyClass
 
-        verifyClass( IChunkableExportContext, self._getTargetClass() )
+        verifyClass(IChunkableExportContext, self._getTargetClass())
+
 
 class ConformsToIChunkableImportContext:
 
-    def test_IChunkableImportContext_conformance( self ):
+    def test_IChunkableImportContext_conformance(self):
 
         from Products.GenericSetup.interfaces import IChunkableImportContext
         from zope.interface.verify import verifyClass
 
-        verifyClass( IChunkableImportContext, self._getTargetClass() )
+        verifyClass(IChunkableImportContext, self._getTargetClass())
+
 
 class ConformsToIStepRegistry:
 
-    def test_IStepRegistry_conformance( self ):
+    def test_IStepRegistry_conformance(self):
 
         from Products.GenericSetup.interfaces import IStepRegistry
         from zope.interface.verify import verifyClass
 
-        verifyClass( IStepRegistry, self._getTargetClass() )
+        verifyClass(IStepRegistry, self._getTargetClass())
+
 
 class ConformsToIImportStepRegistry:
 
-    def test_IImportStepRegistry_conformance( self ):
+    def test_IImportStepRegistry_conformance(self):
 
         from Products.GenericSetup.interfaces import IImportStepRegistry
         from zope.interface.verify import verifyClass
 
-        verifyClass( IImportStepRegistry, self._getTargetClass() )
+        verifyClass(IImportStepRegistry, self._getTargetClass())
+
 
 class ConformsToIExportStepRegistry:
 
-    def test_IExportStepRegistry_conformance( self ):
+    def test_IExportStepRegistry_conformance(self):
 
         from Products.GenericSetup.interfaces import IExportStepRegistry
         from zope.interface.verify import verifyClass
 
-        verifyClass( IExportStepRegistry, self._getTargetClass() )
+        verifyClass(IExportStepRegistry, self._getTargetClass())
+
 
 class ConformsToIToolsetRegistry:
 
-    def test_IToolsetRegistry_conformance( self ):
+    def test_IToolsetRegistry_conformance(self):
 
         from Products.GenericSetup.interfaces import IToolsetRegistry
         from zope.interface.verify import verifyClass
 
-        verifyClass( IToolsetRegistry, self._getTargetClass() )
+        verifyClass(IToolsetRegistry, self._getTargetClass())
+
 
 class ConformsToIProfileRegistry:
 
-    def test_IProfileRegistry_conformance( self ):
+    def test_IProfileRegistry_conformance(self):
 
         from Products.GenericSetup.interfaces import IProfileRegistry
         from zope.interface.verify import verifyClass
 
-        verifyClass( IProfileRegistry, self._getTargetClass() )
+        verifyClass(IProfileRegistry, self._getTargetClass())
+
 
 class ConformsToISetupTool:
 
-    def test_ISetupTool_conformance( self ):
+    def test_ISetupTool_conformance(self):
 
         from Products.GenericSetup.interfaces import ISetupTool
         from zope.interface.verify import verifyClass
 
-        verifyClass( ISetupTool, self._getTargetClass() )
+        verifyClass(ISetupTool, self._getTargetClass())
+
 
 class ConformsToIContentFactory:
 
@@ -122,7 +134,8 @@ class ConformsToIContentFactory:
         from Products.GenericSetup.interfaces import IContentFactory
         from zope.interface.verify import verifyClass
 
-        verifyClass( IContentFactory, self._getTargetClass() )
+        verifyClass(IContentFactory, self._getTargetClass())
+
 
 class ConformsToIContentFactoryName:
 
@@ -131,7 +144,8 @@ class ConformsToIContentFactoryName:
         from Products.GenericSetup.interfaces import IContentFactoryName
         from zope.interface.verify import verifyClass
 
-        verifyClass( IContentFactoryName, self._getTargetClass() )
+        verifyClass(IContentFactoryName, self._getTargetClass())
+
 
 class ConformsToIFilesystemExporter:
 
@@ -140,7 +154,8 @@ class ConformsToIFilesystemExporter:
         from Products.GenericSetup.interfaces import IFilesystemExporter
         from zope.interface.verify import verifyClass
 
-        verifyClass( IFilesystemExporter, self._getTargetClass() )
+        verifyClass(IFilesystemExporter, self._getTargetClass())
+
 
 class ConformsToIFilesystemImporter:
 
@@ -149,7 +164,8 @@ class ConformsToIFilesystemImporter:
         from Products.GenericSetup.interfaces import IFilesystemImporter
         from zope.interface.verify import verifyClass
 
-        verifyClass( IFilesystemImporter, self._getTargetClass() )
+        verifyClass(IFilesystemImporter, self._getTargetClass())
+
 
 class ConformsToIINIAware:
 
@@ -158,7 +174,8 @@ class ConformsToIINIAware:
         from Products.GenericSetup.interfaces import IINIAware
         from zope.interface.verify import verifyClass
 
-        verifyClass (IINIAware, self._getTargetClass() )
+        verifyClass(IINIAware, self._getTargetClass())
+
 
 class ConformsToICSVAware:
 
@@ -167,7 +184,8 @@ class ConformsToICSVAware:
         from Products.GenericSetup.interfaces import ICSVAware
         from zope.interface.verify import verifyClass
 
-        verifyClass( ICSVAware, self._getTargetClass() )
+        verifyClass(ICSVAware, self._getTargetClass())
+
 
 class ConformsToIDAVAware:
 
@@ -176,4 +194,4 @@ class ConformsToIDAVAware:
         from Products.GenericSetup.interfaces import IDAVAware
         from zope.interface.verify import verifyClass
 
-        verifyClass( IDAVAware, self._getTargetClass() )
+        verifyClass(IDAVAware, self._getTargetClass())

--- a/Products/GenericSetup/tests/faux_objects.py
+++ b/Products/GenericSetup/tests/faux_objects.py
@@ -21,6 +21,7 @@ from zope.interface import implements
 class TestSimpleItem(SimpleItem):
     pass
 
+
 class TestSimpleItemWithProperties(SimpleItem, PropertyManager):
     pass
 
@@ -30,6 +31,8 @@ four,five,six
 """
 
 from Products.GenericSetup.interfaces import ICSVAware
+
+
 class TestCSVAware(SimpleItem):
     implements(ICSVAware)
     _was_put = None
@@ -48,6 +51,8 @@ description = %s
 """
 
 from Products.GenericSetup.interfaces import IINIAware
+
+
 class TestINIAware(SimpleItem):
     implements(IINIAware)
     _was_put = None
@@ -68,6 +73,8 @@ Description: %s
 """
 
 from Products.GenericSetup.interfaces import IDAVAware
+
+
 class TestDAVAware(SimpleItem):
     implements(IDAVAware)
     _was_put = None

--- a/Products/GenericSetup/tests/test_components.py
+++ b/Products/GenericSetup/tests/test_components.py
@@ -55,6 +55,7 @@ except ImportError:
     # Avoid generating a spurious dependency
     PersistentComponents = None
 
+
 def createComponentRegistry(context):
     enableSite(context, iface=IObjectManagerSite)
 
@@ -66,17 +67,20 @@ def createComponentRegistry(context):
     components._components = components
     context.setSiteManager(components)
 
+
 class IDummyInterface(Interface):
     """A dummy interface."""
 
     def verify():
         """Returns True."""
 
+
 class IDummyInterface2(Interface):
     """A second dummy interface."""
 
     def verify():
         """Returns True."""
+
 
 class DummyUtility(object):
     """A dummy utility."""
@@ -86,17 +90,20 @@ class DummyUtility(object):
     def verify(self):
         return True
 
+
 class IAnotherDummy(Interface):
     """A third dummy interface."""
 
     def inc():
         """Increments handle count"""
 
+
 class IAnotherDummy2(Interface):
     """A second dummy interface."""
 
     def verify():
         """Returns True."""
+
 
 class DummyObject(object):
     """A dummy object to pass to the handler."""
@@ -107,6 +114,7 @@ class DummyObject(object):
 
     def inc(self):
         self.handled += 1
+
 
 class DummyAdapter(object):
     """A dummy adapter."""
@@ -119,10 +127,12 @@ class DummyAdapter(object):
     def verify(self):
         return True
 
+
 def dummy_handler(context):
     """A dummy event handler."""
-    
+
     context.inc()
+
 
 class DummyTool(SimpleItem):
     """A dummy tool."""
@@ -133,6 +143,7 @@ class DummyTool(SimpleItem):
     security = ClassSecurityInfo()
 
     security.declarePublic('verify')
+
     def verify(self):
         return True
 
@@ -148,6 +159,7 @@ class DummyTool2(SimpleItem):
     security = ClassSecurityInfo()
 
     security.declarePublic('verify')
+
     def verify(self):
         return True
 
@@ -258,16 +270,16 @@ class ComponentRegistryXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
         util.__name__ = name
         util.__parent__ = aq_base(obj)
         obj._setObject(name, aq_base(util),
-            set_owner=False, suppress_events=True)
+                       set_owner=False, suppress_events=True)
         obj.registerUtility(aq_base(obj[name]), IDummyInterface)
 
         util = DummyUtility()
         name = ('Products.GenericSetup.tests.test_components.'
-                    'IDummyInterface2-foo')
+                'IDummyInterface2-foo')
         util.__name__ = name
         util.__parent__ = aq_base(obj)
         obj._setObject(name, aq_base(util),
-            set_owner=False, suppress_events=True)
+                       set_owner=False, suppress_events=True)
         obj.registerUtility(aq_base(obj[name]), IDummyInterface2, name=u'foo')
 
         tool = aq_base(obj.aq_parent['dummy_tool'])
@@ -287,7 +299,7 @@ class ComponentRegistryXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
 
         dummy = DummyObject()
         results = [adap.verify() for adap in
-                        subscribers([dummy], IAnotherDummy2)]
+                   subscribers([dummy], IAnotherDummy2)]
         self.assertEquals(results, [True])
 
         dummy = DummyObject()
@@ -299,7 +311,7 @@ class ComponentRegistryXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
         self.failUnless(util.verify())
         self.failUnless(util.__parent__ == obj)
         name = ('Products.GenericSetup.tests.test_components.'
-                    'IDummyInterface2-foo')
+                'IDummyInterface2-foo')
         self.assertEquals(util.__name__, name)
         self.failUnless(name in obj.objectIds())
 
@@ -407,7 +419,7 @@ class ComponentRegistryXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
 
         dummy = DummyObject()
         results = [adap.verify() for adap in
-                        subscribers([dummy], IAnotherDummy2)]
+                   subscribers([dummy], IAnotherDummy2)]
         self.assertEquals(results, [])
 
         dummy = DummyObject()
@@ -416,7 +428,7 @@ class ComponentRegistryXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
 
         util = queryUtility(IDummyInterface2, name=u'foo')
         name = ('Products.GenericSetup.tests.test_components.'
-                    'IDummyInterface2-foo')
+                'IDummyInterface2-foo')
         self.failUnless(util is None)
         self.failIf(name in obj.objectIds())
 
@@ -460,11 +472,11 @@ if PersistentComponents is not None:
     def test_suite():
         # reimport to make sure tests are run from Products
         from Products.GenericSetup.tests.test_components \
-                import ComponentRegistryXMLAdapterTests
+            import ComponentRegistryXMLAdapterTests
 
         return unittest.TestSuite((
             unittest.makeSuite(ComponentRegistryXMLAdapterTests),
-            ))
+        ))
 else:
     def test_suite():
         return unittest.TestSuite()

--- a/Products/GenericSetup/tests/test_content.py
+++ b/Products/GenericSetup/tests/test_content.py
@@ -930,8 +930,8 @@ def _makeFolder(id):
     from zope.interface import providedBy
 
     folder = Folder(id)
-    directlyProvides(folder, providedBy(folder)
-                     + IObjectManager + IPropertyManager)
+    directlyProvides(folder, providedBy(folder) +
+                     IObjectManager + IPropertyManager)
 
     return folder
 

--- a/Products/GenericSetup/tests/test_content.py
+++ b/Products/GenericSetup/tests/test_content.py
@@ -104,7 +104,7 @@ class SimpleINIAwareTests(unittest.TestCase, ConformsToIINIAware):
         adapter = self._getTargetClass()(context)
         adapter.put_ini('''\
 [DEFAULT]
-int_prop = 13 
+int_prop = 13
 \nfloat_prop = 2.818
 \ndate_prop = %s''' % DATESTR2)
         self.assertEqual(len(context.propertyIds()), 3)
@@ -148,15 +148,15 @@ class FolderishExporterImporterTests(unittest.TestCase):
         from Products.GenericSetup.interfaces import IDAVAware
 
         from Products.GenericSetup.content import \
-             SimpleINIAware
+            SimpleINIAware
         from Products.GenericSetup.content import \
-             FolderishExporterImporter
+            FolderishExporterImporter
         from Products.GenericSetup.content import \
-             CSVAwareFileAdapter
+            CSVAwareFileAdapter
         from Products.GenericSetup.content import \
-             INIAwareFileAdapter
+            INIAwareFileAdapter
         from Products.GenericSetup.content import \
-             DAVAwareFileAdapter
+            DAVAwareFileAdapter
 
         sm = getSiteManager()
 
@@ -204,7 +204,6 @@ class FolderishExporterImporterTests(unittest.TestCase):
                            (IDAVAware,),
                            IFilesystemImporter,
                            )
-
 
     def test_export_empty_site(self):
         from Products.GenericSetup.tests.common import DummyExportContext
@@ -333,7 +332,7 @@ class FolderishExporterImporterTests(unittest.TestCase):
             self.assertEqual(objects[index][0], ITEM_IDS[index])
             self.assertEqual(objects[index][1], dotted)
 
-            filename, text, content_type = context._wrote[index+2]
+            filename, text, content_type = context._wrote[index + 2]
             self.assertEqual(filename, 'structure/%s.ini' % ITEM_IDS[index])
             object = site._getOb(ITEM_IDS[index])
             self.assertEqual(text.strip(),
@@ -370,7 +369,7 @@ class FolderishExporterImporterTests(unittest.TestCase):
         exporter = self._getExporter()
         exporter(context)
 
-        self.assertEqual(len(context._wrote), 2 + (2 *len(FOLDER_IDS)))
+        self.assertEqual(len(context._wrote), 2 + (2 * len(FOLDER_IDS)))
         filename, text, content_type = context._wrote[0]
         self.assertEqual(filename, 'structure/.objects')
         self.assertEqual(content_type, 'text/comma-separated-values')
@@ -499,14 +498,14 @@ class FolderishExporterImporterTests(unittest.TestCase):
         for id in FOLDER_IDS:
             context._files['structure/%s/.objects' % id] = ''
             context._files['structure/%s/.properties' % id] = (
-                _PROPERTIES_TEMPLATE % id )
+                _PROPERTIES_TEMPLATE % id)
 
         _ROOT_OBJECTS = '\n'.join(['%s,%s' % (id, dotted)
-                                        for id in FOLDER_IDS])
+                                   for id in FOLDER_IDS])
 
         context._files['structure/.objects'] = _ROOT_OBJECTS
         context._files['structure/.properties'] = (
-                _PROPERTIES_TEMPLATE % 'Test Site')
+            _PROPERTIES_TEMPLATE % 'Test Site')
 
         importer = self._getImporter()
         importer(context)
@@ -528,13 +527,13 @@ class FolderishExporterImporterTests(unittest.TestCase):
         context = DummyImportContext(site)
         # We want to add 'baz' to 'foo', without losing 'bar'
         context._files['structure/.objects'] = '\n'.join(
-                            ['%s,%s' % (x, dotted) for x in ITEM_IDS])
+            ['%s,%s' % (x, dotted) for x in ITEM_IDS])
         for index in range(len(ITEM_IDS)):
             id = ITEM_IDS[index]
             context._files[
-                    'structure/%s.ini' % id] = KNOWN_INI % ('Title: %s' % id,
-                                                            'xyzzy',
-                                                           )
+                'structure/%s.ini' % id] = KNOWN_INI % ('Title: %s' % id,
+                                                        'xyzzy',
+                                                        )
         importer = self._getImporter()
         importer(context)
 
@@ -555,7 +554,7 @@ class FolderishExporterImporterTests(unittest.TestCase):
         context = DummyImportContext(site)
         # We want to add 'baz' to 'foo', without losing 'bar'
         context._files['structure/.objects'] = '\n'.join(
-                            ['%s,%s' % (x, dotted) for x in ('no_adapter',)])
+            ['%s,%s' % (x, dotted) for x in ('no_adapter',)])
         importer = self._getImporter()
         importer(context)
 
@@ -582,9 +581,9 @@ class FolderishExporterImporterTests(unittest.TestCase):
         for index in range(len(ITEM_IDS)):
             id = ITEM_IDS[index]
             context._files[
-                    'structure/%s.ini' % id] = KNOWN_INI % ('Title: %s' % id,
-                                                            'xyzzy',
-                                                           )
+                'structure/%s.ini' % id] = KNOWN_INI % ('Title: %s' % id,
+                                                        'xyzzy',
+                                                        )
         importer = self._getImporter()
         importer(context)
 
@@ -604,13 +603,13 @@ class FolderishExporterImporterTests(unittest.TestCase):
         context = DummyImportContext(site)
         # We want to add 'baz' to 'foo', without losing 'bar'
         context._files['structure/.objects'] = '\n'.join(
-                                ['%s,Unknown Type' % x for x in ITEM_IDS])
+            ['%s,Unknown Type' % x for x in ITEM_IDS])
         for index in range(len(ITEM_IDS)):
             id = ITEM_IDS[index]
             context._files[
-                    'structure/%s.ini' % id] = KNOWN_INI % ('Title: %s' % id,
-                                                            'xyzzy',
-                                                           )
+                'structure/%s.ini' % id] = KNOWN_INI % ('Title: %s' % id,
+                                                        'xyzzy',
+                                                        )
 
         importer = self._getImporter()
         importer(context)
@@ -698,10 +697,10 @@ class FolderishExporterImporterTests(unittest.TestCase):
         context = DummyImportContext(site)
         # We want to add 'baz' to 'foo', without losing 'bar'
         context._files['structure/.objects'
-                      ] = 'foo,%s' % _getDottedName(foo.__class__)
+                       ] = 'foo,%s' % _getDottedName(foo.__class__)
         context._files['structure/.preserve'] = '*'
         context._files['structure/foo/.objects'
-                      ] = 'baz,%s' % _getDottedName(bar.__class__)
+                       ] = 'baz,%s' % _getDottedName(bar.__class__)
         context._files['structure/foo/.preserve'] = '*'
         context._files['structure/foo/baz/.objects'] = ''
 
@@ -732,18 +731,18 @@ class Test_globpattern(unittest.TestCase):
 
     def test_simple(self):
         self._checkResults('b*', self.NAMELIST,
-                            [x for x in self.NAMELIST if x.startswith('b')])
+                           [x for x in self.NAMELIST if x.startswith('b')])
 
     def test_multiple(self):
         self._checkResults('b*\n*x', self.NAMELIST,
-                            [x for x in self.NAMELIST
-                                if x.startswith('b') or x.endswith('x')])
+                           [x for x in self.NAMELIST
+                            if x.startswith('b') or x.endswith('x')])
 
 
 class CSVAwareFileAdapterTests(unittest.TestCase,
                                ConformsToIFilesystemExporter,
                                ConformsToIFilesystemImporter,
-                              ):
+                               ):
 
     def _getTargetClass(self):
         from Products.GenericSetup.content import CSVAwareFileAdapter
@@ -794,6 +793,7 @@ Title = %s
 Description = This is a test
 """
 
+
 class INIAwareFileAdapterTests(unittest.TestCase,
                                ConformsToIFilesystemExporter,
                                ConformsToIFilesystemImporter,
@@ -827,7 +827,7 @@ class INIAwareFileAdapterTests(unittest.TestCase,
         adapter = self._makeOne(ini_file)
         context = DummyImportContext(None)
         context._files['subpath/to/ini_file.html.ini'] = (
-                        KNOWN_INI % ('Title: ini_file', 'abc'))
+            KNOWN_INI % ('Title: ini_file', 'abc'))
 
         adapter.import_(context, 'subpath/to')
         text = ini_file._was_put
@@ -883,6 +883,7 @@ def _makePropertied(id):
 
     return propertied
 
+
 def _makeCSVAware(id, csv=None):
     from Products.GenericSetup.tests.faux_objects import TestCSVAware
 
@@ -930,7 +931,7 @@ def _makeFolder(id):
 
     folder = Folder(id)
     directlyProvides(folder, providedBy(folder)
-                             + IObjectManager + IPropertyManager)
+                     + IObjectManager + IPropertyManager)
 
     return folder
 
@@ -939,6 +940,7 @@ def _parseCSV(text):
     from csv import reader
     from StringIO import StringIO
     return [x for x in reader(StringIO(text))]
+
 
 def _parseINI(text):
     from ConfigParser import ConfigParser

--- a/Products/GenericSetup/tests/test_context.py
+++ b/Products/GenericSetup/tests/test_context.py
@@ -1,4 +1,4 @@
-#encoding: utf-8
+# encoding: utf-8
 ##############################################################################
 #
 # Copyright (c) 2004 Zope Foundation and Contributors.
@@ -38,82 +38,81 @@ from conformance import ConformsToIChunkableExportContext
 from conformance import ConformsToIChunkableImportContext
 
 
-class DummySite( Folder ):
+class DummySite(Folder):
 
     pass
 
-class DummyTool( Folder ):
+
+class DummyTool(Folder):
 
     pass
+
 
 class DummyPdataStreamIterator:
-    
+
     pass
 
 
-class DirectoryImportContextTests( FilesystemTestBase
-                                 , ConformsToISetupContext
-                                 , ConformsToIImportContext
-                                 , ConformsToIChunkableImportContext
-                                 ):
+class DirectoryImportContextTests(FilesystemTestBase, ConformsToISetupContext, ConformsToIImportContext, ConformsToIChunkableImportContext
+                                  ):
 
     _PROFILE_PATH = '/tmp/ICTTexts'
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.context import DirectoryImportContext
         return DirectoryImportContext
 
-    def test_getLogger( self ):
+    def test_getLogger(self):
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
+        self.assertEqual(len(ctx.listNotes()), 0)
 
         logger = ctx.getLogger('foo')
         logger.info('bar')
 
-        self.assertEqual( len( ctx.listNotes() ), 1 )
+        self.assertEqual(len(ctx.listNotes()), 1)
         level, component, message = ctx.listNotes()[0]
-        self.assertEqual( level, logging.INFO )
-        self.assertEqual( component, 'foo' )
-        self.assertEqual( message, 'bar' )
+        self.assertEqual(level, logging.INFO)
+        self.assertEqual(component, 'foo')
+        self.assertEqual(message, 'bar')
 
         ctx.clearNotes()
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
-    def test_readDataFile_nonesuch( self ):
+    def test_readDataFile_nonesuch(self):
 
         FILENAME = 'nonesuch.txt'
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.readDataFile( FILENAME ), None )
+        self.assertEqual(ctx.readDataFile(FILENAME), None)
 
-    def test_readDataFile_simple( self ):
+    def test_readDataFile_simple(self):
 
         from string import printable
 
         FILENAME = 'simple.txt'
-        self._makeFile( FILENAME, printable )
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.readDataFile( FILENAME ), printable )
+        self.assertEqual(ctx.readDataFile(FILENAME), printable)
 
-    def test_readDataFile_subdir( self ):
+    def test_readDataFile_subdir(self):
 
         from string import printable
 
         FILENAME = 'subdir/nested.txt'
-        self._makeFile( FILENAME, printable )
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.readDataFile( FILENAME ), printable )
+        self.assertEqual(ctx.readDataFile(FILENAME), printable)
 
     def test_getLastModified_nonesuch(self):
         FILENAME = 'nonesuch.txt'
@@ -166,291 +165,287 @@ class DirectoryImportContextTests( FilesystemTestBase
         self.assertTrue(isinstance(lm, DateTime))
         self.assertEqual(lm, DateTime(WHEN))
 
-    def test_isDirectory_nonesuch( self ):
+    def test_isDirectory_nonesuch(self):
 
         FILENAME = 'nonesuch.txt'
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.isDirectory( FILENAME ), None )
+        self.assertEqual(ctx.isDirectory(FILENAME), None)
 
-    def test_isDirectory_simple( self ):
+    def test_isDirectory_simple(self):
 
         from string import printable
 
         FILENAME = 'simple.txt'
-        self._makeFile( FILENAME, printable )
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.isDirectory( FILENAME ), False )
+        self.assertEqual(ctx.isDirectory(FILENAME), False)
 
-    def test_isDirectory_nested( self ):
+    def test_isDirectory_nested(self):
 
         from string import printable
 
         SUBDIR = 'subdir'
-        FILENAME = os.path.join( SUBDIR, 'nested.txt' )
-        self._makeFile( FILENAME, printable )
+        FILENAME = os.path.join(SUBDIR, 'nested.txt')
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.isDirectory( FILENAME ), False )
+        self.assertEqual(ctx.isDirectory(FILENAME), False)
 
-    def test_isDirectory_directory( self ):
+    def test_isDirectory_directory(self):
 
         from string import printable
 
         SUBDIR = 'subdir'
-        FILENAME = os.path.join( SUBDIR, 'nested.txt' )
-        self._makeFile( FILENAME, printable )
+        FILENAME = os.path.join(SUBDIR, 'nested.txt')
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.isDirectory( SUBDIR ), True )
+        self.assertEqual(ctx.isDirectory(SUBDIR), True)
 
-    def test_listDirectory_nonesuch( self ):
+    def test_listDirectory_nonesuch(self):
 
         FILENAME = 'nonesuch.txt'
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.listDirectory( FILENAME ), None )
+        self.assertEqual(ctx.listDirectory(FILENAME), None)
 
-    def test_listDirectory_root( self ):
+    def test_listDirectory_root(self):
 
         from string import printable
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
         FILENAME = 'simple.txt'
-        self._makeFile( FILENAME, printable )
+        self._makeFile(FILENAME, printable)
 
-        self.assertEqual( len( ctx.listDirectory( None ) ), 1 )
-        self.failUnless( FILENAME in ctx.listDirectory( None ) )
+        self.assertEqual(len(ctx.listDirectory(None)), 1)
+        self.failUnless(FILENAME in ctx.listDirectory(None))
 
-    def test_listDirectory_simple( self ):
+    def test_listDirectory_simple(self):
 
         from string import printable
 
         FILENAME = 'simple.txt'
-        self._makeFile( FILENAME, printable )
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.listDirectory( FILENAME ), None )
+        self.assertEqual(ctx.listDirectory(FILENAME), None)
 
-    def test_listDirectory_nested( self ):
+    def test_listDirectory_nested(self):
 
         from string import printable
 
         SUBDIR = 'subdir'
-        FILENAME = os.path.join( SUBDIR, 'nested.txt' )
-        self._makeFile( FILENAME, printable )
+        FILENAME = os.path.join(SUBDIR, 'nested.txt')
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.listDirectory( FILENAME ), None )
+        self.assertEqual(ctx.listDirectory(FILENAME), None)
 
-    def test_listDirectory_single( self ):
+    def test_listDirectory_single(self):
 
         from string import printable
 
         SUBDIR = 'subdir'
-        FILENAME = os.path.join( SUBDIR, 'nested.txt' )
-        self._makeFile( FILENAME, printable )
+        FILENAME = os.path.join(SUBDIR, 'nested.txt')
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        names = ctx.listDirectory( SUBDIR )
-        self.assertEqual( len( names ), 1 )
-        self.failUnless( 'nested.txt' in names )
+        names = ctx.listDirectory(SUBDIR)
+        self.assertEqual(len(names), 1)
+        self.failUnless('nested.txt' in names)
 
-    def test_listDirectory_multiple( self ):
+    def test_listDirectory_multiple(self):
 
         from string import printable
         SUBDIR = 'subdir'
-        FILENAME = os.path.join( SUBDIR, 'nested.txt' )
-        self._makeFile( FILENAME, printable )
-        self._makeFile( os.path.join( SUBDIR, 'another.txt' ), 'ABC' )
+        FILENAME = os.path.join(SUBDIR, 'nested.txt')
+        self._makeFile(FILENAME, printable)
+        self._makeFile(os.path.join(SUBDIR, 'another.txt'), 'ABC')
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        names = ctx.listDirectory( SUBDIR )
-        self.assertEqual( len( names ), 2 )
-        self.failUnless( 'nested.txt' in names )
-        self.failUnless( 'another.txt' in names )
+        names = ctx.listDirectory(SUBDIR)
+        self.assertEqual(len(names), 2)
+        self.failUnless('nested.txt' in names)
+        self.failUnless('another.txt' in names)
 
-    def test_listDirectory_skip_implicit( self ):
+    def test_listDirectory_skip_implicit(self):
 
         from string import printable
         SUBDIR = 'subdir'
-        FILENAME = os.path.join( SUBDIR, 'nested.txt' )
-        self._makeFile( FILENAME, printable )
-        self._makeFile( os.path.join( SUBDIR, 'another.txt' ), 'ABC' )
-        self._makeFile( os.path.join( SUBDIR, 'another.txt~' ), '123' )
-        self._makeFile( os.path.join( SUBDIR, 'CVS/skip.txt' ), 'DEF' )
-        self._makeFile( os.path.join( SUBDIR, '.svn/skip.txt' ), 'GHI' )
+        FILENAME = os.path.join(SUBDIR, 'nested.txt')
+        self._makeFile(FILENAME, printable)
+        self._makeFile(os.path.join(SUBDIR, 'another.txt'), 'ABC')
+        self._makeFile(os.path.join(SUBDIR, 'another.txt~'), '123')
+        self._makeFile(os.path.join(SUBDIR, 'CVS/skip.txt'), 'DEF')
+        self._makeFile(os.path.join(SUBDIR, '.svn/skip.txt'), 'GHI')
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        names = ctx.listDirectory( SUBDIR )
-        self.assertEqual( len( names ), 2 )
-        self.failUnless( 'nested.txt' in names )
-        self.failUnless( 'another.txt' in names )
-        self.failIf( 'another.txt~' in names )
-        self.failIf( 'CVS' in names )
-        self.failIf( '.svn' in names )
+        names = ctx.listDirectory(SUBDIR)
+        self.assertEqual(len(names), 2)
+        self.failUnless('nested.txt' in names)
+        self.failUnless('another.txt' in names)
+        self.failIf('another.txt~' in names)
+        self.failIf('CVS' in names)
+        self.failIf('.svn' in names)
 
-    def test_listDirectory_skip_explicit( self ):
+    def test_listDirectory_skip_explicit(self):
 
         from string import printable
         SUBDIR = 'subdir'
-        FILENAME = os.path.join( SUBDIR, 'nested.txt' )
-        self._makeFile( FILENAME, printable )
-        self._makeFile( os.path.join( SUBDIR, 'another.txt' ), 'ABC' )
-        self._makeFile( os.path.join( SUBDIR, 'another.bak' ), '123' )
-        self._makeFile( os.path.join( SUBDIR, 'CVS/skip.txt' ), 'DEF' )
-        self._makeFile( os.path.join( SUBDIR, '.svn/skip.txt' ), 'GHI' )
+        FILENAME = os.path.join(SUBDIR, 'nested.txt')
+        self._makeFile(FILENAME, printable)
+        self._makeFile(os.path.join(SUBDIR, 'another.txt'), 'ABC')
+        self._makeFile(os.path.join(SUBDIR, 'another.bak'), '123')
+        self._makeFile(os.path.join(SUBDIR, 'CVS/skip.txt'), 'DEF')
+        self._makeFile(os.path.join(SUBDIR, '.svn/skip.txt'), 'GHI')
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
         names = ctx.listDirectory(SUBDIR, skip=('nested.txt',),
                                   skip_suffixes=('.bak',))
-        self.assertEqual( len( names ), 3 )
-        self.failIf( 'nested.txt' in names )
-        self.failIf( 'nested.bak' in names )
-        self.failUnless( 'another.txt' in names )
-        self.failUnless( 'CVS' in names )
-        self.failUnless( '.svn' in names )
+        self.assertEqual(len(names), 3)
+        self.failIf('nested.txt' in names)
+        self.failIf('nested.bak' in names)
+        self.failUnless('another.txt' in names)
+        self.failUnless('CVS' in names)
+        self.failUnless('.svn' in names)
 
 
-class DirectoryExportContextTests( FilesystemTestBase
-                                 , ConformsToISetupContext
-                                 , ConformsToIExportContext
-                                 , ConformsToIChunkableExportContext
-                                 ):
+class DirectoryExportContextTests(FilesystemTestBase, ConformsToISetupContext, ConformsToIExportContext, ConformsToIChunkableExportContext
+                                  ):
 
     _PROFILE_PATH = '/tmp/ECTTexts'
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.context import DirectoryExportContext
         return DirectoryExportContext
 
-    def test_getLogger( self ):
+    def test_getLogger(self):
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
+        self.assertEqual(len(ctx.listNotes()), 0)
 
         logger = ctx.getLogger('foo')
         logger.info('bar')
 
-        self.assertEqual( len( ctx.listNotes() ), 1 )
+        self.assertEqual(len(ctx.listNotes()), 1)
         level, component, message = ctx.listNotes()[0]
-        self.assertEqual( level, logging.INFO )
-        self.assertEqual( component, 'foo' )
-        self.assertEqual( message, 'bar' )
+        self.assertEqual(level, logging.INFO)
+        self.assertEqual(component, 'foo')
+        self.assertEqual(message, 'bar')
 
         ctx.clearNotes()
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
-    def test_writeDataFile_simple( self ):
+    def test_writeDataFile_simple(self):
 
         from string import printable, digits
         FILENAME = 'simple.txt'
-        fqname = self._makeFile( FILENAME, printable )
+        fqname = self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        ctx.writeDataFile( FILENAME, digits, 'text/plain' )
+        ctx.writeDataFile(FILENAME, digits, 'text/plain')
 
-        self.assertEqual( open( fqname, 'rb' ).read(), digits )
+        self.assertEqual(open(fqname, 'rb').read(), digits)
 
-    def test_writeDataFile_unicode( self ):
+    def test_writeDataFile_unicode(self):
 
         from string import printable
         text = u'Kein Weltraum links vom Gerät'
         FILENAME = 'unicode.txt'
-        self._makeFile( FILENAME, printable )
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
         self.assertRaises(ValueError, ctx.writeDataFile,
-                          FILENAME, text, 'text/plain' )
+                          FILENAME, text, 'text/plain')
         text = u'No umlauts'
         self.assertRaises(ValueError, ctx.writeDataFile,
-                          FILENAME, text, 'text/plain' )
+                          FILENAME, text, 'text/plain')
 
-    def test_writeDataFile_new_subdir( self ):
+    def test_writeDataFile_new_subdir(self):
         from string import digits
 
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
-        fqname = os.path.join( self._PROFILE_PATH, SUBDIR, FILENAME )
+        fqname = os.path.join(self._PROFILE_PATH, SUBDIR, FILENAME)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        ctx.writeDataFile( FILENAME, digits, 'text/plain', SUBDIR )
+        ctx.writeDataFile(FILENAME, digits, 'text/plain', SUBDIR)
 
-        self.assertEqual( open( fqname, 'rb' ).read(), digits )
+        self.assertEqual(open(fqname, 'rb').read(), digits)
 
-    def test_writeDataFile_overwrite( self ):
+    def test_writeDataFile_overwrite(self):
 
         from string import printable, digits
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
-        fqname = self._makeFile( os.path.join( SUBDIR, FILENAME )
-                               , printable )
+        fqname = self._makeFile(os.path.join(SUBDIR, FILENAME), printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        ctx.writeDataFile( FILENAME, digits, 'text/plain', SUBDIR )
+        ctx.writeDataFile(FILENAME, digits, 'text/plain', SUBDIR)
 
-        self.assertEqual( open( fqname, 'rb' ).read(), digits )
+        self.assertEqual(open(fqname, 'rb').read(), digits)
 
-    def test_writeDataFile_existing_subdir( self ):
+    def test_writeDataFile_existing_subdir(self):
 
         from string import printable, digits
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
-        self._makeFile( os.path.join( SUBDIR, 'another.txt' ), printable )
-        fqname = os.path.join( self._PROFILE_PATH, SUBDIR, FILENAME )
+        self._makeFile(os.path.join(SUBDIR, 'another.txt'), printable)
+        fqname = os.path.join(self._PROFILE_PATH, SUBDIR, FILENAME)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        ctx.writeDataFile( FILENAME, digits, 'text/plain', SUBDIR )
+        ctx.writeDataFile(FILENAME, digits, 'text/plain', SUBDIR)
 
-        self.assertEqual( open( fqname, 'rb' ).read(), digits )
+        self.assertEqual(open(fqname, 'rb').read(), digits)
 
 
 class TarballImportContextTests(ZopeTestCase, ConformsToISetupContext,
                                 ConformsToIImportContext):
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.context import TarballImportContext
         return TarballImportContext
 
-    def _makeOne( self, file_dict={}, mod_time=None, *args, **kw ):
+    def _makeOne(self, file_dict={}, mod_time=None, *args, **kw):
 
         archive_stream = StringIO()
         archive = TarFile.open('test.tar.gz', 'w:gz', archive_stream)
@@ -475,7 +470,8 @@ class TarballImportContextTests(ZopeTestCase, ConformsToISetupContext,
                 parents.pop()
             _addOneMember(filename, data, modtime)
 
-        file_items = file_dict.items() or [('dummy', '')] # empty archive barfs
+        file_items = file_dict.items() or [
+            ('dummy', '')]  # empty archive barfs
 
         if mod_time is None:
             mod_time = time.time()
@@ -487,83 +483,82 @@ class TarballImportContextTests(ZopeTestCase, ConformsToISetupContext,
         bits = archive_stream.getvalue()
 
         site = DummySite('site').__of__(self.app)
-        site._setObject( 'setup_tool', Folder( 'setup_tool' ) )
-        tool = site._getOb( 'setup_tool' )
+        site._setObject('setup_tool', Folder('setup_tool'))
+        tool = site._getOb('setup_tool')
 
-        ctx = self._getTargetClass()( tool, bits, *args, **kw )
+        ctx = self._getTargetClass()(tool, bits, *args, **kw)
 
-        return site, tool, ctx.__of__( tool )
+        return site, tool, ctx.__of__(tool)
 
-    def test_getLogger( self ):
+    def test_getLogger(self):
 
         site, tool, ctx = self._makeOne()
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
         logger = ctx.getLogger('foo')
         logger.info('bar')
 
-        self.assertEqual( len( ctx.listNotes() ), 1 )
+        self.assertEqual(len(ctx.listNotes()), 1)
         level, component, message = ctx.listNotes()[0]
-        self.assertEqual( level, logging.INFO )
-        self.assertEqual( component, 'foo' )
-        self.assertEqual( message, 'bar' )
+        self.assertEqual(level, logging.INFO)
+        self.assertEqual(component, 'foo')
+        self.assertEqual(message, 'bar')
 
         ctx.clearNotes()
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
-    def test_ctorparms( self ):
+    def test_ctorparms(self):
 
         ENCODING = 'latin-1'
-        site, tool, ctx = self._makeOne( encoding=ENCODING
-                                       , should_purge=True
-                                       )
+        site, tool, ctx = self._makeOne(encoding=ENCODING, should_purge=True
+                                        )
 
-        self.assertEqual( ctx.getEncoding(), ENCODING )
-        self.assertEqual( ctx.shouldPurge(), True )
+        self.assertEqual(ctx.getEncoding(), ENCODING)
+        self.assertEqual(ctx.shouldPurge(), True)
 
-    def test_empty( self ):
+    def test_empty(self):
 
         site, tool, ctx = self._makeOne()
 
-        self.assertEqual( ctx.getSite(), site )
-        self.assertEqual( ctx.getEncoding(), None )
-        self.assertEqual( ctx.shouldPurge(), False )
+        self.assertEqual(ctx.getSite(), site)
+        self.assertEqual(ctx.getEncoding(), None)
+        self.assertEqual(ctx.shouldPurge(), False)
 
         # These methods are all specified to return 'None' for non-existing
         # paths / entities
-        self.assertEqual( ctx.isDirectory( 'nonesuch/path' ), None )
-        self.assertEqual( ctx.listDirectory( 'nonesuch/path' ), None )
+        self.assertEqual(ctx.isDirectory('nonesuch/path'), None)
+        self.assertEqual(ctx.listDirectory('nonesuch/path'), None)
 
-    def test_readDataFile_nonesuch( self ):
+    def test_readDataFile_nonesuch(self):
 
         FILENAME = 'nonesuch.txt'
 
         site, tool, ctx = self._makeOne()
 
-        self.assertEqual( ctx.readDataFile( FILENAME ), None )
-        self.assertEqual( ctx.readDataFile( FILENAME, 'subdir' ), None )
+        self.assertEqual(ctx.readDataFile(FILENAME), None)
+        self.assertEqual(ctx.readDataFile(FILENAME, 'subdir'), None)
 
-    def test_readDataFile_simple( self ):
+    def test_readDataFile_simple(self):
 
         from string import printable
 
         FILENAME = 'simple.txt'
 
-        site, tool, ctx = self._makeOne( { FILENAME: printable } )
+        site, tool, ctx = self._makeOne({FILENAME: printable})
 
-        self.assertEqual( ctx.readDataFile( FILENAME ), printable )
+        self.assertEqual(ctx.readDataFile(FILENAME), printable)
 
-    def test_readDataFile_subdir( self ):
+    def test_readDataFile_subdir(self):
 
         from string import printable
 
         FILENAME = 'subdir.txt'
         SUBDIR = 'subdir'
 
-        site, tool, ctx = self._makeOne( { '%s/%s' % (SUBDIR, FILENAME):
-                                            printable } )
+        site, tool, ctx = self._makeOne({'%s/%s' % (SUBDIR, FILENAME):
+                                         printable})
 
-        self.assertEqual( ctx.readDataFile( FILENAME, SUBDIR ), printable )
+        self.assertEqual(ctx.readDataFile(FILENAME, SUBDIR), printable)
 
     def test_getLastModified_nonesuch(self):
         FILENAME = 'nonesuch.txt'
@@ -608,225 +603,222 @@ class TarballImportContextTests(ZopeTestCase, ConformsToISetupContext,
         self.assertTrue(isinstance(lm, DateTime))
         self.assertEqual(lm, DateTime(WHEN))
 
-    def test_isDirectory_nonesuch( self ):
+    def test_isDirectory_nonesuch(self):
 
         FILENAME = 'nonesuch.txt'
 
         site, tool, ctx = self._makeOne()
 
-        self.assertEqual( ctx.isDirectory( FILENAME ), None )
+        self.assertEqual(ctx.isDirectory(FILENAME), None)
 
-    def test_isDirectory_simple( self ):
+    def test_isDirectory_simple(self):
 
         from string import printable
 
         FILENAME = 'simple.txt'
 
-        site, tool, ctx = self._makeOne( { FILENAME: printable } )
+        site, tool, ctx = self._makeOne({FILENAME: printable})
 
-        self.assertEqual( ctx.isDirectory( FILENAME ), False )
+        self.assertEqual(ctx.isDirectory(FILENAME), False)
 
-    def test_isDirectory_nested( self ):
-
-        from string import printable
-
-        SUBDIR = 'subdir'
-        FILENAME = 'nested.txt'
-        PATH = '%s/%s' % ( SUBDIR, FILENAME )
-
-        site, tool, ctx = self._makeOne( { PATH: printable } )
-
-        self.assertEqual( ctx.isDirectory( PATH ), False )
-
-    def test_isDirectory_subdir( self ):
+    def test_isDirectory_nested(self):
 
         from string import printable
 
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
-        PATH = '%s/%s' % ( SUBDIR, FILENAME )
+        PATH = '%s/%s' % (SUBDIR, FILENAME)
 
-        site, tool, ctx = self._makeOne( { PATH: printable } )
+        site, tool, ctx = self._makeOne({PATH: printable})
 
-        self.assertEqual( ctx.isDirectory( SUBDIR ), True )
+        self.assertEqual(ctx.isDirectory(PATH), False)
 
-    def test_listDirectory_nonesuch( self ):
+    def test_isDirectory_subdir(self):
+
+        from string import printable
+
+        SUBDIR = 'subdir'
+        FILENAME = 'nested.txt'
+        PATH = '%s/%s' % (SUBDIR, FILENAME)
+
+        site, tool, ctx = self._makeOne({PATH: printable})
+
+        self.assertEqual(ctx.isDirectory(SUBDIR), True)
+
+    def test_listDirectory_nonesuch(self):
 
         SUBDIR = 'nonesuch/path'
 
         site, tool, ctx = self._makeOne()
 
-        self.assertEqual( ctx.listDirectory( SUBDIR ), None )
+        self.assertEqual(ctx.listDirectory(SUBDIR), None)
 
-    def test_listDirectory_root( self ):
-
-        from string import printable
-
-        FILENAME = 'simple.txt'
-
-        site, tool, ctx = self._makeOne( { FILENAME: printable } )
-
-        self.assertEqual( len( ctx.listDirectory( None ) ), 1 )
-        self.failUnless( FILENAME in ctx.listDirectory( None ) )
-
-    def test_listDirectory_simple( self ):
+    def test_listDirectory_root(self):
 
         from string import printable
 
         FILENAME = 'simple.txt'
 
-        site, tool, ctx = self._makeOne( { FILENAME: printable } )
+        site, tool, ctx = self._makeOne({FILENAME: printable})
 
-        self.assertEqual( ctx.listDirectory( FILENAME ), None )
+        self.assertEqual(len(ctx.listDirectory(None)), 1)
+        self.failUnless(FILENAME in ctx.listDirectory(None))
 
-    def test_listDirectory_nested( self ):
+    def test_listDirectory_simple(self):
+
+        from string import printable
+
+        FILENAME = 'simple.txt'
+
+        site, tool, ctx = self._makeOne({FILENAME: printable})
+
+        self.assertEqual(ctx.listDirectory(FILENAME), None)
+
+    def test_listDirectory_nested(self):
 
         from string import printable
 
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
-        PATH = '%s/%s' % ( SUBDIR, FILENAME )
+        PATH = '%s/%s' % (SUBDIR, FILENAME)
 
-        site, tool, ctx = self._makeOne( { PATH: printable } )
+        site, tool, ctx = self._makeOne({PATH: printable})
 
-        self.assertEqual( ctx.listDirectory( PATH ), None )
+        self.assertEqual(ctx.listDirectory(PATH), None)
 
-    def test_listDirectory_single( self ):
+    def test_listDirectory_single(self):
 
         from string import printable
 
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
-        PATH = '%s/%s' % ( SUBDIR, FILENAME )
+        PATH = '%s/%s' % (SUBDIR, FILENAME)
 
-        site, tool, ctx = self._makeOne( { PATH: printable } )
+        site, tool, ctx = self._makeOne({PATH: printable})
 
-        names = ctx.listDirectory( SUBDIR )
-        self.assertEqual( len( names ), 1 )
-        self.failUnless( FILENAME in names )
+        names = ctx.listDirectory(SUBDIR)
+        self.assertEqual(len(names), 1)
+        self.failUnless(FILENAME in names)
 
-    def test_listDirectory_multiple( self ):
-
-        from string import printable, uppercase
-
-        SUBDIR = 'subdir'
-        FILENAME1 = 'nested.txt'
-        PATH1 = '%s/%s' % ( SUBDIR, FILENAME1 )
-        FILENAME2 = 'another.txt'
-        PATH2 = '%s/%s' % ( SUBDIR, FILENAME2 )
-
-        site, tool, ctx = self._makeOne( { PATH1: printable
-                                         , PATH2: uppercase
-                                         } )
-                                             
-        names = ctx.listDirectory( SUBDIR )
-        self.assertEqual( len( names ), 2 )
-        self.failUnless( FILENAME1 in names )
-        self.failUnless( FILENAME2 in names )
-
-    def test_listDirectory_skip( self ):
+    def test_listDirectory_multiple(self):
 
         from string import printable, uppercase
 
         SUBDIR = 'subdir'
         FILENAME1 = 'nested.txt'
-        PATH1 = '%s/%s' % ( SUBDIR, FILENAME1 )
+        PATH1 = '%s/%s' % (SUBDIR, FILENAME1)
         FILENAME2 = 'another.txt'
-        PATH2 = '%s/%s' % ( SUBDIR, FILENAME2 )
+        PATH2 = '%s/%s' % (SUBDIR, FILENAME2)
+
+        site, tool, ctx = self._makeOne({PATH1: printable, PATH2: uppercase
+                                         })
+
+        names = ctx.listDirectory(SUBDIR)
+        self.assertEqual(len(names), 2)
+        self.failUnless(FILENAME1 in names)
+        self.failUnless(FILENAME2 in names)
+
+    def test_listDirectory_skip(self):
+
+        from string import printable, uppercase
+
+        SUBDIR = 'subdir'
+        FILENAME1 = 'nested.txt'
+        PATH1 = '%s/%s' % (SUBDIR, FILENAME1)
+        FILENAME2 = 'another.txt'
+        PATH2 = '%s/%s' % (SUBDIR, FILENAME2)
         FILENAME3 = 'another.bak'
-        PATH3 = '%s/%s' % ( SUBDIR, FILENAME3 )
+        PATH3 = '%s/%s' % (SUBDIR, FILENAME3)
 
-        site, tool, ctx = self._makeOne( { PATH1: printable
-                                         , PATH2: uppercase
-                                         , PATH3: 'xyz'
-                                         } )
+        site, tool, ctx = self._makeOne({PATH1: printable, PATH2: uppercase, PATH3: 'xyz'
+                                         })
 
         names = ctx.listDirectory(SUBDIR, skip=(FILENAME1,),
                                   skip_suffixes=('.bak',))
-        self.assertEqual( len( names ), 1 )
-        self.failIf( FILENAME1 in names )
-        self.failUnless( FILENAME2 in names )
-        self.failIf( FILENAME3 in names )
+        self.assertEqual(len(names), 1)
+        self.failIf(FILENAME1 in names)
+        self.failUnless(FILENAME2 in names)
+        self.failIf(FILENAME3 in names)
 
 
 class TarballExportContextTests(ZopeTestCase, ConformsToISetupContext,
                                 ConformsToIExportContext, TarballTester):
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.context import TarballExportContext
         return TarballExportContext
 
-    def test_getLogger( self ):
+    def test_getLogger(self):
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._getTargetClass()( site )
+        ctx = self._getTargetClass()(site)
 
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
         logger = ctx.getLogger('foo')
         logger.info('bar')
 
-        self.assertEqual( len( ctx.listNotes() ), 1 )
+        self.assertEqual(len(ctx.listNotes()), 1)
         level, component, message = ctx.listNotes()[0]
-        self.assertEqual( level, logging.INFO )
-        self.assertEqual( component, 'foo' )
-        self.assertEqual( message, 'bar' )
+        self.assertEqual(level, logging.INFO)
+        self.assertEqual(component, 'foo')
+        self.assertEqual(message, 'bar')
 
         ctx.clearNotes()
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
-    def test_writeDataFile_simple( self ):
+    def test_writeDataFile_simple(self):
 
         from string import printable
-        now = long( time.time() )
+        now = long(time.time())
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._getTargetClass()( site )
+        ctx = self._getTargetClass()(site)
 
-        ctx.writeDataFile( 'foo.txt', printable, 'text/plain' )
+        ctx.writeDataFile('foo.txt', printable, 'text/plain')
 
-        fileish = StringIO( ctx.getArchive() )
+        fileish = StringIO(ctx.getArchive())
 
-        self._verifyTarballContents( fileish, [ 'foo.txt' ], now )
-        self._verifyTarballEntry( fileish, 'foo.txt', printable )
+        self._verifyTarballContents(fileish, ['foo.txt'], now)
+        self._verifyTarballEntry(fileish, 'foo.txt', printable)
 
-    def test_writeDataFile_umluats( self ):
+    def test_writeDataFile_umluats(self):
 
         text = u'Kein Weltraum links vom Gerät'
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._getTargetClass()( site )
+        ctx = self._getTargetClass()(site)
 
         self.assertRaises(ValueError, ctx.writeDataFile,
-                          'foo.txt', text, 'text/plain' )
+                          'foo.txt', text, 'text/plain')
         text = u'No umlauts'
         self.assertRaises(ValueError, ctx.writeDataFile,
-                          'foo.txt', text, 'text/plain' )
+                          'foo.txt', text, 'text/plain')
 
-    def test_writeDataFile_multiple( self ):
+    def test_writeDataFile_multiple(self):
 
         from string import printable
         from string import digits
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._getTargetClass()( site )
+        ctx = self._getTargetClass()(site)
 
-        ctx.writeDataFile( 'foo.txt', printable, 'text/plain' )
-        ctx.writeDataFile( 'bar.txt', digits, 'text/plain' )
+        ctx.writeDataFile('foo.txt', printable, 'text/plain')
+        ctx.writeDataFile('bar.txt', digits, 'text/plain')
 
-        fileish = StringIO( ctx.getArchive() )
+        fileish = StringIO(ctx.getArchive())
 
-        self._verifyTarballContents( fileish, [ 'foo.txt', 'bar.txt' ] )
-        self._verifyTarballEntry( fileish, 'foo.txt', printable )
-        self._verifyTarballEntry( fileish, 'bar.txt', digits )
+        self._verifyTarballContents(fileish, ['foo.txt', 'bar.txt'])
+        self._verifyTarballEntry(fileish, 'foo.txt', printable)
+        self._verifyTarballEntry(fileish, 'bar.txt', digits)
 
-    def test_writeDataFile_PdataStreamIterator( self ):
+    def test_writeDataFile_PdataStreamIterator(self):
 
         from string import printable
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._getTargetClass()( site )
+        ctx = self._getTargetClass()(site)
 
         fp = tempfile.TemporaryFile()
         fp.write(printable)
@@ -834,137 +826,136 @@ class TarballExportContextTests(ZopeTestCase, ConformsToISetupContext,
         pData = DummyPdataStreamIterator()
         pData.file = fp
         pData.size = len(printable)
-        ctx.writeDataFile( 'foo.txt', pData, 'text/plain' )
+        ctx.writeDataFile('foo.txt', pData, 'text/plain')
 
-        fileish = StringIO( ctx.getArchive() )
+        fileish = StringIO(ctx.getArchive())
 
-        self._verifyTarballContents( fileish, [ 'foo.txt' ] )
-        self._verifyTarballEntry( fileish, 'foo.txt', printable)
+        self._verifyTarballContents(fileish, ['foo.txt'])
+        self._verifyTarballEntry(fileish, 'foo.txt', printable)
 
-    def test_writeDataFile_subdir( self ):
+    def test_writeDataFile_subdir(self):
 
         from string import printable
         from string import digits
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._getTargetClass()( site )
+        ctx = self._getTargetClass()(site)
 
-        ctx.writeDataFile( 'foo.txt', printable, 'text/plain' )
-        ctx.writeDataFile( 'bar/baz.txt', digits, 'text/plain' )
+        ctx.writeDataFile('foo.txt', printable, 'text/plain')
+        ctx.writeDataFile('bar/baz.txt', digits, 'text/plain')
 
-        fileish = StringIO( ctx.getArchive() )
+        fileish = StringIO(ctx.getArchive())
 
-        self._verifyTarballContents( fileish,
-                                     ['foo.txt', 'bar', 'bar/baz.txt'] )
-        self._verifyTarballEntry( fileish, 'foo.txt', printable )
-        self._verifyTarballEntry( fileish, 'bar/baz.txt', digits )
+        self._verifyTarballContents(fileish,
+                                    ['foo.txt', 'bar', 'bar/baz.txt'])
+        self._verifyTarballEntry(fileish, 'foo.txt', printable)
+        self._verifyTarballEntry(fileish, 'bar/baz.txt', digits)
 
 
 class SnapshotExportContextTests(ZopeTestCase, ConformsToISetupContext,
                                  ConformsToIExportContext):
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.context import SnapshotExportContext
         return SnapshotExportContext
 
-    def _makeOne( self, *args, **kw ):
+    def _makeOne(self, *args, **kw):
 
-        return self._getTargetClass()( *args, **kw )
+        return self._getTargetClass()(*args, **kw)
 
-    def test_getLogger( self ):
+    def test_getLogger(self):
 
         site = DummySite('site').__of__(self.app)
-        site.setup_tool = DummyTool( 'setup_tool' )
+        site.setup_tool = DummyTool('setup_tool')
         tool = site.setup_tool
-        ctx = self._makeOne( tool, 'simple' )
+        ctx = self._makeOne(tool, 'simple')
 
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
         logger = ctx.getLogger('foo')
         logger.info('bar')
 
-        self.assertEqual( len( ctx.listNotes() ), 1 )
+        self.assertEqual(len(ctx.listNotes()), 1)
         level, component, message = ctx.listNotes()[0]
-        self.assertEqual( level, logging.INFO )
-        self.assertEqual( component, 'foo' )
-        self.assertEqual( message, 'bar' )
+        self.assertEqual(level, logging.INFO)
+        self.assertEqual(component, 'foo')
+        self.assertEqual(message, 'bar')
 
         ctx.clearNotes()
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
-    def test_writeDataFile_simple_image( self ):
+    def test_writeDataFile_simple_image(self):
 
         from OFS.Image import Image
         FILENAME = 'simple.txt'
         CONTENT_TYPE = 'image/png'
-        png_filename = os.path.join( os.path.split( __file__ )[0]
-                                   , 'simple.png' )
-        png_file = open( png_filename, 'rb' )
+        png_filename = os.path.join(os.path.split(__file__)[0], 'simple.png')
+        png_file = open(png_filename, 'rb')
         png_data = png_file.read()
         png_file.close()
 
         site = DummySite('site').__of__(self.app)
-        site.setup_tool = DummyTool( 'setup_tool' )
+        site.setup_tool = DummyTool('setup_tool')
         tool = site.setup_tool
-        ctx = self._makeOne( tool, 'simple' )
+        ctx = self._makeOne(tool, 'simple')
 
-        ctx.writeDataFile( FILENAME, png_data, CONTENT_TYPE )
+        ctx.writeDataFile(FILENAME, png_data, CONTENT_TYPE)
 
-        snapshot = tool.snapshots._getOb( 'simple' )
+        snapshot = tool.snapshots._getOb('simple')
 
-        self.assertEqual( len( snapshot.objectIds() ), 1 )
-        self.failUnless( FILENAME in snapshot.objectIds() )
+        self.assertEqual(len(snapshot.objectIds()), 1)
+        self.failUnless(FILENAME in snapshot.objectIds())
 
-        fileobj = snapshot._getOb( FILENAME )
+        fileobj = snapshot._getOb(FILENAME)
 
-        self.assertEqual( fileobj.getId(), FILENAME )
-        self.assertEqual( fileobj.meta_type, Image.meta_type )
-        self.assertEqual( fileobj.getContentType(), CONTENT_TYPE )
-        self.assertEqual( fileobj.data, png_data )
+        self.assertEqual(fileobj.getId(), FILENAME)
+        self.assertEqual(fileobj.meta_type, Image.meta_type)
+        self.assertEqual(fileobj.getContentType(), CONTENT_TYPE)
+        self.assertEqual(fileobj.data, png_data)
 
-    def test_writeDataFile_simple_plain_text( self ):
+    def test_writeDataFile_simple_plain_text(self):
 
         from string import digits
         FILENAME = 'simple.txt'
         CONTENT_TYPE = 'text/plain'
 
         site = DummySite('site').__of__(self.app)
-        site.setup_tool = DummyTool( 'setup_tool' )
+        site.setup_tool = DummyTool('setup_tool')
         tool = site.setup_tool
-        ctx = self._makeOne( tool, 'simple' )
+        ctx = self._makeOne(tool, 'simple')
 
-        ctx.writeDataFile( FILENAME, digits, CONTENT_TYPE )
+        ctx.writeDataFile(FILENAME, digits, CONTENT_TYPE)
 
-        snapshot = tool.snapshots._getOb( 'simple' )
+        snapshot = tool.snapshots._getOb('simple')
 
-        self.assertEqual( len( snapshot.objectIds() ), 1 )
-        self.failUnless( FILENAME in snapshot.objectIds() )
+        self.assertEqual(len(snapshot.objectIds()), 1)
+        self.failUnless(FILENAME in snapshot.objectIds())
 
-        fileobj = snapshot._getOb( FILENAME )
+        fileobj = snapshot._getOb(FILENAME)
 
-        self.assertEqual( fileobj.getId(), FILENAME )
-        self.assertEqual( fileobj.meta_type, File.meta_type )
-        self.assertEqual( fileobj.getContentType(), CONTENT_TYPE )
-        self.assertEqual( str( fileobj ), digits )
+        self.assertEqual(fileobj.getId(), FILENAME)
+        self.assertEqual(fileobj.meta_type, File.meta_type)
+        self.assertEqual(fileobj.getContentType(), CONTENT_TYPE)
+        self.assertEqual(str(fileobj), digits)
 
-    def test_writeDataFile_simple_plain_text_unicode( self ):
+    def test_writeDataFile_simple_plain_text_unicode(self):
         FILENAME = 'simple.txt'
         CONTENT_TYPE = 'text/plain'
         CONTENT = u'Unicode, with non-ASCII: %s.' % unichr(150)
 
         site = DummySite('site').__of__(self.app)
-        site.setup_tool = DummyTool( 'setup_tool' )
+        site.setup_tool = DummyTool('setup_tool')
         tool = site.setup_tool
-        ctx = self._makeOne( tool, 'simple', 'latin_1' )
+        ctx = self._makeOne(tool, 'simple', 'latin_1')
 
         self.assertRaises(ValueError, ctx.writeDataFile,
-                          FILENAME, CONTENT, CONTENT_TYPE )
+                          FILENAME, CONTENT, CONTENT_TYPE)
         CONTENT = u'No unicode chars'
         self.assertRaises(ValueError, ctx.writeDataFile,
-                          FILENAME, CONTENT, CONTENT_TYPE )
+                          FILENAME, CONTENT, CONTENT_TYPE)
 
-    def test_writeDataFile_simple_xml( self ):
+    def test_writeDataFile_simple_xml(self):
 
         from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
         FILENAME = 'simple.xml'
@@ -972,25 +963,25 @@ class SnapshotExportContextTests(ZopeTestCase, ConformsToISetupContext,
         _XML = """<?xml version="1.0"?><simple />"""
 
         site = DummySite('site').__of__(self.app)
-        site.setup_tool = DummyTool( 'setup_tool' )
+        site.setup_tool = DummyTool('setup_tool')
         tool = site.setup_tool
-        ctx = self._makeOne( tool, 'simple' )
+        ctx = self._makeOne(tool, 'simple')
 
-        ctx.writeDataFile( FILENAME, _XML, CONTENT_TYPE )
+        ctx.writeDataFile(FILENAME, _XML, CONTENT_TYPE)
 
-        snapshot = tool.snapshots._getOb( 'simple' )
+        snapshot = tool.snapshots._getOb('simple')
 
-        self.assertEqual( len( snapshot.objectIds() ), 1 )
-        self.failUnless( FILENAME in snapshot.objectIds() )
+        self.assertEqual(len(snapshot.objectIds()), 1)
+        self.failUnless(FILENAME in snapshot.objectIds())
 
-        template = snapshot._getOb( FILENAME )
+        template = snapshot._getOb(FILENAME)
 
-        self.assertEqual( template.getId(), FILENAME )
-        self.assertEqual( template.meta_type, ZopePageTemplate.meta_type )
-        self.assertEqual( template.read(), _XML )
-        self.failIf( template.html() )
+        self.assertEqual(template.getId(), FILENAME)
+        self.assertEqual(template.meta_type, ZopePageTemplate.meta_type)
+        self.assertEqual(template.read(), _XML)
+        self.failIf(template.html())
 
-    def test_writeDataFile_subdir_dtml( self ):
+    def test_writeDataFile_subdir_dtml(self):
 
         from OFS.DTMLDocument import DTMLDocument
         FILENAME = 'simple.dtml'
@@ -998,28 +989,28 @@ class SnapshotExportContextTests(ZopeTestCase, ConformsToISetupContext,
         _HTML = """<html><body><h1>HTML</h1></body></html>"""
 
         site = DummySite('site').__of__(self.app)
-        site.setup_tool = DummyTool( 'setup_tool' )
+        site.setup_tool = DummyTool('setup_tool')
         tool = site.setup_tool
-        ctx = self._makeOne( tool, 'simple' )
+        ctx = self._makeOne(tool, 'simple')
 
-        ctx.writeDataFile( FILENAME, _HTML, CONTENT_TYPE, 'sub1' )
+        ctx.writeDataFile(FILENAME, _HTML, CONTENT_TYPE, 'sub1')
 
-        snapshot = tool.snapshots._getOb( 'simple' )
-        sub1 = snapshot._getOb( 'sub1' )
+        snapshot = tool.snapshots._getOb('simple')
+        sub1 = snapshot._getOb('sub1')
 
-        self.assertEqual( len( sub1.objectIds() ), 1 )
-        self.failUnless( FILENAME in sub1.objectIds() )
+        self.assertEqual(len(sub1.objectIds()), 1)
+        self.failUnless(FILENAME in sub1.objectIds())
 
-        template = sub1._getOb( FILENAME )
+        template = sub1._getOb(FILENAME)
 
-        self.assertEqual( template.getId(), FILENAME )
-        self.assertEqual( template.meta_type, DTMLDocument.meta_type )
-        self.assertEqual( template.read(), _HTML )
+        self.assertEqual(template.getId(), FILENAME)
+        self.assertEqual(template.meta_type, DTMLDocument.meta_type)
+        self.assertEqual(template.read(), _HTML)
 
-        ctx.writeDataFile( 'sub1/%s2' % FILENAME, _HTML, CONTENT_TYPE)
-        self.assertEqual( len( sub1.objectIds() ), 2 )
+        ctx.writeDataFile('sub1/%s2' % FILENAME, _HTML, CONTENT_TYPE)
+        self.assertEqual(len(sub1.objectIds()), 2)
 
-    def test_writeDataFile_nested_subdirs_html( self ):
+    def test_writeDataFile_nested_subdirs_html(self):
 
         from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
         FILENAME = 'simple.html'
@@ -1027,168 +1018,159 @@ class SnapshotExportContextTests(ZopeTestCase, ConformsToISetupContext,
         _HTML = """<html><body><h1>HTML</h1></body></html>"""
 
         site = DummySite('site').__of__(self.app)
-        site.setup_tool = DummyTool( 'setup_tool' )
+        site.setup_tool = DummyTool('setup_tool')
         tool = site.setup_tool
-        ctx = self._makeOne( tool, 'simple' )
+        ctx = self._makeOne(tool, 'simple')
 
-        ctx.writeDataFile( FILENAME, _HTML, CONTENT_TYPE, 'sub1/sub2' )
+        ctx.writeDataFile(FILENAME, _HTML, CONTENT_TYPE, 'sub1/sub2')
 
-        snapshot = tool.snapshots._getOb( 'simple' )
-        sub1 = snapshot._getOb( 'sub1' )
-        sub2 = sub1._getOb( 'sub2' )
+        snapshot = tool.snapshots._getOb('simple')
+        sub1 = snapshot._getOb('sub1')
+        sub2 = sub1._getOb('sub2')
 
-        self.assertEqual( len( sub2.objectIds() ), 1 )
-        self.failUnless( FILENAME in sub2.objectIds() )
+        self.assertEqual(len(sub2.objectIds()), 1)
+        self.failUnless(FILENAME in sub2.objectIds())
 
-        template = sub2._getOb( FILENAME )
+        template = sub2._getOb(FILENAME)
 
-        self.assertEqual( template.getId(), FILENAME )
-        self.assertEqual( template.meta_type, ZopePageTemplate.meta_type )
-        self.assertEqual( template.read(), _HTML )
-        self.failUnless( template.html() )
+        self.assertEqual(template.getId(), FILENAME)
+        self.assertEqual(template.meta_type, ZopePageTemplate.meta_type)
+        self.assertEqual(template.read(), _HTML)
+        self.failUnless(template.html())
 
-    def test_writeDataFile_multiple( self ):
+    def test_writeDataFile_multiple(self):
 
         from string import printable
         from string import digits
 
         site = DummySite('site').__of__(self.app)
-        site.setup_tool = DummyTool( 'setup_tool' )
+        site.setup_tool = DummyTool('setup_tool')
         tool = site.setup_tool
-        ctx = self._makeOne( tool, 'multiple' )
+        ctx = self._makeOne(tool, 'multiple')
 
-        ctx.writeDataFile( 'foo.txt', printable, 'text/plain' )
-        ctx.writeDataFile( 'bar.txt', digits, 'text/plain' )
+        ctx.writeDataFile('foo.txt', printable, 'text/plain')
+        ctx.writeDataFile('bar.txt', digits, 'text/plain')
 
-        snapshot = tool.snapshots._getOb( 'multiple' )
+        snapshot = tool.snapshots._getOb('multiple')
 
-        self.assertEqual( len( snapshot.objectIds() ), 2 )
+        self.assertEqual(len(snapshot.objectIds()), 2)
 
-        for id in [ 'foo.txt', 'bar.txt' ]:
-            self.failUnless( id in snapshot.objectIds() )
+        for id in ['foo.txt', 'bar.txt']:
+            self.failUnless(id in snapshot.objectIds())
 
 
 class SnapshotImportContextTests(ZopeTestCase, ConformsToISetupContext,
                                  ConformsToIImportContext):
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.context import SnapshotImportContext
         return SnapshotImportContext
 
-    def _makeOne( self, context_id, *args, **kw ):
+    def _makeOne(self, context_id, *args, **kw):
 
         site = DummySite('site').__of__(self.app)
-        site._setObject( 'setup_tool', Folder( 'setup_tool' ) )
-        tool = site._getOb( 'setup_tool' )
+        site._setObject('setup_tool', Folder('setup_tool'))
+        tool = site._getOb('setup_tool')
 
-        tool._setObject( 'snapshots', Folder( 'snapshots' ) )
-        tool.snapshots._setObject( context_id, Folder( context_id ) )
+        tool._setObject('snapshots', Folder('snapshots'))
+        tool.snapshots._setObject(context_id, Folder(context_id))
 
-        ctx = self._getTargetClass()( tool, context_id, *args, **kw )
+        ctx = self._getTargetClass()(tool, context_id, *args, **kw)
 
-        return site, tool, ctx.__of__( tool )
+        return site, tool, ctx.__of__(tool)
 
-    def _makeFile( self
-                 , tool
-                 , snapshot_id
-                 , filename
-                 , contents
-                 , content_type='text/plain'
-                 , mod_time=None
-                 , subdir=None
-                 ):
+    def _makeFile(self, tool, snapshot_id, filename, contents, content_type='text/plain', mod_time=None, subdir=None
+                  ):
 
-        snapshots = tool._getOb( 'snapshots' )
-        folder = snapshots._getOb( snapshot_id )
+        snapshots = tool._getOb('snapshots')
+        folder = snapshots._getOb(snapshot_id)
 
         if subdir is not None:
 
-            for element in subdir.split( '/' ):
+            for element in subdir.split('/'):
 
                 try:
-                    folder = folder._getOb( element )
+                    folder = folder._getOb(element)
                 except AttributeError:
-                    folder._setObject( element, Folder( element ) )
-                    folder = folder._getOb( element )
+                    folder._setObject(element, Folder(element))
+                    folder = folder._getOb(element)
 
-        file = File( filename, '', contents, content_type )
-        folder._setObject( filename, file )
+        file = File(filename, '', contents, content_type)
+        folder._setObject(filename, file)
 
         if mod_time is not None:
             mod_time = DateTime(mod_time).timeTime()
             folder._faux_mod_time = file._faux_mod_time = mod_time
 
-        return folder._getOb( filename )
+        return folder._getOb(filename)
 
-    def test_getLogger( self ):
+    def test_getLogger(self):
 
         SNAPSHOT_ID = 'note'
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
 
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
         logger = ctx.getLogger('foo')
         logger.info('bar')
 
-        self.assertEqual( len( ctx.listNotes() ), 1 )
+        self.assertEqual(len(ctx.listNotes()), 1)
         level, component, message = ctx.listNotes()[0]
-        self.assertEqual( level, logging.INFO )
-        self.assertEqual( component, 'foo' )
-        self.assertEqual( message, 'bar' )
+        self.assertEqual(level, logging.INFO)
+        self.assertEqual(component, 'foo')
+        self.assertEqual(message, 'bar')
 
         ctx.clearNotes()
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
-    def test_ctorparms( self ):
+    def test_ctorparms(self):
 
         SNAPSHOT_ID = 'ctorparms'
         ENCODING = 'latin-1'
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID
-                                       , encoding=ENCODING
-                                       , should_purge=True
-                                       )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID, encoding=ENCODING, should_purge=True
+                                        )
 
-        self.assertEqual( ctx.getEncoding(), ENCODING )
-        self.assertEqual( ctx.shouldPurge(), True )
+        self.assertEqual(ctx.getEncoding(), ENCODING)
+        self.assertEqual(ctx.shouldPurge(), True)
 
-    def test_empty( self ):
+    def test_empty(self):
 
         SNAPSHOT_ID = 'empty'
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
 
-        self.assertEqual( ctx.getSite(), site )
-        self.assertEqual( ctx.getEncoding(), None )
-        self.assertEqual( ctx.shouldPurge(), False )
+        self.assertEqual(ctx.getSite(), site)
+        self.assertEqual(ctx.getEncoding(), None)
+        self.assertEqual(ctx.shouldPurge(), False)
 
         # These methods are all specified to return 'None' for non-existing
         # paths / entities
-        self.assertEqual( ctx.isDirectory( 'nonesuch/path' ), None )
-        self.assertEqual( ctx.listDirectory( 'nonesuch/path' ), None )
+        self.assertEqual(ctx.isDirectory('nonesuch/path'), None)
+        self.assertEqual(ctx.listDirectory('nonesuch/path'), None)
 
-    def test_readDataFile_nonesuch( self ):
+    def test_readDataFile_nonesuch(self):
 
         SNAPSHOT_ID = 'readDataFile_nonesuch'
         FILENAME = 'nonesuch.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
 
-        self.assertEqual( ctx.readDataFile( FILENAME ), None )
-        self.assertEqual( ctx.readDataFile( FILENAME, 'subdir' ), None )
+        self.assertEqual(ctx.readDataFile(FILENAME), None)
+        self.assertEqual(ctx.readDataFile(FILENAME, 'subdir'), None)
 
-    def test_readDataFile_simple( self ):
+    def test_readDataFile_simple(self):
 
         from string import printable
 
         SNAPSHOT_ID = 'readDataFile_simple'
         FILENAME = 'simple.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable)
 
-        self.assertEqual( ctx.readDataFile( FILENAME ), printable )
+        self.assertEqual(ctx.readDataFile(FILENAME), printable)
 
-    def test_readDataFile_Pdata( self ):
+    def test_readDataFile_Pdata(self):
 
         from string import printable
         from OFS.Image import Pdata
@@ -1196,12 +1178,12 @@ class SnapshotImportContextTests(ZopeTestCase, ConformsToISetupContext,
         SNAPSHOT_ID = 'readDataFile_Pdata'
         FILENAME = 'pdata.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, Pdata(printable) )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, Pdata(printable))
 
-        self.assertEqual( ctx.readDataFile( FILENAME ), printable )
+        self.assertEqual(ctx.readDataFile(FILENAME), printable)
 
-    def test_readDataFile_subdir( self ):
+    def test_readDataFile_subdir(self):
 
         from string import printable
 
@@ -1209,13 +1191,12 @@ class SnapshotImportContextTests(ZopeTestCase, ConformsToISetupContext,
         FILENAME = 'subdir.txt'
         SUBDIR = 'subdir'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable
-                      , subdir=SUBDIR )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable, subdir=SUBDIR)
 
-        self.assertEqual( ctx.readDataFile( FILENAME, SUBDIR ), printable )
-        self.assertEqual( ctx.readDataFile( '%s/%s' % (SUBDIR, FILENAME) ),
-                                            printable )
+        self.assertEqual(ctx.readDataFile(FILENAME, SUBDIR), printable)
+        self.assertEqual(ctx.readDataFile('%s/%s' % (SUBDIR, FILENAME)),
+                         printable)
 
     def test_getLastModified_nonesuch(self):
         FILENAME = 'nonesuch.txt'
@@ -1268,43 +1249,42 @@ class SnapshotImportContextTests(ZopeTestCase, ConformsToISetupContext,
         self.assertTrue(isinstance(lm, DateTime))
         self.assertEqual(lm, DateTime(WHEN))
 
-    def test_isDirectory_nonesuch( self ):
+    def test_isDirectory_nonesuch(self):
 
         SNAPSHOT_ID = 'isDirectory_nonesuch'
         FILENAME = 'nonesuch.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
 
-        self.assertEqual( ctx.isDirectory( FILENAME ), None )
+        self.assertEqual(ctx.isDirectory(FILENAME), None)
 
-    def test_isDirectory_simple( self ):
+    def test_isDirectory_simple(self):
 
         from string import printable
 
         SNAPSHOT_ID = 'isDirectory_simple'
         FILENAME = 'simple.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable)
 
-        self.assertEqual( ctx.isDirectory( FILENAME ), False )
+        self.assertEqual(ctx.isDirectory(FILENAME), False)
 
-    def test_isDirectory_nested( self ):
+    def test_isDirectory_nested(self):
 
         from string import printable
 
         SNAPSHOT_ID = 'isDirectory_nested'
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
-        PATH = '%s/%s' % ( SUBDIR, FILENAME )
+        PATH = '%s/%s' % (SUBDIR, FILENAME)
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable
-                             , subdir=SUBDIR )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable, subdir=SUBDIR)
 
-        self.assertEqual( ctx.isDirectory( PATH ), False )
+        self.assertEqual(ctx.isDirectory(PATH), False)
 
-    def test_isDirectory_subdir( self ):
+    def test_isDirectory_subdir(self):
 
         from string import printable
 
@@ -1312,78 +1292,75 @@ class SnapshotImportContextTests(ZopeTestCase, ConformsToISetupContext,
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable
-                             , subdir=SUBDIR )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable, subdir=SUBDIR)
 
-        self.assertEqual( ctx.isDirectory( SUBDIR ), True )
+        self.assertEqual(ctx.isDirectory(SUBDIR), True)
 
-    def test_listDirectory_nonesuch( self ):
+    def test_listDirectory_nonesuch(self):
 
         SNAPSHOT_ID = 'listDirectory_nonesuch'
         SUBDIR = 'nonesuch/path'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
 
-        self.assertEqual( ctx.listDirectory( SUBDIR ), None )
+        self.assertEqual(ctx.listDirectory(SUBDIR), None)
 
-    def test_listDirectory_root( self ):
+    def test_listDirectory_root(self):
 
         from string import printable
 
         SNAPSHOT_ID = 'listDirectory_root'
         FILENAME = 'simple.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable)
 
-        self.assertEqual( len( ctx.listDirectory( None ) ), 1 )
-        self.failUnless( FILENAME in ctx.listDirectory( None ) )
+        self.assertEqual(len(ctx.listDirectory(None)), 1)
+        self.failUnless(FILENAME in ctx.listDirectory(None))
 
-    def test_listDirectory_simple( self ):
+    def test_listDirectory_simple(self):
 
         from string import printable
 
         SNAPSHOT_ID = 'listDirectory_simple'
         FILENAME = 'simple.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable)
 
-        self.assertEqual( ctx.listDirectory( FILENAME ), None )
+        self.assertEqual(ctx.listDirectory(FILENAME), None)
 
-    def test_listDirectory_nested( self ):
-
-        from string import printable
-
-        SNAPSHOT_ID = 'listDirectory_nested'
-        SUBDIR = 'subdir'
-        FILENAME = 'nested.txt'
-        PATH = '%s/%s' % ( SUBDIR, FILENAME )
-
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable
-                             , subdir=SUBDIR )
-
-        self.assertEqual( ctx.listDirectory( PATH ), None )
-
-    def test_listDirectory_single( self ):
+    def test_listDirectory_nested(self):
 
         from string import printable
 
         SNAPSHOT_ID = 'listDirectory_nested'
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
+        PATH = '%s/%s' % (SUBDIR, FILENAME)
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable
-                             , subdir=SUBDIR )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable, subdir=SUBDIR)
 
-        names = ctx.listDirectory( SUBDIR )
-        self.assertEqual( len( names ), 1 )
-        self.failUnless( FILENAME in names )
+        self.assertEqual(ctx.listDirectory(PATH), None)
 
-    def test_listDirectory_multiple( self ):
+    def test_listDirectory_single(self):
+
+        from string import printable
+
+        SNAPSHOT_ID = 'listDirectory_nested'
+        SUBDIR = 'subdir'
+        FILENAME = 'nested.txt'
+
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable, subdir=SUBDIR)
+
+        names = ctx.listDirectory(SUBDIR)
+        self.assertEqual(len(names), 1)
+        self.failUnless(FILENAME in names)
+
+    def test_listDirectory_multiple(self):
 
         from string import printable, uppercase
 
@@ -1392,18 +1369,16 @@ class SnapshotImportContextTests(ZopeTestCase, ConformsToISetupContext,
         FILENAME1 = 'nested.txt'
         FILENAME2 = 'another.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME1, printable
-                              , subdir=SUBDIR )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME2, uppercase
-                              , subdir=SUBDIR )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME1, printable, subdir=SUBDIR)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME2, uppercase, subdir=SUBDIR)
 
-        names = ctx.listDirectory( SUBDIR )
-        self.assertEqual( len( names ), 2 )
-        self.failUnless( FILENAME1 in names )
-        self.failUnless( FILENAME2 in names )
+        names = ctx.listDirectory(SUBDIR)
+        self.assertEqual(len(names), 2)
+        self.failUnless(FILENAME1 in names)
+        self.failUnless(FILENAME2 in names)
 
-    def test_listDirectory_skip( self ):
+    def test_listDirectory_skip(self):
 
         from string import printable, uppercase
 
@@ -1413,28 +1388,25 @@ class SnapshotImportContextTests(ZopeTestCase, ConformsToISetupContext,
         FILENAME2 = 'another.txt'
         FILENAME3 = 'another.bak'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME1, printable
-                              , subdir=SUBDIR )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME2, uppercase
-                              , subdir=SUBDIR )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME3, 'abc'
-                              , subdir=SUBDIR )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME1, printable, subdir=SUBDIR)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME2, uppercase, subdir=SUBDIR)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME3, 'abc', subdir=SUBDIR)
 
         names = ctx.listDirectory(SUBDIR, skip=(FILENAME1,),
                                   skip_suffixes=('.bak',))
-        self.assertEqual( len( names ), 1 )
-        self.failIf( FILENAME1 in names )
-        self.failUnless( FILENAME2 in names )
-        self.failIf( FILENAME3 in names )
+        self.assertEqual(len(names), 1)
+        self.failIf(FILENAME1 in names)
+        self.failUnless(FILENAME2 in names)
+        self.failIf(FILENAME3 in names)
 
 
 def test_suite():
     return unittest.TestSuite((
-        unittest.makeSuite( DirectoryImportContextTests ),
-        unittest.makeSuite( DirectoryExportContextTests ),
-        unittest.makeSuite( TarballImportContextTests ),
-        unittest.makeSuite( TarballExportContextTests ),
-        unittest.makeSuite( SnapshotExportContextTests ),
-        unittest.makeSuite( SnapshotImportContextTests ),
-        ))
+        unittest.makeSuite(DirectoryImportContextTests),
+        unittest.makeSuite(DirectoryExportContextTests),
+        unittest.makeSuite(TarballImportContextTests),
+        unittest.makeSuite(TarballExportContextTests),
+        unittest.makeSuite(SnapshotExportContextTests),
+        unittest.makeSuite(SnapshotImportContextTests),
+    ))

--- a/Products/GenericSetup/tests/test_differ.py
+++ b/Products/GenericSetup/tests/test_differ.py
@@ -24,61 +24,59 @@ from OFS.Image import File
 PYTHON27 = sys.version_info[:2] >= (2, 7)
 
 
-class DummySite( Folder ):
+class DummySite(Folder):
 
     pass
 
 
-class Test_unidiff( unittest.TestCase ):
+class Test_unidiff(unittest.TestCase):
 
-    def test_unidiff_both_text( self ):
-
-        from Products.GenericSetup.differ import unidiff
-
-        diff_lines = unidiff( ONE_FOUR, ZERO_FOUR )
-        diff_text = '\n'.join( diff_lines )
-        if PYTHON27:
-            self.assertEqual( diff_text, DIFF_TEXT_27 )
-        else:
-            self.assertEqual( diff_text, DIFF_TEXT )
-
-    def test_unidiff_both_lines( self ):
+    def test_unidiff_both_text(self):
 
         from Products.GenericSetup.differ import unidiff
 
-        diff_lines = unidiff( ONE_FOUR.splitlines(), ZERO_FOUR.splitlines() )
-        diff_text = '\n'.join( diff_lines )
+        diff_lines = unidiff(ONE_FOUR, ZERO_FOUR)
+        diff_text = '\n'.join(diff_lines)
         if PYTHON27:
-            self.assertEqual( diff_text, DIFF_TEXT_27 )
+            self.assertEqual(diff_text, DIFF_TEXT_27)
         else:
-            self.assertEqual( diff_text, DIFF_TEXT )
+            self.assertEqual(diff_text, DIFF_TEXT)
 
-    def test_unidiff_mixed( self ):
+    def test_unidiff_both_lines(self):
 
         from Products.GenericSetup.differ import unidiff
 
-        diff_lines = unidiff( ONE_FOUR, ZERO_FOUR.splitlines() )
-        diff_text = '\n'.join( diff_lines )
+        diff_lines = unidiff(ONE_FOUR.splitlines(), ZERO_FOUR.splitlines())
+        diff_text = '\n'.join(diff_lines)
         if PYTHON27:
-            self.assertEqual( diff_text, DIFF_TEXT_27 )
+            self.assertEqual(diff_text, DIFF_TEXT_27)
         else:
-            self.assertEqual( diff_text, DIFF_TEXT )
+            self.assertEqual(diff_text, DIFF_TEXT)
 
-    def test_unidiff_ignore_blanks( self ):
+    def test_unidiff_mixed(self):
 
         from Products.GenericSetup.differ import unidiff
 
-        double_spaced = ONE_FOUR.replace( '\n', '\n\n' )
-        diff_lines = unidiff( double_spaced
-                            , ZERO_FOUR.splitlines()
-                            , ignore_blanks=True
-                            )
-
-        diff_text = '\n'.join( diff_lines )
+        diff_lines = unidiff(ONE_FOUR, ZERO_FOUR.splitlines())
+        diff_text = '\n'.join(diff_lines)
         if PYTHON27:
-            self.assertEqual( diff_text, DIFF_TEXT_27 )
+            self.assertEqual(diff_text, DIFF_TEXT_27)
         else:
-            self.assertEqual( diff_text, DIFF_TEXT )
+            self.assertEqual(diff_text, DIFF_TEXT)
+
+    def test_unidiff_ignore_blanks(self):
+
+        from Products.GenericSetup.differ import unidiff
+
+        double_spaced = ONE_FOUR.replace('\n', '\n\n')
+        diff_lines = unidiff(double_spaced, ZERO_FOUR.splitlines(), ignore_blanks=True
+                             )
+
+        diff_text = '\n'.join(diff_lines)
+        if PYTHON27:
+            self.assertEqual(diff_text, DIFF_TEXT_27)
+        else:
+            self.assertEqual(diff_text, DIFF_TEXT)
 
 ZERO_FOUR = """\
 zero
@@ -124,264 +122,290 @@ class ConfigDiffTests(ZopeTestCase):
     site = None
     tool = None
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.differ import ConfigDiff
         return ConfigDiff
 
-    def _makeOne( self, lhs, rhs, *args, **kw ):
+    def _makeOne(self, lhs, rhs, *args, **kw):
 
-        return self._getTargetClass()( lhs, rhs, *args, **kw )
+        return self._getTargetClass()(lhs, rhs, *args, **kw)
 
-    def _makeSite( self ):
+    def _makeSite(self):
 
         if self.site is not None:
             return
 
         site = self.site = DummySite('site').__of__(self.app)
-        site._setObject( 'setup_tool', Folder( 'setup_tool' ) )
-        self.tool = tool = site._getOb( 'setup_tool' )
+        site._setObject('setup_tool', Folder('setup_tool'))
+        self.tool = tool = site._getOb('setup_tool')
 
-        tool._setObject( 'snapshots', Folder( 'snapshots' ) )
+        tool._setObject('snapshots', Folder('snapshots'))
 
-    def _makeContext( self, context_id ):
+    def _makeContext(self, context_id):
 
         from Products.GenericSetup.context import SnapshotImportContext
 
         self._makeSite()
 
         if context_id not in self.tool.snapshots.objectIds():
-            self.tool.snapshots._setObject( context_id, Folder( context_id ) )
+            self.tool.snapshots._setObject(context_id, Folder(context_id))
 
-        ctx = SnapshotImportContext( self.tool, context_id )
+        ctx = SnapshotImportContext(self.tool, context_id)
 
-        return ctx.__of__( self.tool )
+        return ctx.__of__(self.tool)
 
-    def _makeDirectory( self, snapshot_id, subdir ):
+    def _makeDirectory(self, snapshot_id, subdir):
 
         self._makeSite()
-        folder = self.tool.snapshots._getOb( snapshot_id )
+        folder = self.tool.snapshots._getOb(snapshot_id)
 
-        for element in subdir.split( '/' ):
+        for element in subdir.split('/'):
 
             try:
-                folder = folder._getOb( element )
+                folder = folder._getOb(element)
             except AttributeError:
-                folder._setObject( element, Folder( element ) )
-                folder = folder._getOb( element )
+                folder._setObject(element, Folder(element))
+                folder = folder._getOb(element)
 
         return folder
 
-    def _makeFile( self
-                 , snapshot_id
-                 , filename
-                 , contents
-                 , content_type='text/plain'
-                 , mod_time=None
-                 , subdir=None
-                 ):
+    def _makeFile(self, snapshot_id, filename, contents, content_type='text/plain', mod_time=None, subdir=None
+                  ):
 
         self._makeSite()
         snapshots = self.tool.snapshots
-        snapshot = snapshots._getOb( snapshot_id )
+        snapshot = snapshots._getOb(snapshot_id)
 
         if subdir is not None:
-            folder = self._makeDirectory( snapshot_id, subdir )
+            folder = self._makeDirectory(snapshot_id, subdir)
         else:
             folder = snapshot
 
-        file = File( filename, '', contents, content_type )
-        folder._setObject( filename, file )
+        file = File(filename, '', contents, content_type)
+        folder._setObject(filename, file)
 
         if mod_time is not None:
             folder._faux_mod_time = file._faux_mod_time = mod_time
 
-        return folder._getOb( filename )
+        return folder._getOb(filename)
 
-    def test_compare_empties( self ):
+    def test_compare_empties(self):
 
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
 
-        cd = self._makeOne( lhs, rhs )
-
-        diffs = cd.compare()
-
-        self.assertEqual( diffs, '' )
-
-    def test_compare_identical( self ):
-
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
-
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF' )
-        self._makeFile( 'lhs', 'again.txt', 'GHIJKL', subdir='sub' )
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF' )
-        self._makeFile( 'rhs', 'again.txt', 'GHIJKL', subdir='sub' )
-
-        cd = self._makeOne( lhs, rhs )
+        cd = self._makeOne(lhs, rhs)
 
         diffs = cd.compare()
 
-        self.assertEqual( diffs, '' )
+        self.assertEqual(diffs, '')
 
-    def test_compare_changed_file( self ):
+    def test_compare_identical(self):
 
-        BEFORE = DateTime( '2004-01-01T00:00:00Z' )
-        AFTER = DateTime( '2004-02-29T23:59:59Z' )
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
 
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
+        self._makeFile('lhs', 'test.txt', 'ABCDEF')
+        self._makeFile('lhs', 'again.txt', 'GHIJKL', subdir='sub')
+        self._makeFile('rhs', 'test.txt', 'ABCDEF')
+        self._makeFile('rhs', 'again.txt', 'GHIJKL', subdir='sub')
 
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF\nWXYZ', mod_time=BEFORE )
-        self._makeFile( 'lhs', 'again.txt', 'GHIJKL', subdir='sub' )
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF\nQRST', mod_time=AFTER )
-        self._makeFile( 'rhs', 'again.txt', 'GHIJKL', subdir='sub' )
-
-        cd = self._makeOne( lhs, rhs )
+        cd = self._makeOne(lhs, rhs)
 
         diffs = cd.compare()
 
-        if PYTHON27:
-            self.assertEqual( diffs, TEST_TXT_DIFFS_27 % ( BEFORE, AFTER ) )
-        else:
-            self.assertEqual( diffs, TEST_TXT_DIFFS % ( BEFORE, AFTER ) )
+        self.assertEqual(diffs, '')
 
-    def test_compare_changed_file_ignore_blanks( self ):
+    def test_compare_changed_file(self):
 
-        BEFORE = DateTime( '2004-01-01T00:00:00Z' )
-        AFTER = DateTime( '2004-02-29T23:59:59Z' )
+        BEFORE = DateTime('2004-01-01T00:00:00Z')
+        AFTER = DateTime('2004-02-29T23:59:59Z')
 
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
 
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF\nWXYZ', mod_time=BEFORE )
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF\n\n\nWXYZ', mod_time=AFTER )
+        self._makeFile('lhs', 'test.txt', 'ABCDEF\nWXYZ', mod_time=BEFORE)
+        self._makeFile('lhs', 'again.txt', 'GHIJKL', subdir='sub')
+        self._makeFile('rhs', 'test.txt', 'ABCDEF\nQRST', mod_time=AFTER)
+        self._makeFile('rhs', 'again.txt', 'GHIJKL', subdir='sub')
 
-        cd = self._makeOne( lhs, rhs, ignore_blanks=True )
-
-        diffs = cd.compare()
-
-        self.assertEqual( diffs, '' )
-
-    def test_compare_changed_file_explicit_skip( self ):
-
-        BEFORE = DateTime( '2004-01-01T00:00:00Z' )
-        AFTER = DateTime( '2004-02-29T23:59:59Z' )
-
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
-
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF\nWXYZ', subdir='skipme'
-                      , mod_time=BEFORE )
-        self._makeFile( 'lhs', 'again.txt', 'GHIJKL', subdir='sub' )
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF\nQRST', subdir='skipme'
-                      , mod_time=AFTER )
-        self._makeFile( 'rhs', 'again.txt', 'GHIJKL', subdir='sub' )
-
-        cd = self._makeOne( lhs, rhs, skip=[ 'skipme' ] )
-
-        diffs = cd.compare()
-
-        self.assertEqual( diffs, '' )
-
-    def test_compare_changed_file_implicit_skip( self ):
-
-        BEFORE = DateTime( '2004-01-01T00:00:00Z' )
-        AFTER = DateTime( '2004-02-29T23:59:59Z' )
-
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
-
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF\nWXYZ', subdir='CVS'
-                      , mod_time=BEFORE )
-        self._makeFile( 'lhs', 'again.txt', 'GHIJKL', subdir='.svn'
-                      , mod_time=BEFORE )
-
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF\nQRST', subdir='CVS'
-                      , mod_time=AFTER )
-        self._makeFile( 'rhs', 'again.txt', 'MNOPQR', subdir='.svn'
-                      , mod_time=AFTER )
-
-        cd = self._makeOne( lhs, rhs )
-
-        diffs = cd.compare()
-
-        self.assertEqual( diffs, '' )
-
-    def test_compare_added_file_no_missing_as_empty( self ):
-
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
-
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF\nWXYZ' )
-        self._makeDirectory( 'lhs', subdir='sub' )
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF\nWXYZ' )
-        self._makeFile( 'rhs', 'again.txt', 'GHIJKL', subdir='sub' )
-
-        cd = self._makeOne( lhs, rhs )
-
-        diffs = cd.compare()
-
-        self.assertEqual( diffs, ADDED_FILE_DIFFS_NO_MAE )
-
-    def test_compare_added_file_missing_as_empty( self ):
-
-        AFTER = DateTime( '2004-02-29T23:59:59Z' )
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
-
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF\nWXYZ' )
-        self._makeDirectory( 'lhs', subdir='sub' )
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF\nWXYZ' )
-        self._makeFile( 'rhs', 'again.txt', 'GHIJKL', subdir='sub'
-                      , mod_time=AFTER )
-
-        cd = self._makeOne( lhs, rhs, missing_as_empty=True )
+        cd = self._makeOne(lhs, rhs)
 
         diffs = cd.compare()
 
         if PYTHON27:
-            self.assertEqual( diffs, ADDED_FILE_DIFFS_MAE_27 % AFTER )
+            self.assertEqual(diffs, TEST_TXT_DIFFS_27 % (BEFORE, AFTER))
         else:
-            self.assertEqual( diffs, ADDED_FILE_DIFFS_MAE % AFTER )
+            self.assertEqual(diffs, TEST_TXT_DIFFS % (BEFORE, AFTER))
 
-    def test_compare_removed_file_no_missing_as_empty( self ):
+    def test_compare_changed_file_ignore_blanks(self):
 
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
+        BEFORE = DateTime('2004-01-01T00:00:00Z')
+        AFTER = DateTime('2004-02-29T23:59:59Z')
 
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF\nWXYZ' )
-        self._makeFile( 'lhs', 'again.txt', 'GHIJKL', subdir='sub' )
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF\nWXYZ' )
-        self._makeDirectory( 'rhs', subdir='sub' )
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
 
-        cd = self._makeOne( lhs, rhs )
+        self._makeFile('lhs', 'test.txt', 'ABCDEF\nWXYZ', mod_time=BEFORE)
+        self._makeFile('rhs', 'test.txt', 'ABCDEF\n\n\nWXYZ', mod_time=AFTER)
+
+        cd = self._makeOne(lhs, rhs, ignore_blanks=True)
 
         diffs = cd.compare()
 
-        self.assertEqual( diffs, REMOVED_FILE_DIFFS_NO_MAE )
+        self.assertEqual(diffs, '')
 
-    def test_compare_removed_file_missing_as_empty( self ):
+    def test_compare_changed_file_explicit_skip(self):
 
-        BEFORE = DateTime( '2004-01-01T00:00:00Z' )
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
+        BEFORE = DateTime('2004-01-01T00:00:00Z')
+        AFTER = DateTime('2004-02-29T23:59:59Z')
 
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF\nWXYZ' )
-        self._makeFile( 'lhs', 'again.txt', 'GHIJKL', subdir='sub'
-                      , mod_time=BEFORE )
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF\nWXYZ' )
-        self._makeDirectory( 'rhs', subdir='sub' )
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
 
-        cd = self._makeOne( lhs, rhs, missing_as_empty=True )
+        self._makeFile(
+            'lhs',
+            'test.txt',
+            'ABCDEF\nWXYZ',
+            subdir='skipme',
+            mod_time=BEFORE)
+        self._makeFile('lhs', 'again.txt', 'GHIJKL', subdir='sub')
+        self._makeFile(
+            'rhs',
+            'test.txt',
+            'ABCDEF\nQRST',
+            subdir='skipme',
+            mod_time=AFTER)
+        self._makeFile('rhs', 'again.txt', 'GHIJKL', subdir='sub')
+
+        cd = self._makeOne(lhs, rhs, skip=['skipme'])
+
+        diffs = cd.compare()
+
+        self.assertEqual(diffs, '')
+
+    def test_compare_changed_file_implicit_skip(self):
+
+        BEFORE = DateTime('2004-01-01T00:00:00Z')
+        AFTER = DateTime('2004-02-29T23:59:59Z')
+
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
+
+        self._makeFile(
+            'lhs',
+            'test.txt',
+            'ABCDEF\nWXYZ',
+            subdir='CVS',
+            mod_time=BEFORE)
+        self._makeFile(
+            'lhs',
+            'again.txt',
+            'GHIJKL',
+            subdir='.svn',
+            mod_time=BEFORE)
+
+        self._makeFile(
+            'rhs',
+            'test.txt',
+            'ABCDEF\nQRST',
+            subdir='CVS',
+            mod_time=AFTER)
+        self._makeFile(
+            'rhs',
+            'again.txt',
+            'MNOPQR',
+            subdir='.svn',
+            mod_time=AFTER)
+
+        cd = self._makeOne(lhs, rhs)
+
+        diffs = cd.compare()
+
+        self.assertEqual(diffs, '')
+
+    def test_compare_added_file_no_missing_as_empty(self):
+
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
+
+        self._makeFile('lhs', 'test.txt', 'ABCDEF\nWXYZ')
+        self._makeDirectory('lhs', subdir='sub')
+        self._makeFile('rhs', 'test.txt', 'ABCDEF\nWXYZ')
+        self._makeFile('rhs', 'again.txt', 'GHIJKL', subdir='sub')
+
+        cd = self._makeOne(lhs, rhs)
+
+        diffs = cd.compare()
+
+        self.assertEqual(diffs, ADDED_FILE_DIFFS_NO_MAE)
+
+    def test_compare_added_file_missing_as_empty(self):
+
+        AFTER = DateTime('2004-02-29T23:59:59Z')
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
+
+        self._makeFile('lhs', 'test.txt', 'ABCDEF\nWXYZ')
+        self._makeDirectory('lhs', subdir='sub')
+        self._makeFile('rhs', 'test.txt', 'ABCDEF\nWXYZ')
+        self._makeFile(
+            'rhs',
+            'again.txt',
+            'GHIJKL',
+            subdir='sub',
+            mod_time=AFTER)
+
+        cd = self._makeOne(lhs, rhs, missing_as_empty=True)
 
         diffs = cd.compare()
 
         if PYTHON27:
-            self.assertEqual( diffs, REMOVED_FILE_DIFFS_MAE_27 % BEFORE )
+            self.assertEqual(diffs, ADDED_FILE_DIFFS_MAE_27 % AFTER)
         else:
-            self.assertEqual( diffs, REMOVED_FILE_DIFFS_MAE % BEFORE )
+            self.assertEqual(diffs, ADDED_FILE_DIFFS_MAE % AFTER)
+
+    def test_compare_removed_file_no_missing_as_empty(self):
+
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
+
+        self._makeFile('lhs', 'test.txt', 'ABCDEF\nWXYZ')
+        self._makeFile('lhs', 'again.txt', 'GHIJKL', subdir='sub')
+        self._makeFile('rhs', 'test.txt', 'ABCDEF\nWXYZ')
+        self._makeDirectory('rhs', subdir='sub')
+
+        cd = self._makeOne(lhs, rhs)
+
+        diffs = cd.compare()
+
+        self.assertEqual(diffs, REMOVED_FILE_DIFFS_NO_MAE)
+
+    def test_compare_removed_file_missing_as_empty(self):
+
+        BEFORE = DateTime('2004-01-01T00:00:00Z')
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
+
+        self._makeFile('lhs', 'test.txt', 'ABCDEF\nWXYZ')
+        self._makeFile(
+            'lhs',
+            'again.txt',
+            'GHIJKL',
+            subdir='sub',
+            mod_time=BEFORE)
+        self._makeFile('rhs', 'test.txt', 'ABCDEF\nWXYZ')
+        self._makeDirectory('rhs', subdir='sub')
+
+        cd = self._makeOne(lhs, rhs, missing_as_empty=True)
+
+        diffs = cd.compare()
+
+        if PYTHON27:
+            self.assertEqual(diffs, REMOVED_FILE_DIFFS_MAE_27 % BEFORE)
+        else:
+            self.assertEqual(diffs, REMOVED_FILE_DIFFS_MAE % BEFORE)
 
 
 TEST_TXT_DIFFS = """\
@@ -455,4 +479,4 @@ def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(Test_unidiff),
         unittest.makeSuite(ConfigDiffTests),
-        ))
+    ))

--- a/Products/GenericSetup/tests/test_events.py
+++ b/Products/GenericSetup/tests/test_events.py
@@ -5,13 +5,14 @@ from Products.GenericSetup.interfaces import IBeforeProfileImportEvent
 from Products.GenericSetup.events import ProfileImportedEvent
 from Products.GenericSetup.interfaces import IProfileImportedEvent
 
+
 class BaseEventTests:
     def testInterface(self):
-        event=self.klass("tool", "profile_id", "steps", "full_import")
+        event = self.klass("tool", "profile_id", "steps", "full_import")
         verifyObject(self.iface, event)
 
     def testNormalConstruction(self):
-        event=self.klass("tool", "profile_id", "steps", "full_import")
+        event = self.klass("tool", "profile_id", "steps", "full_import")
         self.assertEqual(event.tool, "tool")
         self.assertEqual(event.profile_id, "profile_id")
         self.assertEqual(event.steps, "steps")
@@ -41,4 +42,3 @@ def test_suite():
     suite.addTest(unittest.makeSuite(BeforeProfileImportEventTests))
     suite.addTest(unittest.makeSuite(ProfileImportedEventTests))
     return suite
-

--- a/Products/GenericSetup/tests/test_profile_metadata.py
+++ b/Products/GenericSetup/tests/test_profile_metadata.py
@@ -40,7 +40,7 @@ _METADATA_MAP = {
     'description': desc,
     'version': version,
     'dependencies': (dep1, dep2),
-    }
+}
 
 _METADATA_EMPTY_DEPENDENCIES_XML = """<?xml version="1.0"?>
 <metadata>
@@ -54,15 +54,16 @@ _METADATA_MAP_EMPTY_DEPENDENCIES = {
     'description': desc,
     'version': version,
     'dependencies': (),
-    }
+}
 
-class ProfileMetadataTests( ZopeTestCase ):
+
+class ProfileMetadataTests(ZopeTestCase):
 
     installProduct('GenericSetup')
 
     def test_parseXML(self):
-        metadata = ProfileMetadata( '' )
-        parsed = metadata.parseXML( _METADATA_XML )
+        metadata = ProfileMetadata('')
+        parsed = metadata.parseXML(_METADATA_XML)
         self.assertEqual(parsed, _METADATA_MAP)
 
     def test_relativePath(self):
@@ -78,11 +79,12 @@ class ProfileMetadataTests( ZopeTestCase ):
 
     def test_parseXML_empty_dependencies(self):
         # https://bugs.launchpad.net/bugs/255301
-        metadata = ProfileMetadata( '')
+        metadata = ProfileMetadata('')
         parsed = metadata.parseXML(_METADATA_EMPTY_DEPENDENCIES_XML)
         self.assertEqual(parsed, _METADATA_MAP_EMPTY_DEPENDENCIES)
 
+
 def test_suite():
     return unittest.TestSuite((
-        unittest.makeSuite( ProfileMetadataTests ),
-        ))
+        unittest.makeSuite(ProfileMetadataTests),
+    ))

--- a/Products/GenericSetup/tests/test_registry.py
+++ b/Products/GenericSetup/tests/test_registry.py
@@ -28,19 +28,23 @@ from conformance import ConformsToIToolsetRegistry
 from conformance import ConformsToIProfileRegistry
 
 
-#==============================================================================
+# =============================================================================
 #   Dummy handlers
-#==============================================================================
-def ONE_FUNC(context): pass
+# =============================================================================
+def ONE_FUNC(context):
+    pass
 
 
-def TWO_FUNC(context): pass
+def TWO_FUNC(context):
+    pass
 
 
-def THREE_FUNC(context): pass
+def THREE_FUNC(context):
+    pass
 
 
-def FOUR_FUNC(context): pass
+def FOUR_FUNC(context):
+    pass
 
 
 def DOC_FUNC(site):
@@ -55,9 +59,9 @@ THREE_FUNC_NAME = '%s.%s' % (__name__, THREE_FUNC.__name__)
 FOUR_FUNC_NAME = '%s.%s' % (__name__, FOUR_FUNC.__name__)
 DOC_FUNC_NAME = '%s.%s' % (__name__, DOC_FUNC.__name__)
 
-#==============================================================================
+# =============================================================================
 #   SSR tests
-#==============================================================================
+# =============================================================================
 
 
 class ImportStepRegistryTests(BaseRegistryTests, ConformsToIStepRegistry, ConformsToIImportStepRegistry
@@ -419,7 +423,7 @@ _SINGLE_IMPORT_XML = """\
   One small step
  </import-step>
 </import-steps>
-""" % ( ONE_FUNC_NAME, )
+""" % (ONE_FUNC_NAME)
 
 _ORDERED_IMPORT_XML = """\
 <?xml version="1.0"?>
@@ -445,11 +449,11 @@ _ORDERED_IMPORT_XML = """\
   Texas two step
  </import-step>
 </import-steps>
-""" % ( ONE_FUNC_NAME, THREE_FUNC_NAME, TWO_FUNC_NAME )
+""" % (ONE_FUNC_NAME, THREE_FUNC_NAME, TWO_FUNC_NAME)
 
-#==============================================================================
+# =============================================================================
 #   ESR tests
-#==============================================================================
+# =============================================================================
 
 
 class ExportStepRegistryTests(BaseRegistryTests, ConformsToIStepRegistry, ConformsToIExportStepRegistry
@@ -480,7 +484,8 @@ class ExportStepRegistryTests(BaseRegistryTests, ConformsToIStepRegistry, Confor
     def test_getStep_defaulted(self):
 
         registry = self._makeOne()
-        default = lambda x: False
+        def default(x):
+            return False
         self.assertEqual(registry.getStep('nonesuch', default), default)
 
     def test_getStepMetadata_nonesuch(self):
@@ -629,7 +634,7 @@ _SINGLE_EXPORT_XML = """\
   One small step
  </export-step>
 </export-steps>
-""" % ( ONE_FUNC_NAME, )
+""" % (ONE_FUNC_NAME)
 
 _ORDERED_EXPORT_XML = """\
 <?xml version="1.0"?>
@@ -650,11 +655,11 @@ _ORDERED_EXPORT_XML = """\
   Texas two step
  </export-step>
 </export-steps>
-""" % ( ONE_FUNC_NAME, THREE_FUNC_NAME, TWO_FUNC_NAME )
+""" % (ONE_FUNC_NAME, THREE_FUNC_NAME, TWO_FUNC_NAME)
 
-#==============================================================================
+# =============================================================================
 #   ToolsetRegistry tests
-#==============================================================================
+# =============================================================================
 
 
 class ToolsetRegistryTests(BaseRegistryTests, ConformsToIToolsetRegistry

--- a/Products/GenericSetup/tests/test_registry.py
+++ b/Products/GenericSetup/tests/test_registry.py
@@ -31,497 +31,376 @@ from conformance import ConformsToIProfileRegistry
 #==============================================================================
 #   Dummy handlers
 #==============================================================================
-def ONE_FUNC( context ): pass
-def TWO_FUNC( context ): pass
-def THREE_FUNC( context ): pass
-def FOUR_FUNC( context ): pass
-def DOC_FUNC( site ):
+def ONE_FUNC(context): pass
+
+
+def TWO_FUNC(context): pass
+
+
+def THREE_FUNC(context): pass
+
+
+def FOUR_FUNC(context): pass
+
+
+def DOC_FUNC(site):
     """This is the first line.
 
     This is the second line.
     """
 
-ONE_FUNC_NAME = '%s.%s' % ( __name__, ONE_FUNC.__name__ )
-TWO_FUNC_NAME = '%s.%s' % ( __name__, TWO_FUNC.__name__ )
-THREE_FUNC_NAME = '%s.%s' % ( __name__, THREE_FUNC.__name__ )
-FOUR_FUNC_NAME = '%s.%s' % ( __name__, FOUR_FUNC.__name__ )
-DOC_FUNC_NAME = '%s.%s' % ( __name__, DOC_FUNC.__name__ )
+ONE_FUNC_NAME = '%s.%s' % (__name__, ONE_FUNC.__name__)
+TWO_FUNC_NAME = '%s.%s' % (__name__, TWO_FUNC.__name__)
+THREE_FUNC_NAME = '%s.%s' % (__name__, THREE_FUNC.__name__)
+FOUR_FUNC_NAME = '%s.%s' % (__name__, FOUR_FUNC.__name__)
+DOC_FUNC_NAME = '%s.%s' % (__name__, DOC_FUNC.__name__)
 
 #==============================================================================
 #   SSR tests
 #==============================================================================
-class ImportStepRegistryTests( BaseRegistryTests
-                             , ConformsToIStepRegistry
-                             , ConformsToIImportStepRegistry
-                             ):
+
+
+class ImportStepRegistryTests(BaseRegistryTests, ConformsToIStepRegistry, ConformsToIImportStepRegistry
+                              ):
 
     layer = ExportImportZCMLLayer
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.registry import ImportStepRegistry
         return ImportStepRegistry
 
-    def test_empty( self ):
+    def test_empty(self):
 
         registry = self._makeOne()
 
-        self.assertEqual( len( registry.listSteps() ), 0 )
-        self.assertEqual( len( registry.listStepMetadata() ), 0 )
-        self.assertEqual( len( registry.sortSteps() ), 0 )
+        self.assertEqual(len(registry.listSteps()), 0)
+        self.assertEqual(len(registry.listStepMetadata()), 0)
+        self.assertEqual(len(registry.sortSteps()), 0)
 
-    def test_getStep_nonesuch( self ):
+    def test_getStep_nonesuch(self):
 
         registry = self._makeOne()
 
-        self.assertEqual( registry.getStep( 'nonesuch' ), None )
-        self.assertEqual( registry.getStep( 'nonesuch' ), None )
+        self.assertEqual(registry.getStep('nonesuch'), None)
+        self.assertEqual(registry.getStep('nonesuch'), None)
         default = object()
-        self.failUnless( registry.getStepMetadata( 'nonesuch'
-                                                 , default ) is default )
-        self.failUnless( registry.getStep( 'nonesuch', default ) is default )
-        self.failUnless( registry.getStepMetadata( 'nonesuch'
-                                                 , default ) is default )
+        self.failUnless(
+            registry.getStepMetadata(
+                'nonesuch',
+                default) is default)
+        self.failUnless(registry.getStep('nonesuch', default) is default)
+        self.failUnless(
+            registry.getStepMetadata(
+                'nonesuch',
+                default) is default)
 
-    def test_getStep_defaulted( self ):
+    def test_getStep_defaulted(self):
 
         registry = self._makeOne()
         default = object()
 
-        self.failUnless( registry.getStep( 'nonesuch', default ) is default )
-        self.assertEqual( registry.getStepMetadata( 'nonesuch', {} ), {} )
+        self.failUnless(registry.getStep('nonesuch', default) is default)
+        self.assertEqual(registry.getStepMetadata('nonesuch', {}), {})
 
-    def test_registerStep_docstring( self ):
-
-        registry = self._makeOne()
-
-        registry.registerStep( id='docstring'
-                             , version='1'
-                             , handler=DOC_FUNC
-                             , dependencies=()
-                             )
-
-        info = registry.getStepMetadata( 'docstring' )
-        self.assertEqual( info[ 'id' ], 'docstring' )
-        self.assertEqual( info[ 'handler' ], DOC_FUNC_NAME )
-        self.assertEqual( info[ 'dependencies' ], () )
-        self.assertEqual( info[ 'title' ], 'This is the first line.' )
-        self.assertEqual( info[ 'description' ] , 'This is the second line.' )
-
-    def test_registerStep_docstring_override( self ):
+    def test_registerStep_docstring(self):
 
         registry = self._makeOne()
 
-        registry.registerStep( id='docstring'
-                             , version='1'
-                             , handler=DOC_FUNC
-                             , dependencies=()
-                             , title='Title'
-                             )
+        registry.registerStep(id='docstring', version='1', handler=DOC_FUNC, dependencies=()
+                              )
 
-        info = registry.getStepMetadata( 'docstring' )
-        self.assertEqual( info[ 'id' ], 'docstring' )
-        self.assertEqual( info[ 'handler' ], DOC_FUNC_NAME )
-        self.assertEqual( info[ 'dependencies' ], () )
-        self.assertEqual( info[ 'title' ], 'Title' )
-        self.assertEqual( info[ 'description' ] , 'This is the second line.' )
+        info = registry.getStepMetadata('docstring')
+        self.assertEqual(info['id'], 'docstring')
+        self.assertEqual(info['handler'], DOC_FUNC_NAME)
+        self.assertEqual(info['dependencies'], ())
+        self.assertEqual(info['title'], 'This is the first line.')
+        self.assertEqual(info['description'], 'This is the second line.')
 
-    def test_registerStep_single( self ):
+    def test_registerStep_docstring_override(self):
 
         registry = self._makeOne()
 
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'two', 'three' )
-                             , title='One Step'
-                             , description='One small step'
-                             )
+        registry.registerStep(id='docstring', version='1', handler=DOC_FUNC, dependencies=(), title='Title'
+                              )
+
+        info = registry.getStepMetadata('docstring')
+        self.assertEqual(info['id'], 'docstring')
+        self.assertEqual(info['handler'], DOC_FUNC_NAME)
+        self.assertEqual(info['dependencies'], ())
+        self.assertEqual(info['title'], 'Title')
+        self.assertEqual(info['description'], 'This is the second line.')
+
+    def test_registerStep_single(self):
+
+        registry = self._makeOne()
+
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('two', 'three'), title='One Step', description='One small step'
+                              )
 
         steps = registry.listSteps()
-        self.assertEqual( len( steps ), 1 )
-        self.failUnless( 'one' in steps )
-        self.assertEqual( registry.getStep( 'one' ), ONE_FUNC )
+        self.assertEqual(len(steps), 1)
+        self.failUnless('one' in steps)
+        self.assertEqual(registry.getStep('one'), ONE_FUNC)
 
-        info = registry.getStepMetadata( 'one' )
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'version' ], '1' )
-        self.assertEqual( info[ 'handler' ], ONE_FUNC_NAME )
-        self.assertEqual( info[ 'dependencies' ], ( 'two', 'three' ) )
-        self.assertEqual( info[ 'title' ], 'One Step' )
-        self.assertEqual( info[ 'description' ], 'One small step' )
-
-        info_list = registry.listStepMetadata()
-        self.assertEqual( len( info_list ), 1 )
-        self.assertEqual( info, info_list[ 0 ] )
-
-    def test_registerStep_conflict( self ):
-
-        registry = self._makeOne()
-
-        registry.registerStep( id='one', version='1', handler=ONE_FUNC_NAME )
-
-        self.assertRaises( KeyError
-                         , registry.registerStep
-                         , id='one'
-                         , version='0'
-                         , handler=ONE_FUNC
-                         )
-
-        registry.registerStep( id='one', version='1', handler=ONE_FUNC_NAME )
+        info = registry.getStepMetadata('one')
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['version'], '1')
+        self.assertEqual(info['handler'], ONE_FUNC_NAME)
+        self.assertEqual(info['dependencies'], ('two', 'three'))
+        self.assertEqual(info['title'], 'One Step')
+        self.assertEqual(info['description'], 'One small step')
 
         info_list = registry.listStepMetadata()
-        self.assertEqual( len( info_list ), 1 )
+        self.assertEqual(len(info_list), 1)
+        self.assertEqual(info, info_list[0])
 
-    def test_registerStep_replacement( self ):
-
-        registry = self._makeOne()
-
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'two', 'three' )
-                             , title='One Step'
-                             , description='One small step'
-                             )
-
-        registry.registerStep( id='one'
-                             , version='1.1'
-                             , handler=ONE_FUNC
-                             , dependencies=()
-                             , title='Leads to Another'
-                             , description='Another small step'
-                             )
-
-        info = registry.getStepMetadata( 'one' )
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'version' ], '1.1' )
-        self.assertEqual( info[ 'dependencies' ], () )
-        self.assertEqual( info[ 'title' ], 'Leads to Another' )
-        self.assertEqual( info[ 'description' ], 'Another small step' )
-
-    def test_registerStep_multiple( self ):
+    def test_registerStep_conflict(self):
 
         registry = self._makeOne()
 
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=()
-                             )
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC_NAME)
 
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=()
-                             )
+        self.assertRaises(KeyError, registry.registerStep, id='one', version='0', handler=ONE_FUNC
+                          )
 
-        registry.registerStep( id='three'
-                             , version='3'
-                             , handler=THREE_FUNC
-                             , dependencies=()
-                             )
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC_NAME)
+
+        info_list = registry.listStepMetadata()
+        self.assertEqual(len(info_list), 1)
+
+    def test_registerStep_replacement(self):
+
+        registry = self._makeOne()
+
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('two', 'three'), title='One Step', description='One small step'
+                              )
+
+        registry.registerStep(id='one', version='1.1', handler=ONE_FUNC, dependencies=(), title='Leads to Another', description='Another small step'
+                              )
+
+        info = registry.getStepMetadata('one')
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['version'], '1.1')
+        self.assertEqual(info['dependencies'], ())
+        self.assertEqual(info['title'], 'Leads to Another')
+        self.assertEqual(info['description'], 'Another small step')
+
+    def test_registerStep_multiple(self):
+
+        registry = self._makeOne()
+
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=()
+                              )
+
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=()
+                              )
+
+        registry.registerStep(id='three', version='3', handler=THREE_FUNC, dependencies=()
+                              )
 
         steps = registry.listSteps()
-        self.assertEqual( len( steps ), 3 )
-        self.failUnless( 'one' in steps )
-        self.failUnless( 'two' in steps )
-        self.failUnless( 'three' in steps )
+        self.assertEqual(len(steps), 3)
+        self.failUnless('one' in steps)
+        self.failUnless('two' in steps)
+        self.failUnless('three' in steps)
 
-    def test_sortStep_simple( self ):
+    def test_sortStep_simple(self):
 
         registry = self._makeOne()
 
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'two', )
-                             )
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('two', )
+                              )
 
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=()
-                             )
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=()
+                              )
 
         steps = registry.sortSteps()
-        self.assertEqual( len( steps ), 2 )
-        one = steps.index( 'one' )
-        two = steps.index( 'two' )
+        self.assertEqual(len(steps), 2)
+        one = steps.index('one')
+        two = steps.index('two')
 
-        self.failUnless( 0 <= two < one )
+        self.failUnless(0 <= two < one)
 
-    def test_sortStep_chained( self ):
-
-        registry = self._makeOne()
-
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'three', )
-                             , title='One small step'
-                             )
-
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=( 'one', )
-                             , title='Texas two step'
-                             )
-
-        registry.registerStep( id='three'
-                             , version='3'
-                             , handler=THREE_FUNC
-                             , dependencies=()
-                             , title='Gimme three steps'
-                             )
-       
-        steps = registry.sortSteps()
-        self.assertEqual( len( steps ), 3 )
-        one = steps.index( 'one' )
-        two = steps.index( 'two' )
-        three = steps.index( 'three' )
-
-        self.failUnless( 0 <= three < one < two )
-
-
-    def test_sortStep_complex( self ):
+    def test_sortStep_chained(self):
 
         registry = self._makeOne()
 
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'two', )
-                             , title='One small step'
-                             )
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('three', ), title='One small step'
+                              )
 
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=( 'four', )
-                             , title='Texas two step'
-                             )
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=('one', ), title='Texas two step'
+                              )
 
-        registry.registerStep( id='three'
-                             , version='3'
-                             , handler=THREE_FUNC
-                             , dependencies=( 'four', )
-                             , title='Gimme three steps'
-                             )
-
-        registry.registerStep( id='four'
-                             , version='4'
-                             , handler=FOUR_FUNC
-                             , dependencies=()
-                             , title='Four step program'
-                             )
+        registry.registerStep(id='three', version='3', handler=THREE_FUNC, dependencies=(), title='Gimme three steps'
+                              )
 
         steps = registry.sortSteps()
-        self.assertEqual( len( steps ), 4 )
-        one = steps.index( 'one' )
-        two = steps.index( 'two' )
-        three = steps.index( 'three' )
-        four = steps.index( 'four' )
+        self.assertEqual(len(steps), 3)
+        one = steps.index('one')
+        two = steps.index('two')
+        three = steps.index('three')
 
-        self.failUnless( 0 <= four < two < one )
-        self.failUnless( 0 <= four < three )
+        self.failUnless(0 <= three < one < two)
 
-    def test_sortStep_equivalence( self ):
+    def test_sortStep_complex(self):
 
         registry = self._makeOne()
 
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'two', 'three' )
-                             , title='One small step'
-                             )
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('two', ), title='One small step'
+                              )
 
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=( 'four', )
-                             , title='Texas two step'
-                             )
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=('four', ), title='Texas two step'
+                              )
 
-        registry.registerStep( id='three'
-                             , version='3'
-                             , handler=THREE_FUNC
-                             , dependencies=( 'four', )
-                             , title='Gimme three steps'
-                             )
+        registry.registerStep(id='three', version='3', handler=THREE_FUNC, dependencies=('four', ), title='Gimme three steps'
+                              )
 
-        registry.registerStep( id='four'
-                             , version='4'
-                             , handler=FOUR_FUNC
-                             , dependencies=()
-                             , title='Four step program'
-                             )
+        registry.registerStep(id='four', version='4', handler=FOUR_FUNC, dependencies=(), title='Four step program'
+                              )
 
         steps = registry.sortSteps()
-        self.assertEqual( len( steps ), 4 )
-        one = steps.index( 'one' )
-        two = steps.index( 'two' )
-        three = steps.index( 'three' )
-        four = steps.index( 'four' )
+        self.assertEqual(len(steps), 4)
+        one = steps.index('one')
+        two = steps.index('two')
+        three = steps.index('three')
+        four = steps.index('four')
 
-        self.failUnless( 0 <= four < two < one )
-        self.failUnless( 0 <= four < three < one )
+        self.failUnless(0 <= four < two < one)
+        self.failUnless(0 <= four < three)
 
-    def test_checkComplete_simple( self ):
-
-        registry = self._makeOne()
-
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'two', )
-                             )
-
-        incomplete = registry.checkComplete()
-        self.assertEqual( len( incomplete ), 1 )
-        self.failUnless( ( 'one', 'two' ) in incomplete )
-
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=()
-                             )
-
-        self.assertEqual( len( registry.checkComplete() ), 0 )
-
-    def test_checkComplete_double( self ):
+    def test_sortStep_equivalence(self):
 
         registry = self._makeOne()
 
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'two', 'three' )
-                             )
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('two', 'three'), title='One small step'
+                              )
+
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=('four', ), title='Texas two step'
+                              )
+
+        registry.registerStep(id='three', version='3', handler=THREE_FUNC, dependencies=('four', ), title='Gimme three steps'
+                              )
+
+        registry.registerStep(id='four', version='4', handler=FOUR_FUNC, dependencies=(), title='Four step program'
+                              )
+
+        steps = registry.sortSteps()
+        self.assertEqual(len(steps), 4)
+        one = steps.index('one')
+        two = steps.index('two')
+        three = steps.index('three')
+        four = steps.index('four')
+
+        self.failUnless(0 <= four < two < one)
+        self.failUnless(0 <= four < three < one)
+
+    def test_checkComplete_simple(self):
+
+        registry = self._makeOne()
+
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('two', )
+                              )
 
         incomplete = registry.checkComplete()
-        self.assertEqual( len( incomplete ), 2 )
-        self.failUnless( ( 'one', 'two' ) in incomplete )
-        self.failUnless( ( 'one', 'three' ) in incomplete )
+        self.assertEqual(len(incomplete), 1)
+        self.failUnless(('one', 'two') in incomplete)
 
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=()
-                             )
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=()
+                              )
 
-        incomplete = registry.checkComplete()
-        self.assertEqual( len( incomplete ), 1 )
-        self.failUnless( ( 'one', 'three' ) in incomplete )
+        self.assertEqual(len(registry.checkComplete()), 0)
 
-        registry.registerStep( id='three'
-                             , version='3'
-                             , handler=THREE_FUNC
-                             , dependencies=()
-                             )
+    def test_checkComplete_double(self):
 
-        self.assertEqual( len( registry.checkComplete() ), 0 )
+        registry = self._makeOne()
 
-        registry.registerStep( id='two'
-                             , version='2.1'
-                             , handler=TWO_FUNC
-                             , dependencies=( 'four', )
-                             )
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('two', 'three')
+                              )
 
         incomplete = registry.checkComplete()
-        self.assertEqual( len( incomplete ), 1 )
-        self.failUnless( ( 'two', 'four' ) in incomplete )
+        self.assertEqual(len(incomplete), 2)
+        self.failUnless(('one', 'two') in incomplete)
+        self.failUnless(('one', 'three') in incomplete)
 
-    def test_generateXML_empty( self ):
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=()
+                              )
 
-        registry = self._makeOne().__of__(self.app)
+        incomplete = registry.checkComplete()
+        self.assertEqual(len(incomplete), 1)
+        self.failUnless(('one', 'three') in incomplete)
 
-        self._compareDOM( registry.generateXML(), _EMPTY_IMPORT_XML , debug=True)
+        registry.registerStep(id='three', version='3', handler=THREE_FUNC, dependencies=()
+                              )
 
-    def test_generateXML_single( self ):
+        self.assertEqual(len(registry.checkComplete()), 0)
 
-        registry = self._makeOne().__of__(self.app)
+        registry.registerStep(id='two', version='2.1', handler=TWO_FUNC, dependencies=('four', )
+                              )
 
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=()
-                             , title='One Step'
-                             , description='One small step'
-                             )
+        incomplete = registry.checkComplete()
+        self.assertEqual(len(incomplete), 1)
+        self.failUnless(('two', 'four') in incomplete)
 
-        self._compareDOM( registry.generateXML(), _SINGLE_IMPORT_XML )
-
-    def test_generateXML_ordered( self ):
-
-        registry = self._makeOne().__of__(self.app)
-
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'two', )
-                             , title='One Step'
-                             , description='One small step'
-                             )
-
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=( 'three', )
-                             , title='Two Steps'
-                             , description='Texas two step'
-                             )
-
-        registry.registerStep( id='three'
-                             , version='3'
-                             , handler=THREE_FUNC
-                             , dependencies=()
-                             , title='Three Steps'
-                             , description='Gimme three steps'
-                             )
-
-        self._compareDOM( registry.generateXML(), _ORDERED_IMPORT_XML )
-
-    def test_parseXML_empty( self ):
+    def test_generateXML_empty(self):
 
         registry = self._makeOne().__of__(self.app)
 
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=()
-                             , description='One small step'
-                             )
+        self._compareDOM(registry.generateXML(), _EMPTY_IMPORT_XML, debug=True)
 
-        info_list = registry.parseXML( _EMPTY_IMPORT_XML )
-
-        self.assertEqual( len( info_list ), 0 )
-
-    def test_parseXML_single( self ):
+    def test_generateXML_single(self):
 
         registry = self._makeOne().__of__(self.app)
 
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=()
-                             , title='Two Steps'
-                             , description='Texas two step'
-                             )
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=(), title='One Step', description='One small step'
+                              )
 
-        info_list = registry.parseXML( _SINGLE_IMPORT_XML )
+        self._compareDOM(registry.generateXML(), _SINGLE_IMPORT_XML)
 
-        self.assertEqual( len( info_list ), 1 )
+    def test_generateXML_ordered(self):
 
-        info = info_list[ 0 ]
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'version' ], '1' )
-        self.assertEqual( info[ 'handler' ], ONE_FUNC_NAME )
-        self.assertEqual( info[ 'dependencies' ], () )
-        self.assertEqual( info[ 'title' ], 'One Step' )
-        self.failUnless( 'One small step' in info[ 'description' ] )
+        registry = self._makeOne().__of__(self.app)
+
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('two', ), title='One Step', description='One small step'
+                              )
+
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=('three', ), title='Two Steps', description='Texas two step'
+                              )
+
+        registry.registerStep(id='three', version='3', handler=THREE_FUNC, dependencies=(), title='Three Steps', description='Gimme three steps'
+                              )
+
+        self._compareDOM(registry.generateXML(), _ORDERED_IMPORT_XML)
+
+    def test_parseXML_empty(self):
+
+        registry = self._makeOne().__of__(self.app)
+
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=(), description='One small step'
+                              )
+
+        info_list = registry.parseXML(_EMPTY_IMPORT_XML)
+
+        self.assertEqual(len(info_list), 0)
+
+    def test_parseXML_single(self):
+
+        registry = self._makeOne().__of__(self.app)
+
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=(), title='Two Steps', description='Texas two step'
+                              )
+
+        info_list = registry.parseXML(_SINGLE_IMPORT_XML)
+
+        self.assertEqual(len(info_list), 1)
+
+        info = info_list[0]
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['version'], '1')
+        self.assertEqual(info['handler'], ONE_FUNC_NAME)
+        self.assertEqual(info['dependencies'], ())
+        self.assertEqual(info['title'], 'One Step')
+        self.failUnless('One small step' in info['description'])
 
 
 _EMPTY_IMPORT_XML = """\
@@ -571,189 +450,168 @@ _ORDERED_IMPORT_XML = """\
 #==============================================================================
 #   ESR tests
 #==============================================================================
-class ExportStepRegistryTests( BaseRegistryTests
-                             , ConformsToIStepRegistry
-                             , ConformsToIExportStepRegistry
-                             ):
+
+
+class ExportStepRegistryTests(BaseRegistryTests, ConformsToIStepRegistry, ConformsToIExportStepRegistry
+                              ):
 
     layer = ExportImportZCMLLayer
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.registry import ExportStepRegistry
         return ExportStepRegistry
 
-    def _makeOne( self, *args, **kw ):
+    def _makeOne(self, *args, **kw):
 
-        return self._getTargetClass()( *args, **kw )
+        return self._getTargetClass()(*args, **kw)
 
-    def test_empty( self ):
-
-        registry = self._makeOne()
-        self.assertEqual( len( registry.listSteps() ), 0 )
-        self.assertEqual( len( registry.listStepMetadata() ), 0 )
-
-    def test_getStep_nonesuch( self ):
+    def test_empty(self):
 
         registry = self._makeOne()
-        self.assertEqual( registry.getStep( 'nonesuch' ), None )
+        self.assertEqual(len(registry.listSteps()), 0)
+        self.assertEqual(len(registry.listStepMetadata()), 0)
 
-    def test_getStep_defaulted( self ):
+    def test_getStep_nonesuch(self):
+
+        registry = self._makeOne()
+        self.assertEqual(registry.getStep('nonesuch'), None)
+
+    def test_getStep_defaulted(self):
 
         registry = self._makeOne()
         default = lambda x: False
-        self.assertEqual( registry.getStep( 'nonesuch', default ), default )
+        self.assertEqual(registry.getStep('nonesuch', default), default)
 
-    def test_getStepMetadata_nonesuch( self ):
-
-        registry = self._makeOne()
-        self.assertEqual( registry.getStepMetadata( 'nonesuch' ), None )
-
-    def test_getStepMetadata_defaulted( self ):
+    def test_getStepMetadata_nonesuch(self):
 
         registry = self._makeOne()
-        self.assertEqual( registry.getStepMetadata( 'nonesuch', {} ), {} )
+        self.assertEqual(registry.getStepMetadata('nonesuch'), None)
 
-    def test_registerStep_simple( self ):
-
-        registry = self._makeOne()
-        registry.registerStep( 'one', ONE_FUNC_NAME )
-        info = registry.getStepMetadata( 'one', {} )
-
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'handler' ], ONE_FUNC_NAME )
-        self.assertEqual( info[ 'title' ], 'one' )
-        self.assertEqual( info[ 'description' ], '' )
-
-    def test_registerStep_docstring( self ):
+    def test_getStepMetadata_defaulted(self):
 
         registry = self._makeOne()
-        registry.registerStep( 'one', DOC_FUNC )
-        info = registry.getStepMetadata( 'one', {} )
+        self.assertEqual(registry.getStepMetadata('nonesuch', {}), {})
 
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'handler' ], DOC_FUNC_NAME )
-        self.assertEqual( info[ 'title' ], 'This is the first line.' )
-        self.assertEqual( info[ 'description' ] , 'This is the second line.' )
-
-    def test_registerStep_docstring_with_override( self ):
+    def test_registerStep_simple(self):
 
         registry = self._makeOne()
-        registry.registerStep( 'one', DOC_FUNC
-                               , description='Description' )
-        info = registry.getStepMetadata( 'one', {} )
+        registry.registerStep('one', ONE_FUNC_NAME)
+        info = registry.getStepMetadata('one', {})
 
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'handler' ], DOC_FUNC_NAME )
-        self.assertEqual( info[ 'title' ], 'This is the first line.' )
-        self.assertEqual( info[ 'description' ], 'Description' )
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['handler'], ONE_FUNC_NAME)
+        self.assertEqual(info['title'], 'one')
+        self.assertEqual(info['description'], '')
 
-    def test_registerStep_collision( self ):
+    def test_registerStep_docstring(self):
 
         registry = self._makeOne()
-        registry.registerStep( 'one', ONE_FUNC )
-        registry.registerStep( 'one', TWO_FUNC )
-        info = registry.getStepMetadata( 'one', {} )
+        registry.registerStep('one', DOC_FUNC)
+        info = registry.getStepMetadata('one', {})
 
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'handler' ], TWO_FUNC_NAME )
-        self.assertEqual( info[ 'title' ], 'one' )
-        self.assertEqual( info[ 'description' ], '' )
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['handler'], DOC_FUNC_NAME)
+        self.assertEqual(info['title'], 'This is the first line.')
+        self.assertEqual(info['description'], 'This is the second line.')
 
-    def test_generateXML_empty( self ):
+    def test_registerStep_docstring_with_override(self):
+
+        registry = self._makeOne()
+        registry.registerStep('one', DOC_FUNC, description='Description')
+        info = registry.getStepMetadata('one', {})
+
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['handler'], DOC_FUNC_NAME)
+        self.assertEqual(info['title'], 'This is the first line.')
+        self.assertEqual(info['description'], 'Description')
+
+    def test_registerStep_collision(self):
+
+        registry = self._makeOne()
+        registry.registerStep('one', ONE_FUNC)
+        registry.registerStep('one', TWO_FUNC)
+        info = registry.getStepMetadata('one', {})
+
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['handler'], TWO_FUNC_NAME)
+        self.assertEqual(info['title'], 'one')
+        self.assertEqual(info['description'], '')
+
+    def test_generateXML_empty(self):
 
         registry = self._makeOne().__of__(self.app)
 
-        self._compareDOM( registry.generateXML(), _EMPTY_EXPORT_XML )
+        self._compareDOM(registry.generateXML(), _EMPTY_EXPORT_XML)
 
-    def test_generateXML_single( self ):
-
-        registry = self._makeOne().__of__(self.app)
-
-        registry.registerStep( id='one'
-                             , handler=ONE_FUNC
-                             , title='One Step'
-                             , description='One small step'
-                             )
-
-        self._compareDOM( registry.generateXML(), _SINGLE_EXPORT_XML )
-
-    def test_generateXML_ordered( self ):
+    def test_generateXML_single(self):
 
         registry = self._makeOne().__of__(self.app)
 
-        registry.registerStep( id='one'
-                             , handler=ONE_FUNC
-                             , title='One Step'
-                             , description='One small step'
-                             )
+        registry.registerStep(id='one', handler=ONE_FUNC, title='One Step', description='One small step'
+                              )
 
-        registry.registerStep( id='two'
-                             , handler=TWO_FUNC
-                             , title='Two Steps'
-                             , description='Texas two step'
-                             )
+        self._compareDOM(registry.generateXML(), _SINGLE_EXPORT_XML)
 
-        registry.registerStep( id='three'
-                             , handler=THREE_FUNC
-                             , title='Three Steps'
-                             , description='Gimme three steps'
-                             )
-
-        self._compareDOM( registry.generateXML(), _ORDERED_EXPORT_XML )
-
-    def test_parseXML_empty( self ):
+    def test_generateXML_ordered(self):
 
         registry = self._makeOne().__of__(self.app)
 
-        registry.registerStep( id='one'
-                             , handler=ONE_FUNC
-                             , description='One small step'
-                             )
+        registry.registerStep(id='one', handler=ONE_FUNC, title='One Step', description='One small step'
+                              )
 
-        info_list = registry.parseXML( _EMPTY_EXPORT_XML )
+        registry.registerStep(id='two', handler=TWO_FUNC, title='Two Steps', description='Texas two step'
+                              )
 
-        self.assertEqual( len( info_list ), 0 )
+        registry.registerStep(id='three', handler=THREE_FUNC, title='Three Steps', description='Gimme three steps'
+                              )
 
-    def test_parseXML_single( self ):
+        self._compareDOM(registry.generateXML(), _ORDERED_EXPORT_XML)
 
-        registry = self._makeOne().__of__(self.app)
-
-        registry.registerStep( id='two'
-                             , handler=TWO_FUNC
-                             , title='Two Steps'
-                             , description='Texas two step'
-                             )
-
-        info_list = registry.parseXML( _SINGLE_EXPORT_XML )
-
-        self.assertEqual( len( info_list ), 1 )
-
-        info = info_list[ 0 ]
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'handler' ], ONE_FUNC_NAME )
-        self.assertEqual( info[ 'title' ], 'One Step' )
-        self.failUnless( 'One small step' in info[ 'description' ] )
-
-    def test_parseXML_single_as_ascii( self ):
+    def test_parseXML_empty(self):
 
         registry = self._makeOne().__of__(self.app)
 
-        registry.registerStep( id='two'
-                             , handler=TWO_FUNC
-                             , title='Two Steps'
-                             , description='Texas two step'
-                             )
+        registry.registerStep(id='one', handler=ONE_FUNC, description='One small step'
+                              )
 
-        info_list = registry.parseXML( _SINGLE_EXPORT_XML, encoding='ascii' )
+        info_list = registry.parseXML(_EMPTY_EXPORT_XML)
 
-        self.assertEqual( len( info_list ), 1 )
+        self.assertEqual(len(info_list), 0)
 
-        info = info_list[ 0 ]
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'handler' ], ONE_FUNC_NAME )
-        self.assertEqual( info[ 'title' ], 'One Step' )
-        self.failUnless( 'One small step' in info[ 'description' ] )
+    def test_parseXML_single(self):
+
+        registry = self._makeOne().__of__(self.app)
+
+        registry.registerStep(id='two', handler=TWO_FUNC, title='Two Steps', description='Texas two step'
+                              )
+
+        info_list = registry.parseXML(_SINGLE_EXPORT_XML)
+
+        self.assertEqual(len(info_list), 1)
+
+        info = info_list[0]
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['handler'], ONE_FUNC_NAME)
+        self.assertEqual(info['title'], 'One Step')
+        self.failUnless('One small step' in info['description'])
+
+    def test_parseXML_single_as_ascii(self):
+
+        registry = self._makeOne().__of__(self.app)
+
+        registry.registerStep(id='two', handler=TWO_FUNC, title='Two Steps', description='Texas two step'
+                              )
+
+        info_list = registry.parseXML(_SINGLE_EXPORT_XML, encoding='ascii')
+
+        self.assertEqual(len(info_list), 1)
+
+        info = info_list[0]
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['handler'], ONE_FUNC_NAME)
+        self.assertEqual(info['title'], 'One Step')
+        self.failUnless('One small step' in info['description'])
 
 
 _EMPTY_EXPORT_XML = """\
@@ -797,179 +655,180 @@ _ORDERED_EXPORT_XML = """\
 #==============================================================================
 #   ToolsetRegistry tests
 #==============================================================================
-class ToolsetRegistryTests( BaseRegistryTests
-                          , ConformsToIToolsetRegistry
-                          ):
+
+
+class ToolsetRegistryTests(BaseRegistryTests, ConformsToIToolsetRegistry
+                           ):
 
     layer = ExportImportZCMLLayer
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.registry import ToolsetRegistry
         return ToolsetRegistry
 
-    def _initSite( self ):
+    def _initSite(self):
 
         self.app.site = Folder(id='site')
         site = self.app.site
 
         return site
 
-    def test_empty( self ):
+    def test_empty(self):
 
         site = self._initSite()
-        configurator = self._makeOne().__of__( site )
+        configurator = self._makeOne().__of__(site)
 
-        self.assertEqual( len( configurator.listForbiddenTools() ), 0 )
-        self.assertEqual( len( configurator.listRequiredTools() ), 0 )
-        self.assertEqual( len( configurator.listRequiredToolInfo() ), 0 )
+        self.assertEqual(len(configurator.listForbiddenTools()), 0)
+        self.assertEqual(len(configurator.listRequiredTools()), 0)
+        self.assertEqual(len(configurator.listRequiredToolInfo()), 0)
 
-        self.assertRaises( KeyError
-                         , configurator.getRequiredToolInfo, 'nonesuch' )
+        self.assertRaises(
+            KeyError,
+            configurator.getRequiredToolInfo,
+            'nonesuch')
 
-    def test_addForbiddenTool_multiple( self ):
+    def test_addForbiddenTool_multiple(self):
 
-        VERBOTTEN = ( 'foo', 'bar', 'bam' )
+        VERBOTTEN = ('foo', 'bar', 'bam')
 
         site = self._initSite()
-        configurator = self._makeOne().__of__( site )
+        configurator = self._makeOne().__of__(site)
 
         for verbotten in VERBOTTEN:
-            configurator.addForbiddenTool( verbotten )
+            configurator.addForbiddenTool(verbotten)
 
-        self.assertEqual( len( configurator.listForbiddenTools() )
-                        , len( VERBOTTEN ) )
+        self.assertEqual(
+            len(configurator.listForbiddenTools()), len(VERBOTTEN))
 
         for verbotten in configurator.listForbiddenTools():
-            self.failUnless( verbotten in VERBOTTEN )
+            self.failUnless(verbotten in VERBOTTEN)
 
-    def test_addForbiddenTool_duplicate( self ):
-
-        site = self._initSite()
-        configurator = self._makeOne().__of__( site )
-
-        configurator.addForbiddenTool( 'once' )
-        configurator.addForbiddenTool( 'once' )
-
-        self.assertEqual( len( configurator.listForbiddenTools() ), 1 )
-
-    def test_addForbiddenTool_but_required( self ):
+    def test_addForbiddenTool_duplicate(self):
 
         site = self._initSite()
-        configurator = self._makeOne().__of__( site )
+        configurator = self._makeOne().__of__(site)
 
-        configurator.addRequiredTool( 'required', 'some.dotted.name' )
+        configurator.addForbiddenTool('once')
+        configurator.addForbiddenTool('once')
 
-        self.assertRaises( ValueError
-                         , configurator.addForbiddenTool, 'required' )
+        self.assertEqual(len(configurator.listForbiddenTools()), 1)
 
-    def test_addRequiredTool_multiple( self ):
-
-        REQUIRED = ( ( 'one', 'path.to.one' )
-                   , ( 'two', 'path.to.two' )
-                   , ( 'three', 'path.to.three' )
-                   )
+    def test_addForbiddenTool_but_required(self):
 
         site = self._initSite()
-        configurator = self._makeOne().__of__( site )
+        configurator = self._makeOne().__of__(site)
+
+        configurator.addRequiredTool('required', 'some.dotted.name')
+
+        self.assertRaises(
+            ValueError,
+            configurator.addForbiddenTool,
+            'required')
+
+    def test_addRequiredTool_multiple(self):
+
+        REQUIRED = (('one', 'path.to.one'), ('two', 'path.to.two'), ('three', 'path.to.three')
+                    )
+
+        site = self._initSite()
+        configurator = self._makeOne().__of__(site)
 
         for tool_id, dotted_name in REQUIRED:
-            configurator.addRequiredTool( tool_id, dotted_name )
+            configurator.addRequiredTool(tool_id, dotted_name)
 
-        self.assertEqual( len( configurator.listRequiredTools() )
-                        , len( REQUIRED ) )
+        self.assertEqual(len(configurator.listRequiredTools()), len(REQUIRED))
 
-        for id in [ x[0] for x in REQUIRED ]:
-            self.failUnless( id in configurator.listRequiredTools() )
+        for id in [x[0] for x in REQUIRED]:
+            self.failUnless(id in configurator.listRequiredTools())
 
-        self.assertEqual( len( configurator.listRequiredToolInfo() )
-                        , len( REQUIRED ) )
+        self.assertEqual(
+            len(configurator.listRequiredToolInfo()), len(REQUIRED))
 
         for tool_id, dotted_name in REQUIRED:
-            info = configurator.getRequiredToolInfo( tool_id )
-            self.assertEqual( info[ 'id' ], tool_id )
-            self.assertEqual( info[ 'class' ], dotted_name )
+            info = configurator.getRequiredToolInfo(tool_id)
+            self.assertEqual(info['id'], tool_id)
+            self.assertEqual(info['class'], dotted_name)
 
-    def test_addRequiredTool_duplicate( self ):
-
-        site = self._initSite()
-        configurator = self._makeOne().__of__( site )
-
-        configurator.addRequiredTool( 'required', 'some.dotted.name' )
-        configurator.addRequiredTool( 'required', 'another.name' )
-
-        info = configurator.getRequiredToolInfo( 'required' )
-        self.assertEqual( info[ 'id' ], 'required' )
-        self.assertEqual( info[ 'class' ], 'another.name' )
-
-    def test_addRequiredTool_but_forbidden( self ):
+    def test_addRequiredTool_duplicate(self):
 
         site = self._initSite()
-        configurator = self._makeOne().__of__( site )
+        configurator = self._makeOne().__of__(site)
 
-        configurator.addForbiddenTool( 'forbidden' )
+        configurator.addRequiredTool('required', 'some.dotted.name')
+        configurator.addRequiredTool('required', 'another.name')
 
-        self.assertRaises( ValueError
-                         , configurator.addRequiredTool
-                         , 'forbidden'
-                         , 'a.name'
-                         )
+        info = configurator.getRequiredToolInfo('required')
+        self.assertEqual(info['id'], 'required')
+        self.assertEqual(info['class'], 'another.name')
 
-    def test_generateXML_empty( self ):
-
-        site = self._initSite()
-        configurator = self._makeOne().__of__( site )
-
-        self._compareDOM( configurator.generateXML(), _EMPTY_TOOLSET_XML )
-
-    def test_generateXML_normal( self ):
+    def test_addRequiredTool_but_forbidden(self):
 
         site = self._initSite()
-        configurator = self._makeOne().__of__( site )
+        configurator = self._makeOne().__of__(site)
 
-        configurator.addForbiddenTool( 'doomed' )
-        configurator.addRequiredTool( 'mandatory', 'path.to.one' )
-        configurator.addRequiredTool( 'obligatory', 'path.to.another' )
+        configurator.addForbiddenTool('forbidden')
 
-        configurator.parseXML( _NORMAL_TOOLSET_XML )
+        self.assertRaises(ValueError, configurator.addRequiredTool, 'forbidden', 'a.name'
+                          )
 
-    def test_parseXML_empty( self ):
-
-        site = self._initSite()
-        configurator = self._makeOne().__of__( site )
-
-        configurator.parseXML( _EMPTY_TOOLSET_XML )
-
-        self.assertEqual( len( configurator.listForbiddenTools() ), 0 )
-        self.assertEqual( len( configurator.listRequiredTools() ), 0 )
-
-    def test_parseXML_normal( self ):
+    def test_generateXML_empty(self):
 
         site = self._initSite()
-        configurator = self._makeOne().__of__( site )
+        configurator = self._makeOne().__of__(site)
 
-        configurator.parseXML( _NORMAL_TOOLSET_XML )
+        self._compareDOM(configurator.generateXML(), _EMPTY_TOOLSET_XML)
 
-        self.assertEqual( len( configurator.listForbiddenTools() ), 1 )
-        self.failUnless( 'doomed' in configurator.listForbiddenTools() )
-
-        self.assertEqual( len( configurator.listRequiredTools() ), 2 )
-
-        self.failUnless( 'mandatory' in configurator.listRequiredTools() )
-        info = configurator.getRequiredToolInfo( 'mandatory' )
-        self.assertEqual( info[ 'class' ], 'path.to.one' )
-
-        self.failUnless( 'obligatory' in configurator.listRequiredTools() )
-        info = configurator.getRequiredToolInfo( 'obligatory' )
-        self.assertEqual( info[ 'class' ], 'path.to.another' )
-
-    def test_parseXML_confused( self ):
+    def test_generateXML_normal(self):
 
         site = self._initSite()
-        configurator = self._makeOne().__of__( site )
+        configurator = self._makeOne().__of__(site)
 
-        self.assertRaises( ValueError
-                         , configurator.parseXML, _CONFUSED_TOOLSET_XML )
+        configurator.addForbiddenTool('doomed')
+        configurator.addRequiredTool('mandatory', 'path.to.one')
+        configurator.addRequiredTool('obligatory', 'path.to.another')
+
+        configurator.parseXML(_NORMAL_TOOLSET_XML)
+
+    def test_parseXML_empty(self):
+
+        site = self._initSite()
+        configurator = self._makeOne().__of__(site)
+
+        configurator.parseXML(_EMPTY_TOOLSET_XML)
+
+        self.assertEqual(len(configurator.listForbiddenTools()), 0)
+        self.assertEqual(len(configurator.listRequiredTools()), 0)
+
+    def test_parseXML_normal(self):
+
+        site = self._initSite()
+        configurator = self._makeOne().__of__(site)
+
+        configurator.parseXML(_NORMAL_TOOLSET_XML)
+
+        self.assertEqual(len(configurator.listForbiddenTools()), 1)
+        self.failUnless('doomed' in configurator.listForbiddenTools())
+
+        self.assertEqual(len(configurator.listRequiredTools()), 2)
+
+        self.failUnless('mandatory' in configurator.listRequiredTools())
+        info = configurator.getRequiredToolInfo('mandatory')
+        self.assertEqual(info['class'], 'path.to.one')
+
+        self.failUnless('obligatory' in configurator.listRequiredTools())
+        info = configurator.getRequiredToolInfo('obligatory')
+        self.assertEqual(info['class'], 'path.to.another')
+
+    def test_parseXML_confused(self):
+
+        site = self._initSite()
+        configurator = self._makeOne().__of__(site)
+
+        self.assertRaises(
+            ValueError,
+            configurator.parseXML,
+            _CONFUSED_TOOLSET_XML)
 
 
 _EMPTY_TOOLSET_XML = """\
@@ -995,36 +854,36 @@ _CONFUSED_TOOLSET_XML = """\
 </tool-setup>
 """
 
+
 class ISite(Interface):
     pass
 
+
 class IDerivedSite(ISite):
     pass
+
 
 class IAnotherSite(Interface):
     pass
 
 
-class ProfileRegistryTests( BaseRegistryTests
-                          , ConformsToIProfileRegistry
-                          ):
+class ProfileRegistryTests(BaseRegistryTests, ConformsToIProfileRegistry
+                           ):
 
-
-
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.registry import ProfileRegistry
         return ProfileRegistry
 
-    def test_empty( self ):
+    def test_empty(self):
 
         registry = self._makeOne()
 
-        self.assertEqual( len( registry.listProfiles() ), 0 )
-        self.assertEqual( len( registry.listProfiles() ), 0 )
-        self.assertRaises( KeyError, registry.getProfileInfo, 'nonesuch' )
+        self.assertEqual(len(registry.listProfiles()), 0)
+        self.assertEqual(len(registry.listProfiles()), 0)
+        self.assertRaises(KeyError, registry.getProfileInfo, 'nonesuch')
 
-    def test_registerProfile_normal( self ):
+    def test_registerProfile_normal(self):
 
         NAME = 'one'
         TITLE = 'One'
@@ -1035,35 +894,30 @@ class ProfileRegistryTests( BaseRegistryTests
         PROFILE_ID = 'TestProduct:one'
 
         registry = self._makeOne()
-        registry.registerProfile( NAME
-                                , TITLE
-                                , DESCRIPTION
-                                , PATH
-                                , PRODUCT
-                                , PROFILE_TYPE
-                                )
-        
-        self.assertEqual( len( registry.listProfiles() ), 1 )
-        self.assertEqual( len( registry.listProfileInfo() ), 1 )
+        registry.registerProfile(NAME, TITLE, DESCRIPTION, PATH, PRODUCT, PROFILE_TYPE
+                                 )
 
-        info = registry.getProfileInfo( PROFILE_ID )
+        self.assertEqual(len(registry.listProfiles()), 1)
+        self.assertEqual(len(registry.listProfileInfo()), 1)
 
-        self.assertEqual( info[ 'id' ], PROFILE_ID )
-        self.assertEqual( info[ 'title' ], TITLE )
-        self.assertEqual( info[ 'description' ], DESCRIPTION )
-        self.assertEqual( info[ 'path' ], PATH )
-        self.assertEqual( info[ 'product' ], PRODUCT )
-        self.assertEqual( info[ 'type' ], PROFILE_TYPE )
-        self.assertEqual( info[ 'for' ], None )
+        info = registry.getProfileInfo(PROFILE_ID)
+
+        self.assertEqual(info['id'], PROFILE_ID)
+        self.assertEqual(info['title'], TITLE)
+        self.assertEqual(info['description'], DESCRIPTION)
+        self.assertEqual(info['path'], PATH)
+        self.assertEqual(info['product'], PRODUCT)
+        self.assertEqual(info['type'], PROFILE_TYPE)
+        self.assertEqual(info['for'], None)
 
         # We strip off any 'profile-' or 'snapshot-' at the beginning
         # of the profile id.
-        info2 = registry.getProfileInfo( 'profile-' + PROFILE_ID )
+        info2 = registry.getProfileInfo('profile-' + PROFILE_ID)
         self.assertEqual(info, info2)
-        info3 = registry.getProfileInfo( 'snapshot-' + PROFILE_ID )
+        info3 = registry.getProfileInfo('snapshot-' + PROFILE_ID)
         self.assertEqual(info, info3)
 
-    def test_registerProfile_duplicate( self ):
+    def test_registerProfile_duplicate(self):
 
         NAME = 'one'
         TITLE = 'One'
@@ -1071,13 +925,16 @@ class ProfileRegistryTests( BaseRegistryTests
         PATH = '/path/to/one'
 
         registry = self._makeOne()
-        registry.registerProfile( NAME, TITLE, DESCRIPTION, PATH )
-        self.assertRaises( KeyError
-                         , registry.registerProfile
-                         , NAME, TITLE, DESCRIPTION, PATH )
+        registry.registerProfile(NAME, TITLE, DESCRIPTION, PATH)
+        self.assertRaises(
+            KeyError,
+            registry.registerProfile,
+            NAME,
+            TITLE,
+            DESCRIPTION,
+            PATH)
 
-
-    def test_registerProfile_site_type( self ):
+    def test_registerProfile_site_type(self):
 
         NAME = 'one'
         TITLE = 'One'
@@ -1091,60 +948,46 @@ class ProfileRegistryTests( BaseRegistryTests
         DERIVED_FOR = IDerivedSite
 
         registry = self._makeOne()
-        registry.registerProfile( NAME
-                                , TITLE
-                                , DESCRIPTION
-                                , PATH
-                                , PRODUCT
-                                , PROFILE_TYPE
-                                , for_=FOR
-                                )
+        registry.registerProfile(NAME, TITLE, DESCRIPTION, PATH, PRODUCT, PROFILE_TYPE, for_=FOR
+                                 )
 
+        self.assertEqual(len(registry.listProfiles()), 1)
+        self.assertEqual(len(registry.listProfiles(for_=FOR)), 1)
+        self.assertEqual(len(registry.listProfiles(for_=DERIVED_FOR)), 1)
+        self.assertEqual(len(registry.listProfiles(for_=NOT_FOR)), 0)
 
-        self.assertEqual( len( registry.listProfiles() ), 1 )
-        self.assertEqual( len( registry.listProfiles( for_=FOR ) ), 1 )
-        self.assertEqual( len( registry.listProfiles( for_=DERIVED_FOR ) )
-                        , 1 )
-        self.assertEqual( len( registry.listProfiles( for_=NOT_FOR ) )
-                        , 0 )
-
-        self.assertEqual( len( registry.listProfileInfo() ), 1 )
-        self.assertEqual( len( registry.listProfileInfo( for_=FOR ) ), 1 )
-        self.assertEqual( len( registry.listProfileInfo( for_=DERIVED_FOR ) )
-                        , 1 )
-        self.assertEqual( len( registry.listProfileInfo( for_=NOT_FOR ) )
-                        , 0 )
+        self.assertEqual(len(registry.listProfileInfo()), 1)
+        self.assertEqual(len(registry.listProfileInfo(for_=FOR)), 1)
+        self.assertEqual(len(registry.listProfileInfo(for_=DERIVED_FOR)), 1)
+        self.assertEqual(len(registry.listProfileInfo(for_=NOT_FOR)), 0)
 
         # Verify that these lookups succeed...
-        info1 = registry.getProfileInfo( PROFILE_ID )
-        info2 = registry.getProfileInfo( PROFILE_ID, for_=FOR )
-        info3 = registry.getProfileInfo( PROFILE_ID, for_=DERIVED_FOR )
+        info1 = registry.getProfileInfo(PROFILE_ID)
+        info2 = registry.getProfileInfo(PROFILE_ID, for_=FOR)
+        info3 = registry.getProfileInfo(PROFILE_ID, for_=DERIVED_FOR)
 
         self.assertEqual(info1, info2)
         self.assertEqual(info1, info3)
 
         # ...and that this one fails.
-        self.assertRaises( KeyError
-                         , registry.getProfileInfo
-                         , PROFILE_ID
-                         , for_=NOT_FOR
-                         )
+        self.assertRaises(KeyError, registry.getProfileInfo, PROFILE_ID, for_=NOT_FOR
+                          )
 
-        info = registry.getProfileInfo( PROFILE_ID , for_=FOR )
+        info = registry.getProfileInfo(PROFILE_ID, for_=FOR)
 
-        self.assertEqual( info[ 'id' ], PROFILE_ID )
-        self.assertEqual( info[ 'title' ], TITLE )
-        self.assertEqual( info[ 'description' ], DESCRIPTION )
-        self.assertEqual( info[ 'path' ], PATH )
-        self.assertEqual( info[ 'product' ], PRODUCT )
-        self.assertEqual( info[ 'type' ], PROFILE_TYPE )
-        self.assertEqual( info[ 'for' ], FOR )
+        self.assertEqual(info['id'], PROFILE_ID)
+        self.assertEqual(info['title'], TITLE)
+        self.assertEqual(info['description'], DESCRIPTION)
+        self.assertEqual(info['path'], PATH)
+        self.assertEqual(info['product'], PRODUCT)
+        self.assertEqual(info['type'], PROFILE_TYPE)
+        self.assertEqual(info['for'], FOR)
 
 
 def test_suite():
     return unittest.TestSuite((
-        unittest.makeSuite( ImportStepRegistryTests ),
-        unittest.makeSuite( ExportStepRegistryTests ),
-        unittest.makeSuite( ToolsetRegistryTests ),
-        unittest.makeSuite( ProfileRegistryTests ),
-        ))
+        unittest.makeSuite(ImportStepRegistryTests),
+        unittest.makeSuite(ExportStepRegistryTests),
+        unittest.makeSuite(ToolsetRegistryTests),
+        unittest.makeSuite(ProfileRegistryTests),
+    ))

--- a/Products/GenericSetup/tests/test_rolemap.py
+++ b/Products/GenericSetup/tests/test_rolemap.py
@@ -27,247 +27,246 @@ class RolemapExportConfiguratorTests(BaseRegistryTests):
 
     layer = ExportImportZCMLLayer
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.rolemap import RolemapExportConfigurator
         return RolemapExportConfigurator
 
-    def test_listRoles_normal( self ):
+    def test_listRoles_normal(self):
 
-        EXPECTED = [ 'Anonymous', 'Authenticated', 'Manager', 'Owner' ]
+        EXPECTED = ['Anonymous', 'Authenticated', 'Manager', 'Owner']
         self.app.site = Folder(id='site')
         site = self.app.site
-        configurator = self._makeOne( site )
+        configurator = self._makeOne(site)
 
-        roles = list( configurator.listRoles() )
-        self.assertEqual( len( roles ), len( EXPECTED ) )
+        roles = list(configurator.listRoles())
+        self.assertEqual(len(roles), len(EXPECTED))
 
         roles.sort()
 
-        for found, expected in zip( roles, EXPECTED ):
-            self.assertEqual( found, expected )
+        for found, expected in zip(roles, EXPECTED):
+            self.assertEqual(found, expected)
 
-    def test_listRoles_added( self ):
+    def test_listRoles_added(self):
 
-        EXPECTED = [ 'Anonymous', 'Authenticated', 'Manager', 'Owner', 'ZZZ' ]
+        EXPECTED = ['Anonymous', 'Authenticated', 'Manager', 'Owner', 'ZZZ']
         self.app.site = Folder(id='site')
         site = self.app.site
-        existing_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
-        existing_roles.append( 'ZZZ' )
+        existing_roles = list(getattr(site, '__ac_roles__', []))[:]
+        existing_roles.append('ZZZ')
         site.__ac_roles__ = existing_roles
 
-        configurator = self._makeOne( site )
+        configurator = self._makeOne(site)
 
-        roles = list( configurator.listRoles() )
-        self.assertEqual( len( roles ), len( EXPECTED ) )
+        roles = list(configurator.listRoles())
+        self.assertEqual(len(roles), len(EXPECTED))
 
         roles.sort()
 
-        for found, expected in zip( roles, EXPECTED ):
-            self.assertEqual( found, expected )
+        for found, expected in zip(roles, EXPECTED):
+            self.assertEqual(found, expected)
 
-    def test_listPermissions_nooverrides( self ):
+    def test_listPermissions_nooverrides(self):
 
         site = Folder(id='site').__of__(self.app)
-        configurator = self._makeOne( site )
+        configurator = self._makeOne(site)
 
-        self.assertEqual( len( configurator.listPermissions() ), 0 )
+        self.assertEqual(len(configurator.listPermissions()), 0)
 
-    def test_listPermissions_acquire( self ):
+    def test_listPermissions_acquire(self):
 
         ACI = 'Access contents information'
-        ROLES = [ 'Manager', 'Owner' ]
+        ROLES = ['Manager', 'Owner']
 
         site = Folder(id='site').__of__(self.app)
-        site.manage_permission( ACI, ROLES, acquire=1 )
-        configurator = self._makeOne( site )
+        site.manage_permission(ACI, ROLES, acquire=1)
+        configurator = self._makeOne(site)
 
-        self.assertEqual( len( configurator.listPermissions() ), 1 )
-        info = configurator.listPermissions()[ 0 ]
-        self.assertEqual( info[ 'name' ], ACI )
-        self.assertEqual( info[ 'roles' ], ROLES )
-        self.failUnless( info[ 'acquire' ] )
+        self.assertEqual(len(configurator.listPermissions()), 1)
+        info = configurator.listPermissions()[0]
+        self.assertEqual(info['name'], ACI)
+        self.assertEqual(info['roles'], ROLES)
+        self.failUnless(info['acquire'])
 
-    def test_listPermissions_no_acquire( self ):
+    def test_listPermissions_no_acquire(self):
 
         ACI = 'Access contents information'
-        ROLES = [ 'Manager', 'Owner' ]
+        ROLES = ['Manager', 'Owner']
 
         site = Folder(id='site').__of__(self.app)
-        site.manage_permission( ACI, ROLES )
-        configurator = self._makeOne( site )
+        site.manage_permission(ACI, ROLES)
+        configurator = self._makeOne(site)
 
-        self.assertEqual( len( configurator.listPermissions() ), 1 )
-        info = configurator.listPermissions()[ 0 ]
-        self.assertEqual( info[ 'name' ], ACI )
-        self.assertEqual( info[ 'roles' ], ROLES )
-        self.failIf( info[ 'acquire' ] )
+        self.assertEqual(len(configurator.listPermissions()), 1)
+        info = configurator.listPermissions()[0]
+        self.assertEqual(info['name'], ACI)
+        self.assertEqual(info['roles'], ROLES)
+        self.failIf(info['acquire'])
 
-    def test_generateXML_empty( self ):
+    def test_generateXML_empty(self):
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        configurator = self._makeOne( site ).__of__( site )
+        configurator = self._makeOne(site).__of__(site)
 
-        self._compareDOM( configurator.generateXML(), _EMPTY_EXPORT )
+        self._compareDOM(configurator.generateXML(), _EMPTY_EXPORT)
 
-    def test_generateXML_added_role( self ):
+    def test_generateXML_added_role(self):
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        existing_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
-        existing_roles.append( 'ZZZ' )
+        existing_roles = list(getattr(site, '__ac_roles__', []))[:]
+        existing_roles.append('ZZZ')
         site.__ac_roles__ = existing_roles
-        configurator = self._makeOne( site ).__of__( site )
+        configurator = self._makeOne(site).__of__(site)
 
-        self._compareDOM( configurator.generateXML(), _ADDED_ROLE_EXPORT )
+        self._compareDOM(configurator.generateXML(), _ADDED_ROLE_EXPORT)
 
-    def test_generateEXML_acquired_perm( self ):
-
-        ACI = 'Access contents information'
-        ROLES = [ 'Manager', 'Owner' ]
-
-        site = Folder(id='site').__of__(self.app)
-        site.manage_permission( ACI, ROLES, acquire=1 )
-        configurator = self._makeOne( site ).__of__( site )
-
-        self._compareDOM( configurator.generateXML(), _ACQUIRED_EXPORT )
-
-    def test_generateEXML_unacquired_perm( self ):
+    def test_generateEXML_acquired_perm(self):
 
         ACI = 'Access contents information'
-        ROLES = [ 'Manager', 'Owner', 'ZZZ' ]
+        ROLES = ['Manager', 'Owner']
 
         site = Folder(id='site').__of__(self.app)
-        existing_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
-        existing_roles.append( 'ZZZ' )
+        site.manage_permission(ACI, ROLES, acquire=1)
+        configurator = self._makeOne(site).__of__(site)
+
+        self._compareDOM(configurator.generateXML(), _ACQUIRED_EXPORT)
+
+    def test_generateEXML_unacquired_perm(self):
+
+        ACI = 'Access contents information'
+        ROLES = ['Manager', 'Owner', 'ZZZ']
+
+        site = Folder(id='site').__of__(self.app)
+        existing_roles = list(getattr(site, '__ac_roles__', []))[:]
+        existing_roles.append('ZZZ')
         site.__ac_roles__ = existing_roles
-        site.manage_permission( ACI, ROLES )
-        configurator = self._makeOne( site ).__of__( site )
+        site.manage_permission(ACI, ROLES)
+        configurator = self._makeOne(site).__of__(site)
 
-        self._compareDOM( configurator.generateXML(), _COMBINED_EXPORT )
+        self._compareDOM(configurator.generateXML(), _COMBINED_EXPORT)
 
-    def test_generateEXML_unacquired_perm_added_role( self ):
+    def test_generateEXML_unacquired_perm_added_role(self):
 
         ACI = 'Access contents information'
-        ROLES = [ 'Manager', 'Owner' ]
+        ROLES = ['Manager', 'Owner']
 
         site = Folder(id='site').__of__(self.app)
-        site.manage_permission( ACI, ROLES )
-        configurator = self._makeOne( site ).__of__( site )
+        site.manage_permission(ACI, ROLES)
+        configurator = self._makeOne(site).__of__(site)
 
-        self._compareDOM( configurator.generateXML(), _UNACQUIRED_EXPORT )
+        self._compareDOM(configurator.generateXML(), _UNACQUIRED_EXPORT)
 
 
 class RolemapImportConfiguratorTests(BaseRegistryTests):
 
     layer = ExportImportZCMLLayer
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.rolemap import RolemapImportConfigurator
         return RolemapImportConfigurator
 
-    def test_parseXML_empty( self ):
+    def test_parseXML_empty(self):
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        existing_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
-        configurator = self._makeOne( site )
+        existing_roles = list(getattr(site, '__ac_roles__', []))[:]
+        configurator = self._makeOne(site)
 
-        rolemap_info = configurator.parseXML( _EMPTY_EXPORT )
+        rolemap_info = configurator.parseXML(_EMPTY_EXPORT)
 
-        self.assertEqual( len( rolemap_info[ 'roles' ] ), len(existing_roles) )
-        self.assertEqual( len( rolemap_info[ 'permissions' ] ), 0 )
+        self.assertEqual(len(rolemap_info['roles']), len(existing_roles))
+        self.assertEqual(len(rolemap_info['permissions']), 0)
 
-    def test_parseXML_added_role( self ):
+    def test_parseXML_added_role(self):
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        configurator = self._makeOne( site )
+        configurator = self._makeOne(site)
 
-        rolemap_info = configurator.parseXML( _ADDED_ROLE_EXPORT )
-        roles = rolemap_info[ 'roles' ]
+        rolemap_info = configurator.parseXML(_ADDED_ROLE_EXPORT)
+        roles = rolemap_info['roles']
 
-        self.assertEqual( len( roles ), 5 )
-        self.failUnless( 'Anonymous' in roles )
-        self.failUnless( 'Authenticated' in roles )
-        self.failUnless( 'Manager' in roles )
-        self.failUnless( 'Owner' in roles )
-        self.failUnless( 'ZZZ' in roles )
+        self.assertEqual(len(roles), 5)
+        self.failUnless('Anonymous' in roles)
+        self.failUnless('Authenticated' in roles)
+        self.failUnless('Manager' in roles)
+        self.failUnless('Owner' in roles)
+        self.failUnless('ZZZ' in roles)
 
-    def test_parseXML_acquired_permission( self ):
+    def test_parseXML_acquired_permission(self):
 
         ACI = 'Access contents information'
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        configurator = self._makeOne( site )
+        configurator = self._makeOne(site)
 
-        rolemap_info = configurator.parseXML( _ACQUIRED_EXPORT )
+        rolemap_info = configurator.parseXML(_ACQUIRED_EXPORT)
 
-        self.assertEqual( len( rolemap_info[ 'permissions' ] ), 1 )
-        permission = rolemap_info[ 'permissions' ][ 0 ]
+        self.assertEqual(len(rolemap_info['permissions']), 1)
+        permission = rolemap_info['permissions'][0]
 
-        self.assertEqual( permission[ 'name' ], ACI )
-        self.failUnless( permission[ 'acquire' ] )
+        self.assertEqual(permission['name'], ACI)
+        self.failUnless(permission['acquire'])
 
-        p_roles = permission[ 'roles' ]
-        self.assertEqual( len( p_roles ), 2 )
-        self.failUnless( 'Manager' in p_roles )
-        self.failUnless( 'Owner' in p_roles )
+        p_roles = permission['roles']
+        self.assertEqual(len(p_roles), 2)
+        self.failUnless('Manager' in p_roles)
+        self.failUnless('Owner' in p_roles)
 
-    def test_parseXML_unacquired_permission( self ):
-
-        ACI = 'Access contents information'
-
-        self.app.site = Folder(id='site')
-        site = self.app.site
-        configurator = self._makeOne( site )
-
-        rolemap_info = configurator.parseXML( _UNACQUIRED_EXPORT )
-
-        self.assertEqual( len( rolemap_info[ 'permissions' ] ), 1 )
-        permission = rolemap_info[ 'permissions' ][ 0 ]
-
-        self.assertEqual( permission[ 'name' ], ACI )
-        self.failIf( permission[ 'acquire' ] )
-
-        p_roles = permission[ 'roles' ]
-        self.assertEqual( len( p_roles ), 2 )
-        self.failUnless( 'Manager' in p_roles )
-        self.failUnless( 'Owner' in p_roles )
-
-    def test_parseXML_unacquired_permission_added_role( self ):
+    def test_parseXML_unacquired_permission(self):
 
         ACI = 'Access contents information'
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        configurator = self._makeOne( site )
+        configurator = self._makeOne(site)
 
-        rolemap_info = configurator.parseXML( _COMBINED_EXPORT )
-        roles = rolemap_info[ 'roles' ]
+        rolemap_info = configurator.parseXML(_UNACQUIRED_EXPORT)
 
-        self.assertEqual( len( roles ), 5 )
-        self.failUnless( 'Anonymous' in roles )
-        self.failUnless( 'Authenticated' in roles )
-        self.failUnless( 'Manager' in roles )
-        self.failUnless( 'Owner' in roles )
-        self.failUnless( 'ZZZ' in roles )
+        self.assertEqual(len(rolemap_info['permissions']), 1)
+        permission = rolemap_info['permissions'][0]
 
-        self.assertEqual( len( rolemap_info[ 'permissions' ] ), 1 )
-        permission = rolemap_info[ 'permissions' ][ 0 ]
+        self.assertEqual(permission['name'], ACI)
+        self.failIf(permission['acquire'])
 
-        self.assertEqual( permission[ 'name' ], ACI )
-        self.failIf( permission[ 'acquire' ] )
+        p_roles = permission['roles']
+        self.assertEqual(len(p_roles), 2)
+        self.failUnless('Manager' in p_roles)
+        self.failUnless('Owner' in p_roles)
 
-        p_roles = permission[ 'roles' ]
-        self.assertEqual( len( p_roles ), 3 )
-        self.failUnless( 'Manager' in p_roles )
-        self.failUnless( 'Owner' in p_roles )
-        self.failUnless( 'ZZZ' in p_roles )
+    def test_parseXML_unacquired_permission_added_role(self):
 
+        ACI = 'Access contents information'
+
+        self.app.site = Folder(id='site')
+        site = self.app.site
+        configurator = self._makeOne(site)
+
+        rolemap_info = configurator.parseXML(_COMBINED_EXPORT)
+        roles = rolemap_info['roles']
+
+        self.assertEqual(len(roles), 5)
+        self.failUnless('Anonymous' in roles)
+        self.failUnless('Authenticated' in roles)
+        self.failUnless('Manager' in roles)
+        self.failUnless('Owner' in roles)
+        self.failUnless('ZZZ' in roles)
+
+        self.assertEqual(len(rolemap_info['permissions']), 1)
+        permission = rolemap_info['permissions'][0]
+
+        self.assertEqual(permission['name'], ACI)
+        self.failIf(permission['acquire'])
+
+        p_roles = permission['roles']
+        self.assertEqual(len(p_roles), 3)
+        self.failUnless('Manager' in p_roles)
+        self.failUnless('Owner' in p_roles)
+        self.failUnless('ZZZ' in p_roles)
 
 
 _EMPTY_EXPORT = """\
@@ -358,111 +357,111 @@ _COMBINED_EXPORT = """\
 </rolemap>
 """
 
-class Test_exportRolemap( BaseRegistryTests ):
+
+class Test_exportRolemap(BaseRegistryTests):
 
     layer = ExportImportZCMLLayer
 
-    def test_unchanged( self ):
+    def test_unchanged(self):
 
         self.app.site = Folder('site')
         site = self.app.site
 
-        context = DummyExportContext( site )
+        context = DummyExportContext(site)
 
         from Products.GenericSetup.rolemap import exportRolemap
-        exportRolemap( context )
+        exportRolemap(context)
 
-        self.assertEqual( len( context._wrote ), 1 )
-        filename, text, content_type = context._wrote[ 0 ]
-        self.assertEqual( filename, 'rolemap.xml' )
-        self._compareDOM( text, _EMPTY_EXPORT )
-        self.assertEqual( content_type, 'text/xml' )
+        self.assertEqual(len(context._wrote), 1)
+        filename, text, content_type = context._wrote[0]
+        self.assertEqual(filename, 'rolemap.xml')
+        self._compareDOM(text, _EMPTY_EXPORT)
+        self.assertEqual(content_type, 'text/xml')
 
-    def test_added_role( self ):
+    def test_added_role(self):
 
         self.app.site = Folder('site')
         site = self.app.site
-        existing_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
-        existing_roles.append( 'ZZZ' )
+        existing_roles = list(getattr(site, '__ac_roles__', []))[:]
+        existing_roles.append('ZZZ')
         site.__ac_roles__ = existing_roles
 
-        context = DummyExportContext( site )
+        context = DummyExportContext(site)
 
         from Products.GenericSetup.rolemap import exportRolemap
-        exportRolemap( context )
+        exportRolemap(context)
 
-        self.assertEqual( len( context._wrote ), 1 )
-        filename, text, content_type = context._wrote[ 0 ]
-        self.assertEqual( filename, 'rolemap.xml' )
-        self._compareDOM( text, _ADDED_ROLE_EXPORT )
-        self.assertEqual( content_type, 'text/xml' )
+        self.assertEqual(len(context._wrote), 1)
+        filename, text, content_type = context._wrote[0]
+        self.assertEqual(filename, 'rolemap.xml')
+        self._compareDOM(text, _ADDED_ROLE_EXPORT)
+        self.assertEqual(content_type, 'text/xml')
 
-
-    def test_acquired_perm( self ):
+    def test_acquired_perm(self):
 
         ACI = 'Access contents information'
-        ROLES = [ 'Manager', 'Owner' ]
+        ROLES = ['Manager', 'Owner']
 
         self.app.site = Folder('site')
         site = self.app.site
-        site.manage_permission( ACI, ROLES, acquire=1 )
+        site.manage_permission(ACI, ROLES, acquire=1)
 
-        context = DummyExportContext( site )
+        context = DummyExportContext(site)
 
         from Products.GenericSetup.rolemap import exportRolemap
-        exportRolemap( context )
+        exportRolemap(context)
 
-        self.assertEqual( len( context._wrote ), 1 )
-        filename, text, content_type = context._wrote[ 0 ]
-        self.assertEqual( filename, 'rolemap.xml' )
-        self._compareDOM( text, _ACQUIRED_EXPORT )
-        self.assertEqual( content_type, 'text/xml' )
+        self.assertEqual(len(context._wrote), 1)
+        filename, text, content_type = context._wrote[0]
+        self.assertEqual(filename, 'rolemap.xml')
+        self._compareDOM(text, _ACQUIRED_EXPORT)
+        self.assertEqual(content_type, 'text/xml')
 
-    def test_unacquired_perm( self ):
+    def test_unacquired_perm(self):
 
         ACI = 'Access contents information'
-        ROLES = [ 'Manager', 'Owner', 'ZZZ' ]
+        ROLES = ['Manager', 'Owner', 'ZZZ']
 
         self.app.site = Folder('site')
         site = self.app.site
-        existing_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
-        existing_roles.append( 'ZZZ' )
+        existing_roles = list(getattr(site, '__ac_roles__', []))[:]
+        existing_roles.append('ZZZ')
         site.__ac_roles__ = existing_roles
-        site.manage_permission( ACI, ROLES )
+        site.manage_permission(ACI, ROLES)
 
-        context = DummyExportContext( site )
+        context = DummyExportContext(site)
 
         from Products.GenericSetup.rolemap import exportRolemap
-        exportRolemap( context )
+        exportRolemap(context)
 
-        self.assertEqual( len( context._wrote ), 1 )
-        filename, text, content_type = context._wrote[ 0 ]
-        self.assertEqual( filename, 'rolemap.xml' )
-        self._compareDOM( text, _COMBINED_EXPORT )
-        self.assertEqual( content_type, 'text/xml' )
+        self.assertEqual(len(context._wrote), 1)
+        filename, text, content_type = context._wrote[0]
+        self.assertEqual(filename, 'rolemap.xml')
+        self._compareDOM(text, _COMBINED_EXPORT)
+        self.assertEqual(content_type, 'text/xml')
 
-    def test_unacquired_perm_added_role( self ):
+    def test_unacquired_perm_added_role(self):
 
         ACI = 'Access contents information'
-        ROLES = [ 'Manager', 'Owner' ]
+        ROLES = ['Manager', 'Owner']
 
         self.app.site = Folder('site')
         site = self.app.site
-        site.manage_permission( ACI, ROLES )
+        site.manage_permission(ACI, ROLES)
 
-        context = DummyExportContext( site )
+        context = DummyExportContext(site)
 
         from Products.GenericSetup.rolemap import exportRolemap
-        exportRolemap( context )
+        exportRolemap(context)
 
-        self.assertEqual( len( context._wrote ), 1 )
-        filename, text, content_type = context._wrote[ 0 ]
-        self.assertEqual( filename, 'rolemap.xml' )
-        self._compareDOM( text, _UNACQUIRED_EXPORT )
-        self.assertEqual( content_type, 'text/xml' )
+        self.assertEqual(len(context._wrote), 1)
+        filename, text, content_type = context._wrote[0]
+        self.assertEqual(filename, 'rolemap.xml')
+        self._compareDOM(text, _UNACQUIRED_EXPORT)
+        self.assertEqual(content_type, 'text/xml')
 
 
-class Test_importRolemap( BaseRegistryTests ):
+class Test_importRolemap(BaseRegistryTests):
 
     layer = ExportImportZCMLLayer
 
@@ -472,7 +471,7 @@ class Test_importRolemap( BaseRegistryTests ):
         VIEW = 'View'
 
         self.app.site = Folder(id='site')
-        site = self.app.site # wrap
+        site = self.app.site  # wrap
         original_roles = list(getattr(site, '__ac_roles__', []))[:]
         modified_roles = original_roles[:]
         modified_roles.append('ZZZ')
@@ -482,12 +481,12 @@ class Test_importRolemap( BaseRegistryTests ):
         site.manage_permission(ACI, ('Manager', 'ZZZ'))
 
         existing_allowed = [x['name'] for x in site.rolesOfPermission(ACI)
-                                if x['selected']]
+                            if x['selected']]
 
         self.assertEqual(existing_allowed, ['Manager', 'ZZZ'])
 
         context = DummyImportContext(site, True)
-        #context._files[ 'rolemap.xml' ] = _EMPTY_EXPORT # no file!
+        # context._files[ 'rolemap.xml' ] = _EMPTY_EXPORT # no file!
 
         from Products.GenericSetup.rolemap import importRolemap
         importRolemap(context)
@@ -500,321 +499,321 @@ class Test_importRolemap( BaseRegistryTests ):
         self.assertEqual(modified_roles, new_roles)
 
         new_allowed = [x['name'] for x in site.rolesOfPermission(ACI)
-                                if x['selected']]
+                       if x['selected']]
 
         self.assertEqual(new_allowed, existing_allowed)
 
-    def test_empty_default_purge( self ):
+    def test_empty_default_purge(self):
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        original_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
+        original_roles = list(getattr(site, '__ac_roles__', []))[:]
         modified_roles = original_roles[:]
-        modified_roles.append( 'ZZZ' )
+        modified_roles.append('ZZZ')
         site.__ac_roles__ = modified_roles
 
-        context = DummyImportContext( site )
-        context._files[ 'rolemap.xml' ] = _EMPTY_EXPORT
+        context = DummyImportContext(site)
+        context._files['rolemap.xml'] = _EMPTY_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        new_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
+        new_roles = list(getattr(site, '__ac_roles__', []))[:]
 
         original_roles.sort()
         new_roles.sort()
 
-        self.assertEqual( original_roles, new_roles )
+        self.assertEqual(original_roles, new_roles)
 
-    def test_empty_explicit_purge( self ):
+    def test_empty_explicit_purge(self):
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        original_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
+        original_roles = list(getattr(site, '__ac_roles__', []))[:]
         modified_roles = original_roles[:]
-        modified_roles.append( 'ZZZ' )
+        modified_roles.append('ZZZ')
         site.__ac_roles__ = modified_roles
 
-        context = DummyImportContext( site, True )
-        context._files[ 'rolemap.xml' ] = _EMPTY_EXPORT
+        context = DummyImportContext(site, True)
+        context._files['rolemap.xml'] = _EMPTY_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        new_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
+        new_roles = list(getattr(site, '__ac_roles__', []))[:]
 
         original_roles.sort()
         new_roles.sort()
 
-        self.assertEqual( original_roles, new_roles )
+        self.assertEqual(original_roles, new_roles)
 
-    def test_empty_skip_purge( self ):
+    def test_empty_skip_purge(self):
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        original_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
+        original_roles = list(getattr(site, '__ac_roles__', []))[:]
         modified_roles = original_roles[:]
-        modified_roles.append( 'ZZZ' )
+        modified_roles.append('ZZZ')
         site.__ac_roles__ = modified_roles
 
-        context = DummyImportContext( site, False )
-        context._files[ 'rolemap.xml' ] = _EMPTY_EXPORT
+        context = DummyImportContext(site, False)
+        context._files['rolemap.xml'] = _EMPTY_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        new_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
+        new_roles = list(getattr(site, '__ac_roles__', []))[:]
 
         modified_roles.sort()
         new_roles.sort()
 
-        self.assertEqual( modified_roles, new_roles )
+        self.assertEqual(modified_roles, new_roles)
 
-    def test_acquired_permission_explicit_purge( self ):
+    def test_acquired_permission_explicit_purge(self):
 
         ACI = 'Access contents information'
         VIEW = 'View'
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        site.manage_permission( ACI, () )
-        site.manage_permission( VIEW, () )
+        site.manage_permission(ACI, ())
+        site.manage_permission(VIEW, ())
 
-        existing_allowed = [ x[ 'name' ]
-                                for x in site.rolesOfPermission( ACI )
-                                if x[ 'selected' ] ]
+        existing_allowed = [x['name']
+                            for x in site.rolesOfPermission(ACI)
+                            if x['selected']]
 
-        self.assertEqual( existing_allowed, [] )
+        self.assertEqual(existing_allowed, [])
 
-        self.failIf( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failIf(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
 
-        context = DummyImportContext( site, True )
-        context._files[ 'rolemap.xml' ] = _ACQUIRED_EXPORT
+        context = DummyImportContext(site, True)
+        context._files['rolemap.xml'] = _ACQUIRED_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        new_allowed = [ x[ 'name' ]
-                           for x in site.rolesOfPermission( ACI )
-                           if x[ 'selected' ] ]
+        new_allowed = [x['name']
+                       for x in site.rolesOfPermission(ACI)
+                       if x['selected']]
 
-        self.assertEqual( new_allowed, [ 'Manager', 'Owner' ] )
+        self.assertEqual(new_allowed, ['Manager', 'Owner'])
 
         # ACI is overwritten by XML, but VIEW was purged
-        self.failUnless( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failUnless( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failUnless(site.acquiredRolesAreUsedBy(ACI))
+        self.failUnless(site.acquiredRolesAreUsedBy(VIEW))
 
-    def test_acquired_permission_no_purge( self ):
+    def test_acquired_permission_no_purge(self):
 
         ACI = 'Access contents information'
         VIEW = 'View'
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        site.manage_permission( ACI, () )
-        site.manage_permission( VIEW, () )
+        site.manage_permission(ACI, ())
+        site.manage_permission(VIEW, ())
 
-        existing_allowed = [ x[ 'name' ]
-                                for x in site.rolesOfPermission( ACI )
-                                if x[ 'selected' ] ]
+        existing_allowed = [x['name']
+                            for x in site.rolesOfPermission(ACI)
+                            if x['selected']]
 
-        self.assertEqual( existing_allowed, [] )
+        self.assertEqual(existing_allowed, [])
 
-        self.failIf( site.acquiredRolesAreUsedBy( ACI ) )
+        self.failIf(site.acquiredRolesAreUsedBy(ACI))
 
-        context = DummyImportContext( site, False )
-        context._files[ 'rolemap.xml' ] = _ACQUIRED_EXPORT
+        context = DummyImportContext(site, False)
+        context._files['rolemap.xml'] = _ACQUIRED_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        new_allowed = [ x[ 'name' ]
-                           for x in site.rolesOfPermission( ACI )
-                           if x[ 'selected' ] ]
+        new_allowed = [x['name']
+                       for x in site.rolesOfPermission(ACI)
+                       if x['selected']]
 
-        self.assertEqual( new_allowed, [ 'Manager', 'Owner' ] )
+        self.assertEqual(new_allowed, ['Manager', 'Owner'])
 
         # ACI is overwritten by XML, but VIEW is not
-        self.failUnless( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failUnless(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
 
-    def test_unacquired_permission_explicit_purge( self ):
-
-        ACI = 'Access contents information'
-        VIEW = 'View'
-
-        self.app.site = Folder(id='site')
-        site = self.app.site
-        site.manage_permission( VIEW, () )
-
-        existing_allowed = [ x[ 'name' ]
-                                for x in site.rolesOfPermission( ACI )
-                                if x[ 'selected' ] ]
-
-        self.assertEqual( existing_allowed, [ 'Manager' ] )
-
-        self.failUnless( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
-
-        context = DummyImportContext( site, True )
-        context._files[ 'rolemap.xml' ] = _UNACQUIRED_EXPORT
-
-        from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
-
-        new_allowed = [ x[ 'name' ]
-                           for x in site.rolesOfPermission( ACI )
-                           if x[ 'selected' ] ]
-
-        self.assertEqual( new_allowed, [ 'Manager', 'Owner' ] )
-
-        self.failIf( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failUnless( site.acquiredRolesAreUsedBy( VIEW ) )
-
-    def test_unacquired_permission_skip_purge( self ):
+    def test_unacquired_permission_explicit_purge(self):
 
         ACI = 'Access contents information'
         VIEW = 'View'
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        site.manage_permission( VIEW, () )
+        site.manage_permission(VIEW, ())
 
-        existing_allowed = [ x[ 'name' ]
-                                for x in site.rolesOfPermission( ACI )
-                                if x[ 'selected' ] ]
+        existing_allowed = [x['name']
+                            for x in site.rolesOfPermission(ACI)
+                            if x['selected']]
 
-        self.assertEqual( existing_allowed, [ 'Manager' ] )
+        self.assertEqual(existing_allowed, ['Manager'])
 
-        self.failUnless( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failUnless(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
 
-        context = DummyImportContext( site, False )
-        context._files[ 'rolemap.xml' ] = _UNACQUIRED_EXPORT
+        context = DummyImportContext(site, True)
+        context._files['rolemap.xml'] = _UNACQUIRED_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        new_allowed = [ x[ 'name' ]
-                           for x in site.rolesOfPermission( ACI )
-                           if x[ 'selected' ] ]
+        new_allowed = [x['name']
+                       for x in site.rolesOfPermission(ACI)
+                       if x['selected']]
 
-        self.assertEqual( new_allowed, [ 'Manager', 'Owner' ] )
+        self.assertEqual(new_allowed, ['Manager', 'Owner'])
 
-        self.failIf( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failIf(site.acquiredRolesAreUsedBy(ACI))
+        self.failUnless(site.acquiredRolesAreUsedBy(VIEW))
 
-    def test_unacquired_permission_added_role_explicit_purge( self ):
+    def test_unacquired_permission_skip_purge(self):
 
         ACI = 'Access contents information'
         VIEW = 'View'
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        site.manage_permission( VIEW, () )
+        site.manage_permission(VIEW, ())
 
-        existing_allowed = [ x[ 'name' ]
-                                for x in site.rolesOfPermission( ACI )
-                                if x[ 'selected' ] ]
+        existing_allowed = [x['name']
+                            for x in site.rolesOfPermission(ACI)
+                            if x['selected']]
 
-        self.assertEqual( existing_allowed, [ 'Manager' ] )
+        self.assertEqual(existing_allowed, ['Manager'])
 
-        self.failUnless( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failUnless(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
 
-        self.failIf( site._has_user_defined_role( 'ZZZ' ) )
-
-        context = DummyImportContext( site, True )
-        context._files[ 'rolemap.xml' ] = _COMBINED_EXPORT
+        context = DummyImportContext(site, False)
+        context._files['rolemap.xml'] = _UNACQUIRED_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        self.failUnless( site._has_user_defined_role( 'ZZZ' ) )
+        new_allowed = [x['name']
+                       for x in site.rolesOfPermission(ACI)
+                       if x['selected']]
 
-        new_allowed = [ x[ 'name' ]
-                           for x in site.rolesOfPermission( ACI )
-                           if x[ 'selected' ] ]
+        self.assertEqual(new_allowed, ['Manager', 'Owner'])
 
-        self.assertEqual( new_allowed, [ 'Manager', 'Owner', 'ZZZ' ] )
+        self.failIf(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
 
-        self.failIf( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failUnless( site.acquiredRolesAreUsedBy( VIEW ) )
-
-    def test_unacquired_permission_added_role_skip_purge( self ):
+    def test_unacquired_permission_added_role_explicit_purge(self):
 
         ACI = 'Access contents information'
         VIEW = 'View'
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        site.manage_permission( VIEW, () )
+        site.manage_permission(VIEW, ())
 
-        existing_allowed = [ x[ 'name' ]
-                                for x in site.rolesOfPermission( ACI )
-                                if x[ 'selected' ] ]
+        existing_allowed = [x['name']
+                            for x in site.rolesOfPermission(ACI)
+                            if x['selected']]
 
-        self.assertEqual( existing_allowed, [ 'Manager' ] )
+        self.assertEqual(existing_allowed, ['Manager'])
 
-        self.failUnless( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failUnless(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
 
-        self.failIf( site._has_user_defined_role( 'ZZZ' ) )
+        self.failIf(site._has_user_defined_role('ZZZ'))
 
-        context = DummyImportContext( site, False )
-        context._files[ 'rolemap.xml' ] = _COMBINED_EXPORT
+        context = DummyImportContext(site, True)
+        context._files['rolemap.xml'] = _COMBINED_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        self.failUnless( site._has_user_defined_role( 'ZZZ' ) )
+        self.failUnless(site._has_user_defined_role('ZZZ'))
 
-        new_allowed = [ x[ 'name' ]
-                           for x in site.rolesOfPermission( ACI )
-                           if x[ 'selected' ] ]
+        new_allowed = [x['name']
+                       for x in site.rolesOfPermission(ACI)
+                       if x['selected']]
 
-        self.assertEqual( new_allowed, [ 'Manager', 'Owner', 'ZZZ' ] )
+        self.assertEqual(new_allowed, ['Manager', 'Owner', 'ZZZ'])
 
-        self.failIf( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failIf(site.acquiredRolesAreUsedBy(ACI))
+        self.failUnless(site.acquiredRolesAreUsedBy(VIEW))
 
-    def test_unacquired_permission_added_role_skip_purge_encode_ascii( self ):
+    def test_unacquired_permission_added_role_skip_purge(self):
 
         ACI = 'Access contents information'
         VIEW = 'View'
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        site.manage_permission( VIEW, () )
+        site.manage_permission(VIEW, ())
 
-        existing_allowed = [ x[ 'name' ]
-                                for x in site.rolesOfPermission( ACI )
-                                if x[ 'selected' ] ]
+        existing_allowed = [x['name']
+                            for x in site.rolesOfPermission(ACI)
+                            if x['selected']]
 
-        self.assertEqual( existing_allowed, [ 'Manager' ] )
+        self.assertEqual(existing_allowed, ['Manager'])
 
-        self.failUnless( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failUnless(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
 
-        self.failIf( site._has_user_defined_role( 'ZZZ' ) )
+        self.failIf(site._has_user_defined_role('ZZZ'))
 
-        context = DummyImportContext( site, False, encoding='ascii' )
-        context._files[ 'rolemap.xml' ] = _COMBINED_EXPORT
+        context = DummyImportContext(site, False)
+        context._files['rolemap.xml'] = _COMBINED_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        self.failUnless( site._has_user_defined_role( 'ZZZ' ) )
+        self.failUnless(site._has_user_defined_role('ZZZ'))
 
-        new_allowed = [ x[ 'name' ]
-                           for x in site.rolesOfPermission( ACI )
-                           if x[ 'selected' ] ]
+        new_allowed = [x['name']
+                       for x in site.rolesOfPermission(ACI)
+                       if x['selected']]
 
-        self.assertEqual( new_allowed, [ 'Manager', 'Owner', 'ZZZ' ] )
+        self.assertEqual(new_allowed, ['Manager', 'Owner', 'ZZZ'])
 
-        self.failIf( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failIf(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
+
+    def test_unacquired_permission_added_role_skip_purge_encode_ascii(self):
+
+        ACI = 'Access contents information'
+        VIEW = 'View'
+
+        self.app.site = Folder(id='site')
+        site = self.app.site
+        site.manage_permission(VIEW, ())
+
+        existing_allowed = [x['name']
+                            for x in site.rolesOfPermission(ACI)
+                            if x['selected']]
+
+        self.assertEqual(existing_allowed, ['Manager'])
+
+        self.failUnless(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
+
+        self.failIf(site._has_user_defined_role('ZZZ'))
+
+        context = DummyImportContext(site, False, encoding='ascii')
+        context._files['rolemap.xml'] = _COMBINED_EXPORT
+
+        from Products.GenericSetup.rolemap import importRolemap
+        importRolemap(context)
+
+        self.failUnless(site._has_user_defined_role('ZZZ'))
+
+        new_allowed = [x['name']
+                       for x in site.rolesOfPermission(ACI)
+                       if x['selected']]
+
+        self.assertEqual(new_allowed, ['Manager', 'Owner', 'ZZZ'])
+
+        self.failIf(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
 
 
 def test_suite():
@@ -823,4 +822,4 @@ def test_suite():
         unittest.makeSuite(RolemapImportConfiguratorTests),
         unittest.makeSuite(Test_exportRolemap),
         unittest.makeSuite(Test_importRolemap),
-        ))
+    ))

--- a/Products/GenericSetup/tests/test_stepzcml.py
+++ b/Products/GenericSetup/tests/test_stepzcml.py
@@ -41,6 +41,7 @@ ONE_STEP_ZCML = '''\
     />
 </configure>'''
 
+
 class ImportStepTests(unittest.TestCase):
 
     def setUp(self):
@@ -56,20 +57,20 @@ class ImportStepTests(unittest.TestCase):
     def testOneStepImport(self):
         zcml.load_string(ONE_STEP_ZCML)
         self.assertEqual(_import_step_registry.listSteps(),
-            [ u'Products.GenericSetup.teststep'  ])
+                         [u'Products.GenericSetup.teststep'])
         info = _import_step_registry.getStepMetadata(
             u'Products.GenericSetup.teststep')
-        self.assertEqual( info['description'],
-                u'step description' )
-        self.assertEqual( info['title'],
-                u'step title' )
-        self.assertEqual( info['handler'],
-                'Products.GenericSetup.initialize')
-        self.assertEqual( info['id'],
-                u'Products.GenericSetup.teststep' )
+        self.assertEqual(info['description'],
+                         u'step description')
+        self.assertEqual(info['title'],
+                         u'step title')
+        self.assertEqual(info['handler'],
+                         'Products.GenericSetup.initialize')
+        self.assertEqual(info['id'],
+                         u'Products.GenericSetup.teststep')
 
 
 def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(ImportStepTests),
-        ))
+    ))

--- a/Products/GenericSetup/tests/test_tool.py
+++ b/Products/GenericSetup/tests/test_tool.py
@@ -1168,7 +1168,8 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self.assertEqual(tool._profile_upgrade_versions, {})
 
     def test_upgradeProfile(self):
-        dummy_handler = lambda tool: None
+        def dummy_handler(tool):
+            return
 
         def step3_handler(tool):
             tool._step3_applied = 'just a marker'

--- a/Products/GenericSetup/tests/test_tool.py
+++ b/Products/GenericSetup/tests/test_tool.py
@@ -51,11 +51,15 @@ from Products.GenericSetup.upgrade import listUpgradeSteps
 from Products.GenericSetup.upgrade import UpgradeStep
 
 _before_import_events = []
+
+
 @adapter(IBeforeProfileImportEvent)
 def handleBeforeProfileImportEvent(event):
     _before_import_events.append(event)
 
 _after_import_events = []
+
+
 @adapter(IProfileImportedEvent)
 def handleProfileImportedEvent(event):
     _after_import_events.append(event)
@@ -116,33 +120,33 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
 
         return SetupTool
 
-    def _makeSite( self, title="Don't care" ):
+    def _makeSite(self, title="Don't care"):
 
         site = Folder()
-        site._setId( 'site' )
+        site._setId('site')
         site.title = title
 
-        self.app._setObject( 'site', site )
-        return self.app._getOb( 'site' )
+        self.app._setObject('site', site)
+        return self.app._getOb('site')
 
-    def test_empty( self ):
+    def test_empty(self):
 
         tool = self._makeOne('setup_tool')
 
-        self.assertEqual( tool.getBaselineContextID(), '' )
+        self.assertEqual(tool.getBaselineContextID(), '')
 
         import_registry = tool.getImportStepRegistry()
-        self.assertEqual( len( import_registry.listSteps() ), 0 )
+        self.assertEqual(len(import_registry.listSteps()), 0)
 
         export_registry = tool.getExportStepRegistry()
         export_steps = export_registry.listSteps()
         self.assertEqual(len(export_steps), 0)
 
         toolset_registry = tool.getToolsetRegistry()
-        self.assertEqual( len( toolset_registry.listForbiddenTools() ), 0 )
-        self.assertEqual( len( toolset_registry.listRequiredTools() ), 0 )
+        self.assertEqual(len(toolset_registry.listForbiddenTools()), 0)
+        self.assertEqual(len(toolset_registry.listRequiredTools()), 0)
 
-    def test_getBaselineContextID( self ):
+    def test_getBaselineContextID(self):
         from Products.GenericSetup.tool import EXPORT_STEPS_XML
         from Products.GenericSetup.tool import IMPORT_STEPS_XML
         from Products.GenericSetup.tool import TOOLSET_XML
@@ -156,27 +160,23 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         profile_registry.registerProfile('foo', 'Foo', '', self._PROFILE_PATH)
         tool.setBaselineContext('profile-other:foo')
 
-        self.assertEqual( tool.getBaselineContextID(), 'profile-other:foo' )
+        self.assertEqual(tool.getBaselineContextID(), 'profile-other:foo')
 
-    def test_setBaselineContext_invalid( self ):
-
-        tool = self._makeOne('setup_tool')
-
-        self.assertRaises( KeyError
-                         , tool.setBaselineContext
-                         , 'profile-foo'
-                         )
-
-    def test_setBaselineContext_empty_string( self ):
+    def test_setBaselineContext_invalid(self):
 
         tool = self._makeOne('setup_tool')
 
-        self.assertRaises( KeyError
-                         , tool.setBaselineContext
-                         , ''
-                         )
+        self.assertRaises(KeyError, tool.setBaselineContext, 'profile-foo'
+                          )
 
-    def test_setBaselineContext( self ):
+    def test_setBaselineContext_empty_string(self):
+
+        tool = self._makeOne('setup_tool')
+
+        self.assertRaises(KeyError, tool.setBaselineContext, ''
+                          )
+
+    def test_setBaselineContext(self):
         from Products.GenericSetup.tool import EXPORT_STEPS_XML
         from Products.GenericSetup.tool import IMPORT_STEPS_XML
         from Products.GenericSetup.tool import TOOLSET_XML
@@ -191,70 +191,71 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         profile_registry.registerProfile('foo', 'Foo', '', self._PROFILE_PATH)
         tool.setBaselineContext('profile-other:foo')
 
-        self.assertEqual( tool.getBaselineContextID(), 'profile-other:foo' )
+        self.assertEqual(tool.getBaselineContextID(), 'profile-other:foo')
 
         import_registry = tool.getImportStepRegistry()
-        self.assertEqual( len( import_registry.listSteps() ), 1 )
-        self.failUnless( 'one' in import_registry.listSteps() )
-        info = import_registry.getStepMetadata( 'one' )
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'title' ], 'One Step' )
-        self.assertEqual( info[ 'version' ], '1' )
-        self.failUnless( 'One small step' in info[ 'description' ] )
-        self.assertEqual( info[ 'handler' ]
-                        , 'Products.GenericSetup.tests.test_registry.ONE_FUNC')
+        self.assertEqual(len(import_registry.listSteps()), 1)
+        self.failUnless('one' in import_registry.listSteps())
+        info = import_registry.getStepMetadata('one')
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['title'], 'One Step')
+        self.assertEqual(info['version'], '1')
+        self.failUnless('One small step' in info['description'])
+        self.assertEqual(
+            info['handler'],
+            'Products.GenericSetup.tests.test_registry.ONE_FUNC')
 
-        self.assertEqual( import_registry.getStep( 'one' ), ONE_FUNC )
+        self.assertEqual(import_registry.getStep('one'), ONE_FUNC)
 
         export_registry = tool.getExportStepRegistry()
-        self.assertEqual( len( export_registry.listSteps() ), 1 )
-        self.failUnless( 'one' in import_registry.listSteps() )
-        info = export_registry.getStepMetadata( 'one' )
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'title' ], 'One Step' )
-        self.failUnless( 'One small step' in info[ 'description' ] )
-        self.assertEqual( info[ 'handler' ]
-                        , 'Products.GenericSetup.tests.test_registry.ONE_FUNC')
+        self.assertEqual(len(export_registry.listSteps()), 1)
+        self.failUnless('one' in import_registry.listSteps())
+        info = export_registry.getStepMetadata('one')
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['title'], 'One Step')
+        self.failUnless('One small step' in info['description'])
+        self.assertEqual(
+            info['handler'],
+            'Products.GenericSetup.tests.test_registry.ONE_FUNC')
 
-        self.assertEqual( export_registry.getStep( 'one' ), ONE_FUNC )
+        self.assertEqual(export_registry.getStep('one'), ONE_FUNC)
 
     def test_runImportStepFromProfile_nonesuch(self):
 
         site = self._makeSite()
 
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
-        self.assertRaises( KeyError, tool.runImportStepFromProfile,
-                           '', 'nonesuch' )
+        self.assertRaises(KeyError, tool.runImportStepFromProfile,
+                          '', 'nonesuch')
 
     def test_runImportStepFromProfile_simple(self):
 
         TITLE = 'original title'
-        site = self._makeSite( TITLE )
+        site = self._makeSite(TITLE)
 
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'simple', '1', _uppercaseSiteTitle )
+        registry.registerStep('simple', '1', _uppercaseSiteTitle)
 
-        result = tool.runImportStepFromProfile( 'snapshot-dummy', 'simple' )
+        result = tool.runImportStepFromProfile('snapshot-dummy', 'simple')
 
-        self.assertEqual( len( result[ 'steps' ] ), 1 )
+        self.assertEqual(len(result['steps']), 1)
 
-        self.assertEqual( result[ 'steps' ][ 0 ], 'simple' )
-        self.assertEqual( result[ 'messages' ][ 'simple' ]
-                        , 'Uppercased title' )
+        self.assertEqual(result['steps'][0], 'simple')
+        self.assertEqual(result['messages']['simple'], 'Uppercased title')
 
-        self.assertEqual( site.title, TITLE.upper() )
+        self.assertEqual(site.title, TITLE.upper())
 
         global _before_import_events
-        self.assertEqual( len(_before_import_events), 1)
+        self.assertEqual(len(_before_import_events), 1)
         self.assertEqual(_before_import_events[0].profile_id, 'snapshot-dummy')
         self.assertEqual(_before_import_events[0].steps, ['simple'])
         self.assertEqual(_before_import_events[0].full_import, False)
 
         global _after_import_events
-        self.assertEqual( len(_after_import_events), 1)
+        self.assertEqual(len(_after_import_events), 1)
         self.assertEqual(_after_import_events[0].profile_id, 'snapshot-dummy')
         self.assertEqual(_after_import_events[0].steps, ['simple'])
         self.assertEqual(_after_import_events[0].full_import, False)
@@ -262,37 +263,35 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
     def test_runImportStepFromProfile_dependencies(self):
 
         TITLE = 'original title'
-        site = self._makeSite( TITLE )
+        site = self._makeSite(TITLE)
 
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'dependable', '1', _underscoreSiteTitle )
-        registry.registerStep( 'dependent', '1'
-                             , _uppercaseSiteTitle, ( 'dependable', ) )
+        registry.registerStep('dependable', '1', _underscoreSiteTitle)
+        registry.registerStep(
+            'dependent', '1', _uppercaseSiteTitle, ('dependable', ))
 
-        result = tool.runImportStepFromProfile( 'snapshot-dummy', 'dependent' )
+        result = tool.runImportStepFromProfile('snapshot-dummy', 'dependent')
 
-        self.assertEqual( len( result[ 'steps' ] ), 2 )
+        self.assertEqual(len(result['steps']), 2)
 
-        self.assertEqual( result[ 'steps' ][ 0 ], 'dependable' )
-        self.assertEqual( result[ 'messages' ][ 'dependable' ]
-                        , 'Underscored title' )
+        self.assertEqual(result['steps'][0], 'dependable')
+        self.assertEqual(result['messages']['dependable'], 'Underscored title')
 
-        self.assertEqual( result[ 'steps' ][ 1 ], 'dependent' )
-        self.assertEqual( result[ 'messages' ][ 'dependent' ]
-                        , 'Uppercased title' )
-        self.assertEqual( site.title, TITLE.replace( ' ', '_' ).upper() )
+        self.assertEqual(result['steps'][1], 'dependent')
+        self.assertEqual(result['messages']['dependent'], 'Uppercased title')
+        self.assertEqual(site.title, TITLE.replace(' ', '_').upper())
 
         global _before_import_events
-        self.assertEqual( len(_before_import_events), 1)
+        self.assertEqual(len(_before_import_events), 1)
         self.assertEqual(_before_import_events[0].profile_id, 'snapshot-dummy')
         self.assertEqual(_before_import_events[0].steps,
                          ['dependable', 'dependent'])
         self.assertEqual(_before_import_events[0].full_import, False)
 
         global _after_import_events
-        self.assertEqual( len(_after_import_events), 1)
+        self.assertEqual(len(_after_import_events), 1)
         self.assertEqual(_after_import_events[0].profile_id, 'snapshot-dummy')
         self.assertEqual(_after_import_events[0].steps,
                          ['dependable', 'dependent'])
@@ -301,34 +300,33 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
     def test_runImportStepFromProfile_skip_dependencies(self):
 
         TITLE = 'original title'
-        site = self._makeSite( TITLE )
+        site = self._makeSite(TITLE)
 
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'dependable', '1', _underscoreSiteTitle )
-        registry.registerStep( 'dependent', '1'
-                             , _uppercaseSiteTitle, ( 'dependable', ) )
+        registry.registerStep('dependable', '1', _underscoreSiteTitle)
+        registry.registerStep(
+            'dependent', '1', _uppercaseSiteTitle, ('dependable', ))
 
-        result = tool.runImportStepFromProfile( 'snapshot-dummy', 'dependent',
-                                                run_dependencies=False )
+        result = tool.runImportStepFromProfile('snapshot-dummy', 'dependent',
+                                               run_dependencies=False)
 
-        self.assertEqual( len( result[ 'steps' ] ), 1 )
+        self.assertEqual(len(result['steps']), 1)
 
-        self.assertEqual( result[ 'steps' ][ 0 ], 'dependent' )
-        self.assertEqual( result[ 'messages' ][ 'dependent' ]
-                        , 'Uppercased title' )
+        self.assertEqual(result['steps'][0], 'dependent')
+        self.assertEqual(result['messages']['dependent'], 'Uppercased title')
 
-        self.assertEqual( site.title, TITLE.upper() )
+        self.assertEqual(site.title, TITLE.upper())
 
         global _before_import_events
-        self.assertEqual( len(_before_import_events), 1)
+        self.assertEqual(len(_before_import_events), 1)
         self.assertEqual(_before_import_events[0].profile_id, 'snapshot-dummy')
         self.assertEqual(_before_import_events[0].steps, ['dependent'])
         self.assertEqual(_before_import_events[0].full_import, False)
 
         global _after_import_events
-        self.assertEqual( len(_after_import_events), 1)
+        self.assertEqual(len(_after_import_events), 1)
         self.assertEqual(_after_import_events[0].profile_id, 'snapshot-dummy')
         self.assertEqual(_after_import_events[0].steps, ['dependent'])
         self.assertEqual(_after_import_events[0].full_import, False)
@@ -337,72 +335,72 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
 
         site = self._makeSite()
 
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'purging', '1', _purgeIfRequired )
+        registry.registerStep('purging', '1', _purgeIfRequired)
 
-        result = tool.runImportStepFromProfile( 'snapshot-dummy', 'purging' )
+        result = tool.runImportStepFromProfile('snapshot-dummy', 'purging')
 
-        self.assertEqual( len( result[ 'steps' ] ), 1 )
-        self.assertEqual( result[ 'steps' ][ 0 ], 'purging' )
-        self.assertEqual( result[ 'messages' ][ 'purging' ], 'Purged' )
-        self.failUnless( site.purged )
+        self.assertEqual(len(result['steps']), 1)
+        self.assertEqual(result['steps'][0], 'purging')
+        self.assertEqual(result['messages']['purging'], 'Purged')
+        self.failUnless(site.purged)
 
     def test_runImportStepFromProfile_explicit_purge(self):
 
         site = self._makeSite()
 
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'purging', '1', _purgeIfRequired )
+        registry.registerStep('purging', '1', _purgeIfRequired)
 
-        result = tool.runImportStepFromProfile( 'snapshot-dummy', 'purging',
-                                                purge_old=True )
+        result = tool.runImportStepFromProfile('snapshot-dummy', 'purging',
+                                               purge_old=True)
 
-        self.assertEqual( len( result[ 'steps' ] ), 1 )
-        self.assertEqual( result[ 'steps' ][ 0 ], 'purging' )
-        self.assertEqual( result[ 'messages' ][ 'purging' ], 'Purged' )
-        self.failUnless( site.purged )
+        self.assertEqual(len(result['steps']), 1)
+        self.assertEqual(result['steps'][0], 'purging')
+        self.assertEqual(result['messages']['purging'], 'Purged')
+        self.failUnless(site.purged)
 
     def test_runImportStepFromProfile_skip_purge(self):
 
         site = self._makeSite()
 
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'purging', '1', _purgeIfRequired )
+        registry.registerStep('purging', '1', _purgeIfRequired)
 
-        result = tool.runImportStepFromProfile( 'snapshot-dummy', 'purging',
-                                                purge_old=False )
+        result = tool.runImportStepFromProfile('snapshot-dummy', 'purging',
+                                               purge_old=False)
 
-        self.assertEqual( len( result[ 'steps' ] ), 1 )
-        self.assertEqual( result[ 'steps' ][ 0 ], 'purging' )
-        self.assertEqual( result[ 'messages' ][ 'purging' ], 'Unpurged' )
-        self.failIf( site.purged )
+        self.assertEqual(len(result['steps']), 1)
+        self.assertEqual(result['steps'][0], 'purging')
+        self.assertEqual(result['messages']['purging'], 'Unpurged')
+        self.failIf(site.purged)
 
     def test_runImportStepFromProfile_consistent_context(self):
 
         site = self._makeSite()
 
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'purging', '1', _purgeIfRequired )
-        registry.registerStep( 'dependent', '1'
-                             , _uppercaseSiteTitle, ( 'purging', ) )
+        registry.registerStep('purging', '1', _purgeIfRequired)
+        registry.registerStep(
+            'dependent', '1', _uppercaseSiteTitle, ('purging', ))
 
         tool.runImportStepFromProfile('snapshot-dummy', 'dependent',
                                       purge_old=False)
-        self.failIf( site.purged )
+        self.failIf(site.purged)
 
     def test_runAllImportStepsFromProfile_empty(self):
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         result = tool.runAllImportStepsFromProfile('snapshot-dummy')
 
-        self.assertEqual( len(result['steps']), 3 )
+        self.assertEqual(len(result['steps']), 3)
 
     def test_runAllImportStepsFromProfile_inquicksuccession(self):
         """
@@ -412,7 +410,7 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         """
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         tool.runAllImportStepsFromProfile('snapshot-dummy')
         tool.runAllImportStepsFromProfile('snapshot-dummy')
@@ -425,36 +423,32 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
 
         TITLE = 'original title'
         PROFILE_ID = 'snapshot-testing'
-        site = self._makeSite( TITLE )
-        tool = self._makeOne('setup_tool').__of__( site )
+        site = self._makeSite(TITLE)
+        tool = self._makeOne('setup_tool').__of__(site)
         tool._exclude_global_steps = True
 
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'dependable', '1'
-                             , _underscoreSiteTitle, ( 'purging', ) )
-        registry.registerStep( 'dependent', '1'
-                             , _uppercaseSiteTitle, ( 'dependable', ) )
-        registry.registerStep( 'purging', '1'
-                             , _purgeIfRequired )
+        registry.registerStep(
+            'dependable', '1', _underscoreSiteTitle, ('purging', ))
+        registry.registerStep(
+            'dependent', '1', _uppercaseSiteTitle, ('dependable', ))
+        registry.registerStep('purging', '1', _purgeIfRequired)
 
         result = tool.runAllImportStepsFromProfile(PROFILE_ID)
 
-        self.assertEqual( len(result['steps']), 3 )
+        self.assertEqual(len(result['steps']), 3)
 
-        self.assertEqual( result['steps'][0], 'purging' )
-        self.assertEqual( result[ 'messages' ][ 'purging' ]
-                        , 'Purged' )
+        self.assertEqual(result['steps'][0], 'purging')
+        self.assertEqual(result['messages']['purging'], 'Purged')
 
-        self.assertEqual( result['steps'][1], 'dependable' )
-        self.assertEqual( result[ 'messages' ][ 'dependable' ]
-                        , 'Underscored title' )
+        self.assertEqual(result['steps'][1], 'dependable')
+        self.assertEqual(result['messages']['dependable'], 'Underscored title')
 
-        self.assertEqual( result['steps'][2], 'dependent' )
-        self.assertEqual( result[ 'messages' ][ 'dependent' ]
-                        , 'Uppercased title' )
+        self.assertEqual(result['steps'][2], 'dependent')
+        self.assertEqual(result['messages']['dependent'], 'Uppercased title')
 
-        self.assertEqual( site.title, TITLE.replace( ' ', '_' ).upper() )
-        self.failUnless( site.purged )
+        self.assertEqual(site.title, TITLE.replace(' ', '_').upper())
+        self.failUnless(site.purged)
 
         prefix = 'import-all-%s' % PROFILE_ID
         logged = [x for x in tool.objectIds('File') if x.startswith(prefix)]
@@ -464,16 +458,15 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
 
         TITLE = 'original title'
         PROFILE_ID = u'snapshot-testing'
-        site = self._makeSite( TITLE )
-        tool = self._makeOne('setup_tool').__of__( site )
+        site = self._makeSite(TITLE)
+        tool = self._makeOne('setup_tool').__of__(site)
 
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'dependable', '1'
-                             , _underscoreSiteTitle, ( 'purging', ) )
-        registry.registerStep( 'dependent', '1'
-                             , _uppercaseSiteTitle, ( 'dependable', ) )
-        registry.registerStep( 'purging', '1'
-                             , _purgeIfRequired )
+        registry.registerStep(
+            'dependable', '1', _underscoreSiteTitle, ('purging', ))
+        registry.registerStep(
+            'dependent', '1', _uppercaseSiteTitle, ('dependable', ))
+        registry.registerStep('purging', '1', _purgeIfRequired)
 
         tool.runAllImportStepsFromProfile(PROFILE_ID)
 
@@ -484,56 +477,52 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
     def test_runAllImportStepsFromProfile_sorted_explicit_purge(self):
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
         tool._exclude_global_steps = True
 
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'dependable', '1'
-                             , _underscoreSiteTitle, ( 'purging', ) )
-        registry.registerStep( 'dependent', '1'
-                             , _uppercaseSiteTitle, ( 'dependable', ) )
-        registry.registerStep( 'purging', '1'
-                             , _purgeIfRequired )
+        registry.registerStep(
+            'dependable', '1', _underscoreSiteTitle, ('purging', ))
+        registry.registerStep(
+            'dependent', '1', _uppercaseSiteTitle, ('dependable', ))
+        registry.registerStep('purging', '1', _purgeIfRequired)
 
         result = tool.runAllImportStepsFromProfile('snapshot-dummy',
-                                                   purge_old=True )
+                                                   purge_old=True)
 
-        self.assertEqual( len(result['steps']), 3 )
+        self.assertEqual(len(result['steps']), 3)
 
-        self.assertEqual( result['steps'][0], 'purging' )
-        self.assertEqual( result[ 'messages' ][ 'purging' ]
-                        , 'Purged' )
+        self.assertEqual(result['steps'][0], 'purging')
+        self.assertEqual(result['messages']['purging'], 'Purged')
 
-        self.assertEqual( result['steps'][1], 'dependable' )
-        self.assertEqual( result['steps'][2], 'dependent' )
-        self.failUnless( site.purged )
+        self.assertEqual(result['steps'][1], 'dependable')
+        self.assertEqual(result['steps'][2], 'dependent')
+        self.failUnless(site.purged)
 
     def test_runAllImportStepsFromProfile_sorted_skip_purge(self):
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
         tool._exclude_global_steps = True
 
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'dependable', '1'
-                             , _underscoreSiteTitle, ( 'purging', ) )
-        registry.registerStep( 'dependent', '1'
-                             , _uppercaseSiteTitle, ( 'dependable', ) )
-        registry.registerStep( 'purging', '1'
-                             , _purgeIfRequired )
+        registry.registerStep(
+            'dependable', '1', _underscoreSiteTitle, ('purging', ))
+        registry.registerStep(
+            'dependent', '1', _uppercaseSiteTitle, ('dependable', ))
+        registry.registerStep('purging', '1', _purgeIfRequired)
 
         result = tool.runAllImportStepsFromProfile('snapshot-dummy',
-                                                   purge_old=False )
+                                                   purge_old=False)
 
-        self.assertEqual( len(result['steps']), 3 )
+        self.assertEqual(len(result['steps']), 3)
 
-        self.assertEqual( result['steps'][0], 'purging' )
-        self.assertEqual( result[ 'messages' ][ 'purging' ]
-                        , 'Unpurged' )
+        self.assertEqual(result['steps'][0], 'purging')
+        self.assertEqual(result['messages']['purging'], 'Unpurged')
 
-        self.assertEqual( result['steps'][1], 'dependable' )
-        self.assertEqual( result['steps'][2], 'dependent' )
-        self.failIf( site.purged )
+        self.assertEqual(result['steps'][1], 'dependable')
+        self.assertEqual(result['steps'][2], 'dependent')
+        self.failIf(site.purged)
 
     def test_runAllImportStepsFromProfile_without_depends(self):
         from Products.GenericSetup.metadata import METADATA_XML
@@ -541,15 +530,16 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self._makeFile(METADATA_XML, _METADATA_XML)
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         profile_registry.registerProfile('foo', 'Foo', '', self._PROFILE_PATH)
 
         _imported = []
+
         def applyContext(context):
             _imported.append(context._profile_path)
 
-        tool.applyContext=applyContext
+        tool.applyContext = applyContext
         tool.runAllImportStepsFromProfile('profile-other:foo',
                                           ignore_dependencies=True)
         self.assertEqual(_imported, [self._PROFILE_PATH])
@@ -560,16 +550,17 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self._makeFile(METADATA_XML, _METADATA_XML)
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         profile_registry.registerProfile('foo', 'Foo', '', self._PROFILE_PATH)
         profile_registry.registerProfile('bar', 'Bar', '', self._PROFILE_PATH2)
 
         _imported = []
+
         def applyContext(context):
             _imported.append(context._profile_path)
 
-        tool.applyContext=applyContext
+        tool.applyContext = applyContext
         tool.runAllImportStepsFromProfile('profile-other:foo',
                                           ignore_dependencies=False)
         self.assertEqual(_imported, [self._PROFILE_PATH2, self._PROFILE_PATH])
@@ -705,7 +696,7 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self._makeFile(METADATA_XML, _METADATA_XML)
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         profile_registry.registerProfile('foo', 'Foo', '', self._PROFILE_PATH)
 
@@ -741,7 +732,7 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self._makeFile('import_steps.xml', _IMPORT_STEPS_XML)
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         profile_registry.registerProfile('foo', 'Foo', '', self._PROFILE_PATH)
         profile_registry.registerProfile('bar', 'Bar', '', self._PROFILE_PATH2)
@@ -755,33 +746,32 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
     def test_runAllImportStepsFromProfile_skipStep(self):
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
         result = tool.runAllImportStepsFromProfile(
             'snapshot-dummy',
             blacklisted_steps=['toolset']
         )
 
-        self.assertEqual( (result['messages']['toolset']), 'step skipped' )
+        self.assertEqual((result['messages']['toolset']), 'step skipped')
 
-    def test_runExportStep_nonesuch( self ):
+    def test_runExportStep_nonesuch(self):
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
-        self.assertRaises( ValueError, tool.runExportStep, 'nonesuch' )
+        self.assertRaises(ValueError, tool.runExportStep, 'nonesuch')
 
     def test_runExportStep_step_registry_empty(self):
         site = self._makeSite()
         site.setup_tool = self._makeOne('setup_tool')
         tool = site.setup_tool
 
-        result = tool.runExportStep( 'step_registries' )
+        result = tool.runExportStep('step_registries')
 
-        self.assertEqual( len( result[ 'steps' ] ), 1 )
-        self.assertEqual( result[ 'steps' ][ 0 ], 'step_registries' )
-        self.assertEqual( result[ 'messages' ][ 'step_registries' ]
-                        , None
-                        )
+        self.assertEqual(len(result['steps']), 1)
+        self.assertEqual(result['steps'][0], 'step_registries')
+        self.assertEqual(result['messages']['step_registries'], None
+                         )
 
     def test_runExportStep_step_registry_default(self):
         site = self._makeSite()
@@ -789,25 +779,27 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         tool = site.setup_tool
         tool._import_registry.registerStep('foo', handler='foo.bar')
         tool._export_registry.registerStep('step_registries',
-                'Products.GenericSetup.tool.exportStepRegistries',
-                'Export import / export steps.')
+                                           'Products.GenericSetup.tool.exportStepRegistries',
+                                           'Export import / export steps.')
 
-        result = tool.runExportStep( 'step_registries' )
+        result = tool.runExportStep('step_registries')
 
-        self.assertEqual( len( result[ 'steps' ] ), 1 )
-        self.assertEqual( result[ 'steps' ][ 0 ], 'step_registries' )
-        self.assertEqual( result[ 'messages' ][ 'step_registries' ]
-                        , None
-                        )
-        fileish = StringIO( result[ 'tarball' ] )
+        self.assertEqual(len(result['steps']), 1)
+        self.assertEqual(result['steps'][0], 'step_registries')
+        self.assertEqual(result['messages']['step_registries'], None
+                         )
+        fileish = StringIO(result['tarball'])
 
-        self._verifyTarballContents( fileish, [ 'import_steps.xml'
-                                              , 'export_steps.xml'
-                                              ] )
-        self._verifyTarballEntryXML( fileish, 'import_steps.xml'
-                                   , _DEFAULT_STEP_REGISTRIES_IMPORT_XML )
-        self._verifyTarballEntryXML( fileish, 'export_steps.xml'
-                                   , _DEFAULT_STEP_REGISTRIES_EXPORT_XML )
+        self._verifyTarballContents(fileish, ['import_steps.xml', 'export_steps.xml'
+                                              ])
+        self._verifyTarballEntryXML(
+            fileish,
+            'import_steps.xml',
+            _DEFAULT_STEP_REGISTRIES_IMPORT_XML)
+        self._verifyTarballEntryXML(
+            fileish,
+            'export_steps.xml',
+            _DEFAULT_STEP_REGISTRIES_EXPORT_XML)
 
     def test_runAllExportSteps_empty(self):
         site = self._makeSite()
@@ -816,11 +808,10 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
 
         result = tool.runAllExportSteps()
 
-        self.assertEqual( len(result['steps'] ), 4 )
-        self.assertEqual( result['steps'][1], 'step_registries' )
-        self.assertEqual( result[ 'messages' ][ 'step_registries' ]
-                        , None
-                        )
+        self.assertEqual(len(result['steps']), 4)
+        self.assertEqual(result['steps'][1], 'step_registries')
+        self.assertEqual(result['messages']['step_registries'], None
+                         )
 
     def test_runAllExportSteps_default(self):
         site = self._makeSite()
@@ -828,78 +819,77 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         tool = site.setup_tool
         tool._import_registry.registerStep('foo', handler='foo.bar')
         tool._export_registry.registerStep('step_registries',
-                'Products.GenericSetup.tool.exportStepRegistries',
-                'Export import / export steps.')
+                                           'Products.GenericSetup.tool.exportStepRegistries',
+                                           'Export import / export steps.')
 
         result = tool.runAllExportSteps()
 
-        self.assertEqual( len(result['steps']), 4 )
-        self.assertEqual( result['steps'][1], 'step_registries' )
-        self.assertEqual( result[ 'messages' ][ 'step_registries' ]
-                        , None
-                        )
-        fileish = StringIO( result[ 'tarball' ] )
+        self.assertEqual(len(result['steps']), 4)
+        self.assertEqual(result['steps'][1], 'step_registries')
+        self.assertEqual(result['messages']['step_registries'], None
+                         )
+        fileish = StringIO(result['tarball'])
 
-        self._verifyTarballContents( fileish, [ 'import_steps.xml'
-                                              , 'export_steps.xml'
-                                              , 'rolemap.xml'
-                                              , 'toolset.xml'
-                                              ] )
-        self._verifyTarballEntryXML( fileish, 'import_steps.xml'
-                                   , _DEFAULT_STEP_REGISTRIES_IMPORT_XML )
-        self._verifyTarballEntryXML( fileish, 'export_steps.xml'
-                                   , _DEFAULT_STEP_REGISTRIES_EXPORT_XML )
+        self._verifyTarballContents(fileish, ['import_steps.xml', 'export_steps.xml', 'rolemap.xml', 'toolset.xml'
+                                              ])
+        self._verifyTarballEntryXML(
+            fileish,
+            'import_steps.xml',
+            _DEFAULT_STEP_REGISTRIES_IMPORT_XML)
+        self._verifyTarballEntryXML(
+            fileish,
+            'export_steps.xml',
+            _DEFAULT_STEP_REGISTRIES_EXPORT_XML)
 
-    def test_runAllExportSteps_extras( self ):
+    def test_runAllExportSteps_extras(self):
         site = self._makeSite()
         site.setup_tool = self._makeOne('setup_tool')
         tool = site.setup_tool
         tool._export_registry.registerStep('step_registries',
-                'Products.GenericSetup.tool.exportStepRegistries',
-                'Export import / export steps.')
+                                           'Products.GenericSetup.tool.exportStepRegistries',
+                                           'Export import / export steps.')
 
         import_reg = tool.getImportStepRegistry()
-        import_reg.registerStep( 'dependable', '1'
-                               , _underscoreSiteTitle, ( 'purging', ) )
-        import_reg.registerStep( 'dependent', '1'
-                               , _uppercaseSiteTitle, ( 'dependable', ) )
-        import_reg.registerStep( 'purging', '1'
-                               , _purgeIfRequired )
+        import_reg.registerStep(
+            'dependable', '1', _underscoreSiteTitle, ('purging', ))
+        import_reg.registerStep(
+            'dependent', '1', _uppercaseSiteTitle, ('dependable', ))
+        import_reg.registerStep('purging', '1', _purgeIfRequired)
 
         export_reg = tool.getExportStepRegistry()
-        export_reg.registerStep( 'properties'
-                               , _exportPropertiesINI )
+        export_reg.registerStep('properties', _exportPropertiesINI)
 
         result = tool.runAllExportSteps()
 
-        self.assertEqual( len(result['steps']), 5 )
+        self.assertEqual(len(result['steps']), 5)
 
-        self.failUnless( 'properties' in result[ 'steps' ] )
-        self.assertEqual( result[ 'messages' ][ 'properties' ]
-                        , 'Exported properties'
-                        )
+        self.failUnless('properties' in result['steps'])
+        self.assertEqual(result['messages']['properties'], 'Exported properties'
+                         )
 
-        self.failUnless( 'step_registries' in result[ 'steps' ] )
-        self.assertEqual( result[ 'messages' ][ 'step_registries' ]
-                        , None
-                        )
+        self.failUnless('step_registries' in result['steps'])
+        self.assertEqual(result['messages']['step_registries'], None
+                         )
 
-        fileish = StringIO( result[ 'tarball' ] )
+        fileish = StringIO(result['tarball'])
 
-        self._verifyTarballContents( fileish, [ 'import_steps.xml'
-                                              , 'export_steps.xml'
-                                              , 'properties.ini'
-                                              , 'rolemap.xml'
-                                              , 'toolset.xml'
-                                              ] )
-        self._verifyTarballEntryXML( fileish, 'import_steps.xml'
-                                   , _EXTRAS_STEP_REGISTRIES_IMPORT_XML )
-        self._verifyTarballEntryXML( fileish, 'export_steps.xml'
-                                   , _EXTRAS_STEP_REGISTRIES_EXPORT_XML )
-        self._verifyTarballEntry( fileish, 'properties.ini'
-                                , _PROPERTIES_INI % site.title  )
+        self._verifyTarballContents(fileish, ['import_steps.xml', 'export_steps.xml', 'properties.ini', 'rolemap.xml', 'toolset.xml'
+                                              ])
+        self._verifyTarballEntryXML(
+            fileish,
+            'import_steps.xml',
+            _EXTRAS_STEP_REGISTRIES_IMPORT_XML)
+        self._verifyTarballEntryXML(
+            fileish,
+            'export_steps.xml',
+            _EXTRAS_STEP_REGISTRIES_EXPORT_XML)
+        self._verifyTarballEntry(
+            fileish,
+            'properties.ini',
+            _PROPERTIES_INI %
+            site.title)
 
-    def test_createSnapshot_default( self ):
+    def test_createSnapshot_default(self):
         _EXPECTED = [('import_steps.xml', _DEFAULT_STEP_REGISTRIES_IMPORT_XML),
                      ('export_steps.xml', _DEFAULT_STEP_REGISTRIES_EXPORT_XML),
                      ('rolemap.xml', 'dummy'),
@@ -910,25 +900,24 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         tool = site.setup_tool
         tool._import_registry.registerStep('foo', handler='foo.bar')
         tool._export_registry.registerStep('step_registries',
-                'Products.GenericSetup.tool.exportStepRegistries',
-                'Export import / export steps.')
+                                           'Products.GenericSetup.tool.exportStepRegistries',
+                                           'Export import / export steps.')
 
-        self.assertEqual( len( tool.listSnapshotInfo() ), 0 )
+        self.assertEqual(len(tool.listSnapshotInfo()), 0)
 
-        result = tool.createSnapshot( 'default' )
+        result = tool.createSnapshot('default')
 
-        self.assertEqual( len(result['steps']), 4 )
-        self.assertEqual( result['steps'][1], 'step_registries' )
-        self.assertEqual( result[ 'messages' ][ 'step_registries' ]
-                        , None
-                        )
+        self.assertEqual(len(result['steps']), 4)
+        self.assertEqual(result['steps'][1], 'step_registries')
+        self.assertEqual(result['messages']['step_registries'], None
+                         )
 
-        snapshot = result[ 'snapshot' ]
+        snapshot = result['snapshot']
 
-        self.assertEqual( len( snapshot.objectIds() ), len( _EXPECTED ) )
+        self.assertEqual(len(snapshot.objectIds()), len(_EXPECTED))
 
-        for id in [ x[0] for x in _EXPECTED ]:
-            self.failUnless( id in snapshot.objectIds() )
+        for id in [x[0] for x in _EXPECTED]:
+            self.failUnless(id in snapshot.objectIds())
 
         def normalize_xml(xml):
             # using this might mask a real problem on windows, but so far the
@@ -937,20 +926,20 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
                            [line.strip() for line in xml.splitlines() if line])
             return ' '.join(lines)
 
-        fileobj = snapshot._getOb( 'import_steps.xml' )
-        self.assertEqual( normalize_xml( fileobj.read() ),
-                          normalize_xml(_DEFAULT_STEP_REGISTRIES_IMPORT_XML))
+        fileobj = snapshot._getOb('import_steps.xml')
+        self.assertEqual(normalize_xml(fileobj.read()),
+                         normalize_xml(_DEFAULT_STEP_REGISTRIES_IMPORT_XML))
 
-        fileobj = snapshot._getOb( 'export_steps.xml' )
-        self.assertEqual( normalize_xml( fileobj.read() ),
-                          normalize_xml(_DEFAULT_STEP_REGISTRIES_EXPORT_XML ))
+        fileobj = snapshot._getOb('export_steps.xml')
+        self.assertEqual(normalize_xml(fileobj.read()),
+                         normalize_xml(_DEFAULT_STEP_REGISTRIES_EXPORT_XML))
 
-        self.assertEqual( len( tool.listSnapshotInfo() ), 1 )
+        self.assertEqual(len(tool.listSnapshotInfo()), 1)
 
-        info = tool.listSnapshotInfo()[ 0 ]
+        info = tool.listSnapshotInfo()[0]
 
-        self.assertEqual( info[ 'id' ], 'default' )
-        self.assertEqual( info[ 'title' ], 'default' )
+        self.assertEqual(info['id'], 'default')
+        self.assertEqual(info['title'], 'default')
 
     def test_applyContext(self):
         from Products.GenericSetup.tool import EXPORT_STEPS_XML
@@ -963,38 +952,38 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         tool.getExportStepRegistry().clear()
         tool.getToolsetRegistry().clear()
 
-        context = DummyImportContext( site, tool=tool )
-        context._files[ IMPORT_STEPS_XML ] = _SINGLE_IMPORT_XML
-        context._files[ EXPORT_STEPS_XML ] = _SINGLE_EXPORT_XML
-        context._files[ TOOLSET_XML ] = _NORMAL_TOOLSET_XML
+        context = DummyImportContext(site, tool=tool)
+        context._files[IMPORT_STEPS_XML] = _SINGLE_IMPORT_XML
+        context._files[EXPORT_STEPS_XML] = _SINGLE_EXPORT_XML
+        context._files[TOOLSET_XML] = _NORMAL_TOOLSET_XML
 
         tool.applyContext(context)
 
         import_registry = tool.getImportStepRegistry()
-        self.assertEqual( len( import_registry.listSteps() ), 1 )
-        self.failUnless( 'one' in import_registry.listSteps() )
-        info = import_registry.getStepMetadata( 'one' )
+        self.assertEqual(len(import_registry.listSteps()), 1)
+        self.failUnless('one' in import_registry.listSteps())
+        info = import_registry.getStepMetadata('one')
 
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'title' ], 'One Step' )
-        self.assertEqual( info[ 'version' ], '1' )
-        self.failUnless( 'One small step' in info[ 'description' ] )
-        self.assertEqual(info[ 'handler' ],
-                         'Products.GenericSetup.tests.test_registry.ONE_FUNC' )
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['title'], 'One Step')
+        self.assertEqual(info['version'], '1')
+        self.failUnless('One small step' in info['description'])
+        self.assertEqual(info['handler'],
+                         'Products.GenericSetup.tests.test_registry.ONE_FUNC')
 
-        self.assertEqual( import_registry.getStep( 'one' ), ONE_FUNC )
+        self.assertEqual(import_registry.getStep('one'), ONE_FUNC)
 
         export_registry = tool.getExportStepRegistry()
-        self.assertEqual( len( export_registry.listSteps() ), 1 )
-        self.failUnless( 'one' in import_registry.listSteps() )
-        info = export_registry.getStepMetadata( 'one' )
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'title' ], 'One Step' )
-        self.failUnless( 'One small step' in info[ 'description' ] )
-        self.assertEqual(info[ 'handler' ],
-                         'Products.GenericSetup.tests.test_registry.ONE_FUNC' )
+        self.assertEqual(len(export_registry.listSteps()), 1)
+        self.failUnless('one' in import_registry.listSteps())
+        info = export_registry.getStepMetadata('one')
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['title'], 'One Step')
+        self.failUnless('One small step' in info['description'])
+        self.assertEqual(info['handler'],
+                         'Products.GenericSetup.tests.test_registry.ONE_FUNC')
 
-        self.assertEqual( export_registry.getStep( 'one' ), ONE_FUNC )
+        self.assertEqual(export_registry.getStep('one'), ONE_FUNC)
 
     def test_listContextInfos_empty(self):
         site = self._makeSite()
@@ -1135,13 +1124,17 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self.assertEqual(tool._profile_upgrade_versions, {})
         # Any 'profile-' is stripped off in these calls.
         self.assertEqual(tool.getLastVersionForProfile('foo'), 'unknown')
-        self.assertEqual(tool.getLastVersionForProfile('profile-foo'), 'unknown')
+        self.assertEqual(
+            tool.getLastVersionForProfile('profile-foo'),
+            'unknown')
         tool.setLastVersionForProfile('foo', '1.0')
         self.assertEqual(tool.getLastVersionForProfile('foo'), ('1', '0'))
-        self.assertEqual(tool.getLastVersionForProfile('profile-foo'), ('1', '0'))
+        self.assertEqual(
+            tool.getLastVersionForProfile('profile-foo'), ('1', '0'))
         tool.setLastVersionForProfile('profile-foo', '2.0')
         self.assertEqual(tool.getLastVersionForProfile('foo'), ('2', '0'))
-        self.assertEqual(tool.getLastVersionForProfile('profile-foo'), ('2', '0'))
+        self.assertEqual(
+            tool.getLastVersionForProfile('profile-foo'), ('2', '0'))
 
     def test_manage_doUpgrades_no_profile_id_or_updates(self):
         site = self._makeSite()
@@ -1152,7 +1145,7 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
 
     def test_manage_doUpgrades_upgrade_w_no_target_version(self):
         step = UpgradeStep('TITLE', 'foo', '*', '*', 'DESC',
-                            lambda tool: None)
+                           lambda tool: None)
         _registerUpgradeStep(step)
         site = self._makeSite()
         site.setup_tool = self._makeOne('setup_tool')
@@ -1270,10 +1263,10 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self._makeFile(METADATA_XML, _METADATA_XML)
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         profile_registry.registerProfile('foo', 'Foo', '', self._PROFILE_PATH,
-                                        for_=ISite)
+                                         for_=ISite)
         # tool.listProfileInfo should call registry.listProfileInfo
         # with the for_ parameter
         self.assertEqual(len(tool.listProfileInfo()), 1)
@@ -1355,43 +1348,46 @@ Title=%s
 """
 
 
-def _underscoreSiteTitle( context ):
+def _underscoreSiteTitle(context):
 
     site = context.getSite()
-    site.title = site.title.replace( ' ', '_' )
+    site.title = site.title.replace(' ', '_')
     return 'Underscored title'
 
-def _uppercaseSiteTitle( context ):
+
+def _uppercaseSiteTitle(context):
 
     site = context.getSite()
     site.title = site.title.upper()
     return 'Uppercased title'
 
-def _purgeIfRequired( context ):
+
+def _purgeIfRequired(context):
 
     site = context.getSite()
     purged = site.purged = context.shouldPurge()
     return purged and 'Purged' or 'Unpurged'
 
-def _exportPropertiesINI( context ):
+
+def _exportPropertiesINI(context):
 
     site = context.getSite()
     text = _PROPERTIES_INI % site.title
 
-    context.writeDataFile( 'properties.ini', text, 'text/plain' )
+    context.writeDataFile('properties.ini', text, 'text/plain')
 
     return 'Exported properties'
 
 
 class _ToolsetSetup(BaseRegistryTests):
 
-    def _initSite( self ):
+    def _initSite(self):
         from Products.GenericSetup.tool import SetupTool
 
         site = Folder()
-        site._setId( 'site' )
-        self.app._setObject( 'site', site )
-        site = self.app._getOb( 'site' )
+        site._setId('site')
+        self.app._setObject('site', site)
+        site = self.app._getOb('site')
         site._setObject('setup_tool', SetupTool('setup_tool'))
         return site
 
@@ -1400,40 +1396,40 @@ class Test_exportToolset(_ToolsetSetup):
 
     layer = ExportImportZCMLLayer
 
-    def test_empty( self ):
+    def test_empty(self):
         from Products.GenericSetup.tool import exportToolset
         from Products.GenericSetup.tool import TOOLSET_XML
 
         site = self._initSite()
-        context = DummyExportContext( site, tool=site.setup_tool )
+        context = DummyExportContext(site, tool=site.setup_tool)
 
-        exportToolset( context )
+        exportToolset(context)
 
-        self.assertEqual( len( context._wrote ), 1 )
-        filename, text, content_type = context._wrote[ 0 ]
-        self.assertEqual( filename, TOOLSET_XML )
-        self._compareDOM( text, _EMPTY_TOOLSET_XML )
-        self.assertEqual( content_type, 'text/xml' )
+        self.assertEqual(len(context._wrote), 1)
+        filename, text, content_type = context._wrote[0]
+        self.assertEqual(filename, TOOLSET_XML)
+        self._compareDOM(text, _EMPTY_TOOLSET_XML)
+        self.assertEqual(content_type, 'text/xml')
 
-    def test_normal( self ):
+    def test_normal(self):
         from Products.GenericSetup.tool import exportToolset
         from Products.GenericSetup.tool import TOOLSET_XML
 
         site = self._initSite()
         toolset = site.setup_tool.getToolsetRegistry()
-        toolset.addForbiddenTool( 'doomed' )
-        toolset.addRequiredTool( 'mandatory', 'path.to.one' )
-        toolset.addRequiredTool( 'obligatory', 'path.to.another' )
+        toolset.addForbiddenTool('doomed')
+        toolset.addRequiredTool('mandatory', 'path.to.one')
+        toolset.addRequiredTool('obligatory', 'path.to.another')
 
-        context = DummyExportContext( site, tool=site.setup_tool )
+        context = DummyExportContext(site, tool=site.setup_tool)
 
-        exportToolset( context )
+        exportToolset(context)
 
-        self.assertEqual( len( context._wrote ), 1 )
-        filename, text, content_type = context._wrote[ 0 ]
-        self.assertEqual( filename, TOOLSET_XML )
-        self._compareDOM( text, _NORMAL_TOOLSET_XML )
-        self.assertEqual( content_type, 'text/xml' )
+        self.assertEqual(len(context._wrote), 1)
+        filename, text, content_type = context._wrote[0]
+        self.assertEqual(filename, TOOLSET_XML)
+        self._compareDOM(text, _NORMAL_TOOLSET_XML)
+        self.assertEqual(content_type, 'text/xml')
 
 
 class Test_importToolset(_ToolsetSetup):
@@ -1445,35 +1441,35 @@ class Test_importToolset(_ToolsetSetup):
         from Products.GenericSetup.tool import TOOLSET_XML
 
         site = self._initSite()
-        context = DummyImportContext( site, tool=site.setup_tool )
+        context = DummyImportContext(site, tool=site.setup_tool)
 
         # Import forbidden
-        context._files[ TOOLSET_XML ] = _FORBIDDEN_TOOLSET_XML
-        importToolset( context )
+        context._files[TOOLSET_XML] = _FORBIDDEN_TOOLSET_XML
+        importToolset(context)
 
         tool = context.getSetupTool()
         toolset = tool.getToolsetRegistry()
 
-        self.assertEqual( len( toolset.listForbiddenTools() ), 3 )
-        self.failUnless( 'doomed' in toolset.listForbiddenTools() )
-        self.failUnless( 'damned' in toolset.listForbiddenTools() )
-        self.failUnless( 'blasted' in toolset.listForbiddenTools() )
+        self.assertEqual(len(toolset.listForbiddenTools()), 3)
+        self.failUnless('doomed' in toolset.listForbiddenTools())
+        self.failUnless('damned' in toolset.listForbiddenTools())
+        self.failUnless('blasted' in toolset.listForbiddenTools())
 
         # Import required
-        context._files[ TOOLSET_XML ] = _REQUIRED_TOOLSET_XML
-        importToolset( context )
+        context._files[TOOLSET_XML] = _REQUIRED_TOOLSET_XML
+        importToolset(context)
 
-        self.assertEqual( len( toolset.listRequiredTools() ), 2 )
-        self.failUnless( 'mandatory' in toolset.listRequiredTools() )
-        info = toolset.getRequiredToolInfo( 'mandatory' )
-        self.assertEqual( info[ 'class' ],
-                          'Products.GenericSetup.tests.test_tool.DummyTool' )
-        self.failUnless( 'obligatory' in toolset.listRequiredTools() )
-        info = toolset.getRequiredToolInfo( 'obligatory' )
-        self.assertEqual( info[ 'class' ],
-                          'Products.GenericSetup.tests.test_tool.DummyTool' )
+        self.assertEqual(len(toolset.listRequiredTools()), 2)
+        self.failUnless('mandatory' in toolset.listRequiredTools())
+        info = toolset.getRequiredToolInfo('mandatory')
+        self.assertEqual(info['class'],
+                         'Products.GenericSetup.tests.test_tool.DummyTool')
+        self.failUnless('obligatory' in toolset.listRequiredTools())
+        info = toolset.getRequiredToolInfo('obligatory')
+        self.assertEqual(info['class'],
+                         'Products.GenericSetup.tests.test_tool.DummyTool')
 
-    def test_tool_ids( self ):
+    def test_tool_ids(self):
         # The tool import mechanism used to rely on the fact that all tools
         # have unique IDs set at the class level and that you can call their
         # constructor with no arguments. However, there might be tools
@@ -1482,14 +1478,14 @@ class Test_importToolset(_ToolsetSetup):
         from Products.GenericSetup.tool import TOOLSET_XML
 
         site = self._initSite()
-        context = DummyImportContext( site, tool=site.setup_tool )
-        context._files[ TOOLSET_XML ] = _REQUIRED_TOOLSET_XML
+        context = DummyImportContext(site, tool=site.setup_tool)
+        context._files[TOOLSET_XML] = _REQUIRED_TOOLSET_XML
 
-        importToolset( context )
+        importToolset(context)
 
-        for tool_id in ( 'mandatory', 'obligatory' ):
-            tool = getattr( site, tool_id )
-            self.assertEqual( tool.getId(), tool_id )
+        for tool_id in ('mandatory', 'obligatory'):
+            tool = getattr(site, tool_id)
+            self.assertEqual(tool.getId(), tool_id)
 
     def test_tool_id_required(self):
         # Tests that tool creation will still work when an id is required
@@ -1507,108 +1503,120 @@ class Test_importToolset(_ToolsetSetup):
             tool = getattr(site, tool_id)
             self.assertEqual(tool.getId(), tool_id)
 
-    def test_forbidden_tools( self ):
+    def test_forbidden_tools(self):
         from Products.GenericSetup.tool import importToolset
         from Products.GenericSetup.tool import TOOLSET_XML
 
-        TOOL_IDS = ( 'doomed', 'blasted', 'saved' )
+        TOOL_IDS = ('doomed', 'blasted', 'saved')
 
         site = self._initSite()
 
         for tool_id in TOOL_IDS:
             pseudo = Folder()
-            pseudo._setId( tool_id )
-            site._setObject( tool_id, pseudo )
+            pseudo._setId(tool_id)
+            site._setObject(tool_id, pseudo)
 
-        self.assertEqual( len( site.objectIds() ), len( TOOL_IDS ) + 1 )
+        self.assertEqual(len(site.objectIds()), len(TOOL_IDS) + 1)
 
         for tool_id in TOOL_IDS:
-            self.failUnless( tool_id in site.objectIds() )
+            self.failUnless(tool_id in site.objectIds())
 
-        context = DummyImportContext( site, tool=site.setup_tool )
-        context._files[ TOOLSET_XML ] = _FORBIDDEN_TOOLSET_XML
+        context = DummyImportContext(site, tool=site.setup_tool)
+        context._files[TOOLSET_XML] = _FORBIDDEN_TOOLSET_XML
 
-        importToolset( context )
+        importToolset(context)
 
-        self.assertEqual( len( site.objectIds() ), 2 )
-        self.failUnless( 'setup_tool' in site.objectIds() )
-        self.failUnless( 'saved' in site.objectIds() )
+        self.assertEqual(len(site.objectIds()), 2)
+        self.failUnless('setup_tool' in site.objectIds())
+        self.failUnless('saved' in site.objectIds())
 
-    def test_required_tools_missing( self ):
+    def test_required_tools_missing(self):
         from Products.GenericSetup.tool import importToolset
         from Products.GenericSetup.tool import TOOLSET_XML
 
         site = self._initSite()
-        self.assertEqual( len( site.objectIds() ), 1 )
+        self.assertEqual(len(site.objectIds()), 1)
 
-        context = DummyImportContext( site, tool=site.setup_tool )
-        context._files[ TOOLSET_XML ] = _REQUIRED_TOOLSET_XML
+        context = DummyImportContext(site, tool=site.setup_tool)
+        context._files[TOOLSET_XML] = _REQUIRED_TOOLSET_XML
 
-        importToolset( context )
+        importToolset(context)
 
-        self.assertEqual( len( site.objectIds() ), 3 )
-        self.failUnless( isinstance( aq_base( site._getOb( 'mandatory' ) )
-                                   , DummyTool ) )
-        self.failUnless( isinstance( aq_base( site._getOb( 'obligatory' ) )
-                                   , DummyTool ) )
+        self.assertEqual(len(site.objectIds()), 3)
+        self.failUnless(
+            isinstance(
+                aq_base(
+                    site._getOb('mandatory')),
+                DummyTool))
+        self.failUnless(
+            isinstance(
+                aq_base(
+                    site._getOb('obligatory')),
+                DummyTool))
 
-    def test_required_tools_no_replacement( self ):
+    def test_required_tools_no_replacement(self):
         from Products.GenericSetup.tool import importToolset
         from Products.GenericSetup.tool import TOOLSET_XML
 
         site = self._initSite()
 
         mandatory = DummyTool()
-        mandatory._setId( 'mandatory' )
-        site._setObject( 'mandatory', mandatory )
+        mandatory._setId('mandatory')
+        site._setObject('mandatory', mandatory)
 
         obligatory = DummyTool()
-        obligatory._setId( 'obligatory' )
-        site._setObject( 'obligatory', obligatory )
+        obligatory._setId('obligatory')
+        site._setObject('obligatory', obligatory)
 
-        self.assertEqual( len( site.objectIds() ), 3 )
+        self.assertEqual(len(site.objectIds()), 3)
 
-        context = DummyImportContext( site, tool=site.setup_tool )
-        context._files[ TOOLSET_XML ] = _REQUIRED_TOOLSET_XML
+        context = DummyImportContext(site, tool=site.setup_tool)
+        context._files[TOOLSET_XML] = _REQUIRED_TOOLSET_XML
 
-        importToolset( context )
+        importToolset(context)
 
-        self.assertEqual( len( site.objectIds() ), 3 )
-        self.failUnless( aq_base( site._getOb( 'mandatory' ) ) is mandatory )
-        self.failUnless( aq_base( site._getOb( 'obligatory' ) ) is obligatory )
+        self.assertEqual(len(site.objectIds()), 3)
+        self.failUnless(aq_base(site._getOb('mandatory')) is mandatory)
+        self.failUnless(aq_base(site._getOb('obligatory')) is obligatory)
 
-    def test_required_tools_with_replacement( self ):
+    def test_required_tools_with_replacement(self):
         from Products.GenericSetup.tool import importToolset
         from Products.GenericSetup.tool import TOOLSET_XML
 
         site = self._initSite()
 
         mandatory = AnotherDummyTool()
-        mandatory._setId( 'mandatory' )
-        site._setObject( 'mandatory', mandatory )
+        mandatory._setId('mandatory')
+        site._setObject('mandatory', mandatory)
 
         obligatory = SubclassedDummyTool()
-        obligatory._setId( 'obligatory' )
-        site._setObject( 'obligatory', obligatory )
+        obligatory._setId('obligatory')
+        site._setObject('obligatory', obligatory)
 
-        self.assertEqual( len( site.objectIds() ), 3 )
+        self.assertEqual(len(site.objectIds()), 3)
 
-        context = DummyImportContext( site, tool=site.setup_tool )
-        context._files[ TOOLSET_XML ] = _REQUIRED_TOOLSET_XML
+        context = DummyImportContext(site, tool=site.setup_tool)
+        context._files[TOOLSET_XML] = _REQUIRED_TOOLSET_XML
 
-        importToolset( context )
+        importToolset(context)
 
-        self.assertEqual( len( site.objectIds() ), 3 )
+        self.assertEqual(len(site.objectIds()), 3)
 
-        self.failIf( aq_base( site._getOb( 'mandatory' ) ) is mandatory )
-        self.failUnless( isinstance( aq_base( site._getOb( 'mandatory' ) )
-                                   , DummyTool ) )
+        self.failIf(aq_base(site._getOb('mandatory')) is mandatory)
+        self.failUnless(
+            isinstance(
+                aq_base(
+                    site._getOb('mandatory')),
+                DummyTool))
 
-        self.failIf( aq_base( site._getOb( 'obligatory' ) ) is obligatory )
-        self.failUnless( isinstance( aq_base( site._getOb( 'obligatory' ) )
-                                   , DummyTool ) )
+        self.failIf(aq_base(site._getOb('obligatory')) is obligatory)
+        self.failUnless(
+            isinstance(
+                aq_base(
+                    site._getOb('obligatory')),
+                DummyTool))
 
-    def test_required_tools_missing_acquired_nofail( self ):
+    def test_required_tools_missing_acquired_nofail(self):
         from Products.GenericSetup.tool import importToolset
         from Products.GenericSetup.tool import TOOLSET_XML
 
@@ -1616,12 +1624,12 @@ class Test_importToolset(_ToolsetSetup):
         parent_site = Folder()
 
         mandatory = AnotherDummyTool()
-        mandatory._setId( 'mandatory' )
-        parent_site._setObject( 'mandatory', mandatory )
+        mandatory._setId('mandatory')
+        parent_site._setObject('mandatory', mandatory)
 
         obligatory = AnotherDummyTool()
-        obligatory._setId( 'obligatory' )
-        parent_site._setObject( 'obligatory', obligatory )
+        obligatory._setId('obligatory')
+        parent_site._setObject('obligatory', obligatory)
 
         site = site.__of__(parent_site)
 
@@ -1629,37 +1637,43 @@ class Test_importToolset(_ToolsetSetup):
         # should not prevent new objects from being created if they
         # don't exist in the site
 
-        context = DummyImportContext( site, tool=site.setup_tool )
-        context._files[ TOOLSET_XML ] = _REQUIRED_TOOLSET_XML
+        context = DummyImportContext(site, tool=site.setup_tool)
+        context._files[TOOLSET_XML] = _REQUIRED_TOOLSET_XML
 
-        importToolset( context )
+        importToolset(context)
 
-        self.failIf( aq_base( site._getOb( 'mandatory' ) ) is mandatory )
-        self.failUnless( isinstance( aq_base( site._getOb( 'mandatory' ) )
-                                   , DummyTool ) )
+        self.failIf(aq_base(site._getOb('mandatory')) is mandatory)
+        self.failUnless(
+            isinstance(
+                aq_base(
+                    site._getOb('mandatory')),
+                DummyTool))
 
-        self.failIf( aq_base( site._getOb( 'obligatory' ) ) is obligatory )
-        self.failUnless( isinstance( aq_base( site._getOb( 'obligatory' ) )
-                                   , DummyTool ) )
+        self.failIf(aq_base(site._getOb('obligatory')) is obligatory)
+        self.failUnless(
+            isinstance(
+                aq_base(
+                    site._getOb('obligatory')),
+                DummyTool))
 
-    def test_required_tools_missing_class_with_replacement( self ):
+    def test_required_tools_missing_class_with_replacement(self):
         from Products.GenericSetup.tool import importToolset
         from Products.GenericSetup.tool import TOOLSET_XML
 
         site = self._initSite()
 
         obligatory = AnotherDummyTool()
-        obligatory._setId( 'obligatory' )
-        site._setObject( 'obligatory', obligatory )
+        obligatory._setId('obligatory')
+        site._setObject('obligatory', obligatory)
 
-        self.assertEqual( len( site.objectIds() ), 2 )
+        self.assertEqual(len(site.objectIds()), 2)
 
-        context = DummyImportContext( site, tool=site.setup_tool )
-        context._files[ TOOLSET_XML ] = _BAD_CLASS_TOOLSET_XML
+        context = DummyImportContext(site, tool=site.setup_tool)
+        context._files[TOOLSET_XML] = _BAD_CLASS_TOOLSET_XML
 
-        importToolset( context )
+        importToolset(context)
 
-        self.assertEqual( len( site.objectIds() ), 2 )
+        self.assertEqual(len(site.objectIds()), 2)
 
 
 class DummyTool(Folder):
@@ -1738,9 +1752,10 @@ _BAD_CLASS_TOOLSET_XML = """\
 </tool-setup>
 """
 
+
 def test_suite():
     return unittest.TestSuite((
-        unittest.makeSuite( SetupToolTests ),
-        unittest.makeSuite( Test_exportToolset ),
-        unittest.makeSuite( Test_importToolset ),
-        ))
+        unittest.makeSuite(SetupToolTests),
+        unittest.makeSuite(Test_exportToolset),
+        unittest.makeSuite(Test_importToolset),
+    ))

--- a/Products/GenericSetup/tests/test_utils.py
+++ b/Products/GenericSetup/tests/test_utils.py
@@ -229,14 +229,14 @@ def _getDocumentElement(text):
     return parseString(text).documentElement
 
 
-def _testFunc( *args, **kw ):
-
+def _testFunc(*args, **kw):
     """ This is a test.
 
     This is only a test.
     """
 
 _TEST_FUNC_NAME = 'Products.GenericSetup.tests.test_utils._testFunc'
+
 
 class Whatever:
     pass
@@ -248,42 +248,42 @@ whatever_inst.__name__ = 'whatever_inst'
 
 _WHATEVER_INST_NAME = 'Products.GenericSetup.tests.test_utils.whatever_inst'
 
-class UtilsTests( unittest.TestCase ):
 
-    def test__getDottedName_simple( self ):
+class UtilsTests(unittest.TestCase):
 
-        from Products.GenericSetup.utils import _getDottedName
-
-        self.assertEqual( _getDottedName( _testFunc ), _TEST_FUNC_NAME )
-
-    def test__getDottedName_string( self ):
+    def test__getDottedName_simple(self):
 
         from Products.GenericSetup.utils import _getDottedName
 
-        self.assertEqual( _getDottedName( _TEST_FUNC_NAME ), _TEST_FUNC_NAME )
+        self.assertEqual(_getDottedName(_testFunc), _TEST_FUNC_NAME)
 
-    def test__getDottedName_unicode( self ):
+    def test__getDottedName_string(self):
+
+        from Products.GenericSetup.utils import _getDottedName
+
+        self.assertEqual(_getDottedName(_TEST_FUNC_NAME), _TEST_FUNC_NAME)
+
+    def test__getDottedName_unicode(self):
 
         from Products.GenericSetup.utils import _getDottedName
 
         dotted = u'%s' % _TEST_FUNC_NAME
-        self.assertEqual( _getDottedName( dotted ), _TEST_FUNC_NAME )
-        self.assertEqual( type( _getDottedName( dotted ) ), str )
+        self.assertEqual(_getDottedName(dotted), _TEST_FUNC_NAME)
+        self.assertEqual(type(_getDottedName(dotted)), str)
 
-    def test__getDottedName_class( self ):
-
-        from Products.GenericSetup.utils import _getDottedName
-
-        self.assertEqual( _getDottedName( Whatever ), _WHATEVER_NAME )
-
-    def test__getDottedName_inst( self ):
+    def test__getDottedName_class(self):
 
         from Products.GenericSetup.utils import _getDottedName
 
-        self.assertEqual( _getDottedName( whatever_inst )
-                        , _WHATEVER_INST_NAME )
+        self.assertEqual(_getDottedName(Whatever), _WHATEVER_NAME)
 
-    def test__getDottedName_noname( self ):
+    def test__getDottedName_inst(self):
+
+        from Products.GenericSetup.utils import _getDottedName
+
+        self.assertEqual(_getDottedName(whatever_inst), _WHATEVER_INST_NAME)
+
+    def test__getDottedName_noname(self):
 
         from Products.GenericSetup.utils import _getDottedName
 
@@ -291,7 +291,7 @@ class UtilsTests( unittest.TestCase ):
             pass
 
         doh = Doh()
-        self.assertRaises( ValueError, _getDottedName, doh )
+        self.assertRaises(ValueError, _getDottedName, doh)
 
 
 class PropertyManagerHelpersTests(unittest.TestCase):
@@ -354,14 +354,14 @@ class PropertyManagerHelpersTests(unittest.TestCase):
         obj._updateProperty('foo_date', '2000/01/01 00:00:00 UTC')
         obj._updateProperty('foo_float', '1.1')
         obj._updateProperty('foo_int', '1')
-        obj._updateProperty('foo_lines', 
-                u'Foo\nLines\n\xfcbrigens'.encode('utf-8'))
+        obj._updateProperty('foo_lines',
+                            u'Foo\nLines\n\xfcbrigens'.encode('utf-8'))
         obj._updateProperty('foo_long', '1')
         obj._updateProperty('foo_string', 'Foo String')
         obj._updateProperty('foo_text', 'Foo\nText')
-        obj._updateProperty( 'foo_tokens', ('Foo', 'Tokens') )
+        obj._updateProperty('foo_tokens', ('Foo', 'Tokens'))
         obj._updateProperty('foo_selection', 'Foo')
-        obj._updateProperty( 'foo_mselection', ('Foo', 'Baz') )
+        obj._updateProperty('foo_mselection', ('Foo', 'Baz'))
         obj.foo_boolean0 = 0
         obj._updateProperty('foo_date_naive', '2000/01/01 00:00:00')
         obj._updateProperty('foo_ro', 'RO')
@@ -390,7 +390,7 @@ class PropertyManagerHelpersTests(unittest.TestCase):
 
         # The extraction process wants to decode text properties
         # to unicode using the default ZPublisher encoding, which
-        # defaults to iso-8859-15. We force UTF-8 here because we 
+        # defaults to iso-8859-15. We force UTF-8 here because we
         # forced our properties to be UTF-8 encoded.
         helpers._encoding = 'utf-8'
         node.appendChild(helpers._extractProperties())
@@ -475,12 +475,12 @@ class PropertyManagerHelpersTests(unittest.TestCase):
         helpers._initProperties(node)
 
         self.assertEqual(helpers.context.getProperty('i18n_domain'),
-                        'dummy_domain')
+                         'dummy_domain')
 
     def test__initProperties_nopurge_base(self):
         helpers = self._makeOne()
         node = _getDocumentElement(_NOPURGE_IMPORT)
-        helpers.environ._should_purge = True # base profile
+        helpers.environ._should_purge = True  # base profile
         obj = helpers.context
         obj._properties = ()
         obj.manage_addProperty('lines1', ('Foo', 'Gee'), 'lines')
@@ -495,7 +495,7 @@ class PropertyManagerHelpersTests(unittest.TestCase):
     def test__initProperties_nopurge_extension(self):
         helpers = self._makeOne()
         node = _getDocumentElement(_NOPURGE_IMPORT)
-        helpers.environ._should_purge = False # extension profile
+        helpers.environ._should_purge = False  # extension profile
         obj = helpers.context
         obj._properties = ()
         obj.manage_addProperty('lines1', ('Foo', 'Gee'), 'lines')
@@ -510,7 +510,7 @@ class PropertyManagerHelpersTests(unittest.TestCase):
     def test_initProperties_remove_elements(self):
         helpers = self._makeOne()
         node = _getDocumentElement(_REMOVE_ELEMENT_IMPORT)
-        helpers.environ._should_purge = False # extension profile
+        helpers.environ._should_purge = False  # extension profile
         obj = helpers.context
         obj._properties = ()
         obj.manage_addProperty('lines1', ('Foo', 'Gee'), 'lines')
@@ -522,7 +522,7 @@ class PropertyManagerHelpersTests(unittest.TestCase):
 
     def test_initProperties_remove_properties(self):
         helpers = self._makeOne()
-        helpers.environ._should_purge = False # extension profile
+        helpers.environ._should_purge = False  # extension profile
         obj = helpers.context
         obj._properties = ()
 
@@ -716,14 +716,14 @@ class ObjectManagerHelpersTests(ZopeTestCase):
         helpers._initObjects(node)
         self.failIf('history' in obj.objectIds())
         self.failUnless('future' in obj.objectIds())
-        
+
         # Removing it a second time should not throw an
         # AttributeError.
         node = _getDocumentElement(_REMOVE_IMPORT)
         helpers._initObjects(node)
         self.failIf('history' in obj.objectIds())
         self.failUnless('future' in obj.objectIds())
-        
+
 
 class PrettyDocumentTests(unittest.TestCase):
 
@@ -732,7 +732,7 @@ class PrettyDocumentTests(unittest.TestCase):
         original = 'baz &nbsp;<bar>&"\''
         expected = ('<?xml version="1.0"?>\n'
                     '<doc bar="" foo="baz '
-                        '&amp;nbsp;&lt;bar&gt;&amp;&quot;\'"/>\n')
+                    '&amp;nbsp;&lt;bar&gt;&amp;&quot;\'"/>\n')
 
         doc = PrettyDocument()
         node = doc.createElement('doc')
@@ -772,4 +772,4 @@ def test_suite():
         unittest.makeSuite(MarkerInterfaceHelpersTests),
         unittest.makeSuite(ObjectManagerHelpersTests),
         unittest.makeSuite(PrettyDocumentTests),
-        ))
+    ))

--- a/Products/GenericSetup/tests/test_zcml.py
+++ b/Products/GenericSetup/tests/test_zcml.py
@@ -31,17 +31,22 @@ except ImportError:
 def dummy_importstep(context):
     pass
 
+
 def dummy_exportstep(context):
     pass
+
 
 def dummy_upgrade(context):
     pass
 
+
 def b_dummy_upgrade(context):
     pass
 
+
 def c_dummy_upgrade(context):
     pass
+
 
 def test_simpleRegisterProfile():
     """
@@ -84,6 +89,7 @@ def test_simpleRegisterProfile():
 
       >>> cleanUp()
     """
+
 
 def test_registerProfile():
     """
@@ -129,6 +135,7 @@ def test_registerProfile():
 
       >>> cleanUp()
     """
+
 
 def test_registerUpgradeStep(self):
     """
@@ -190,6 +197,7 @@ def test_registerUpgradeStep(self):
       >>> cleanUp()
     """
 
+
 def test_registerUpgradeDepends(self):
     """
     Use the standalone genericsetup:upgradeDepends directive::
@@ -233,6 +241,7 @@ def test_registerUpgradeDepends(self):
 
       >>> cleanUp()
     """
+
 
 def test_registerUpgradeSteps(self):
     """
@@ -371,15 +380,14 @@ class ImportStepTests(unittest.TestCase):
              handler="Products.GenericSetup.tests.test_zcml.dummy_importstep">
          </genericsetup:importStep>
         </configure>""")
-        self.assertEqual( _import_step_registry.listSteps(), [u'name'])
-        data=_import_step_registry.getStepMetadata(u'name')
+        self.assertEqual(_import_step_registry.listSteps(), [u'name'])
+        data = _import_step_registry.getStepMetadata(u'name')
         self.assertEqual(data["handler"],
-                'Products.GenericSetup.tests.test_zcml.dummy_importstep')
+                         'Products.GenericSetup.tests.test_zcml.dummy_importstep')
         self.assertEqual(data["description"], u"description")
         self.assertEqual(data["title"], u"title")
         self.assertEqual(data["dependencies"], ())
         self.assertEqual(data["id"], u"name")
-
 
     def testWithDependency(self):
         zcml.load_string("""
@@ -393,9 +401,8 @@ class ImportStepTests(unittest.TestCase):
           <depends name="something.else"/>
          </genericsetup:importStep>
         </configure>""")
-        data=_import_step_registry.getStepMetadata(u'name')
+        data = _import_step_registry.getStepMetadata(u'name')
         self.assertEqual(data["dependencies"], (u"something.else",))
-
 
 
 class ExportStepTests(unittest.TestCase):
@@ -418,10 +425,10 @@ class ExportStepTests(unittest.TestCase):
             handler="Products.GenericSetup.tests.test_zcml.dummy_exportstep"
             />
         </configure>""")
-        self.assertEqual( _export_step_registry.listSteps(), [u'name'])
-        data=_export_step_registry.getStepMetadata(u'name')
+        self.assertEqual(_export_step_registry.listSteps(), [u'name'])
+        data = _export_step_registry.getStepMetadata(u'name')
         self.assertEqual(data["handler"],
-                'Products.GenericSetup.tests.test_zcml.dummy_exportstep')
+                         'Products.GenericSetup.tests.test_zcml.dummy_exportstep')
         self.assertEqual(data["description"], u"description")
         self.assertEqual(data["title"], u"title")
         self.assertEqual(data["id"], u"name")

--- a/Products/GenericSetup/tests/tests.py
+++ b/Products/GenericSetup/tests/tests.py
@@ -16,6 +16,7 @@
 import doctest
 import unittest
 
+
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest.DocFileSuite('upgrade.txt'))

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -68,6 +68,7 @@ DEFAULT_DEPENDENCY_STRATEGY = DEPENDENCY_STRATEGY_UPGRADE
 
 generic_logger = logging.getLogger(__name__)
 
+
 def exportStepRegistries(context):
     """ Built-in handler for exporting import / export step registries.
     """
@@ -89,6 +90,7 @@ def exportStepRegistries(context):
         logger.info('Local export steps exported.')
     else:
         logger.debug('No local export steps.')
+
 
 def importToolset(context):
     """ Import required / forbidden tools from XML file.
@@ -145,6 +147,7 @@ def importToolset(context):
 
     logger.info('Toolset imported.')
 
+
 def exportToolset(context):
     """ Export required / forbidden tools to XML file.
     """
@@ -185,18 +188,21 @@ class SetupTool(Folder):
     #   ISetupTool API
     #
     security.declareProtected(ManagePortal, 'getEncoding')
+
     def getEncoding(self):
         """ See ISetupTool.
         """
         return 'utf-8'
 
     security.declareProtected(ManagePortal, 'getBaselineContextID')
+
     def getBaselineContextID(self):
         """ See ISetupTool.
         """
         return self._baseline_context_id
 
     security.declareProtected(ManagePortal, 'setBaselineContext')
+
     def setBaselineContext(self, context_id, encoding=None):
         """ See ISetupTool.
         """
@@ -204,40 +210,47 @@ class SetupTool(Folder):
         self.applyContextById(context_id, encoding)
 
     security.declareProtected(ManagePortal, 'getExcludeGlobalSteps')
+
     def getExcludeGlobalSteps(self):
         """ See ISetupTool.
         """
         return self._exclude_global_steps
 
     security.declareProtected(ManagePortal, 'setExcludeGlobalSteps')
+
     def setExcludeGlobalSteps(self, value):
         """ See ISetupTool.
         """
         self._exclude_global_steps = value
 
     security.declareProtected(ManagePortal, 'applyContextById')
+
     def applyContextById(self, context_id, encoding=None):
         context = self._getImportContext(context_id)
         self.applyContext(context, encoding)
 
     security.declareProtected(ManagePortal, 'applyContext')
+
     def applyContext(self, context, encoding=None):
         self._updateImportStepsRegistry(context, encoding)
         self._updateExportStepsRegistry(context, encoding)
 
     security.declareProtected(ManagePortal, 'getImportStepRegistry')
+
     def getImportStepRegistry(self):
         """ See ISetupTool.
         """
         return self._import_registry
 
     security.declareProtected(ManagePortal, 'getExportStepRegistry')
+
     def getExportStepRegistry(self):
         """ See ISetupTool.
         """
         return self._export_registry
 
     security.declareProtected(ManagePortal, 'getImportStep')
+
     def getImportStep(self, step, default=None):
         """Simple wrapper to query both the global and local step registry."""
         res = self._import_registry.getStep(step, self)
@@ -248,6 +261,7 @@ class SetupTool(Folder):
         return default
 
     security.declareProtected(ManagePortal, 'getSortedImportSteps')
+
     def getSortedImportSteps(self):
         if self._exclude_global_steps:
             steps = set()
@@ -258,6 +272,7 @@ class SetupTool(Folder):
         return tuple(_computeTopologicalSort(step_infos))
 
     security.declareProtected(ManagePortal, 'getImportStepMetadata')
+
     def getImportStepMetadata(self, step, default=None):
         """Simple wrapper to query both the global and local step registry."""
         res = self._import_registry.getStepMetadata(step, self)
@@ -268,6 +283,7 @@ class SetupTool(Folder):
         return default
 
     security.declareProtected(ManagePortal, 'getExportStep')
+
     def getExportStep(self, step, default=None):
         """Simple wrapper to query both the global and local step registry."""
         res = self._export_registry.getStep(step, self)
@@ -278,6 +294,7 @@ class SetupTool(Folder):
         return default
 
     security.declareProtected(ManagePortal, 'listExportSteps')
+
     def listExportSteps(self):
         steps = set(self._export_registry.listSteps())
         if not self._exclude_global_steps:
@@ -285,14 +302,15 @@ class SetupTool(Folder):
         return tuple(steps)
 
     security.declareProtected(ManagePortal, 'listImportSteps')
+
     def listImportSteps(self):
         steps = set(self._import_registry.listSteps())
         if not self._exclude_global_steps:
             steps.update(set(_import_step_registry.listSteps()))
         return tuple(steps)
 
-
     security.declareProtected(ManagePortal, 'getExportStepMetadata')
+
     def getExportStepMetadata(self, step, default=None):
         """Simple wrapper to query both the global and local step registry."""
         res = self._export_registry.getStepMetadata(step, self)
@@ -303,12 +321,14 @@ class SetupTool(Folder):
         return default
 
     security.declareProtected(ManagePortal, 'getToolsetRegistry')
+
     def getToolsetRegistry(self):
         """ See ISetupTool.
         """
         return self._toolset_registry
 
     security.declareProtected(ManagePortal, 'runImportStepFromProfile')
+
     def runImportStepFromProfile(self, profile_id, step_id,
                                  run_dependencies=True, purge_old=None):
         """ See ISetupTool.
@@ -345,7 +365,7 @@ class SetupTool(Folder):
             messages[step] = message or ''
 
         message_list = filter(None, [message])
-        message_list.extend([ '%s: %s' % x[1:] for x in context.listNotes() ])
+        message_list.extend(['%s: %s' % x[1:] for x in context.listNotes()])
         messages[step_id] = '\n'.join(message_list)
 
         event.notify(
@@ -354,6 +374,7 @@ class SetupTool(Folder):
         return {'steps': steps, 'messages': messages}
 
     security.declareProtected(ManagePortal, 'runAllImportStepsFromProfile')
+
     def runAllImportStepsFromProfile(self,
                                      profile_id,
                                      purge_old=None,
@@ -366,12 +387,12 @@ class SetupTool(Folder):
         __traceback_info__ = profile_id
 
         result = self._runImportStepsFromContext(
-                            purge_old=purge_old,
-                            profile_id=profile_id,
-                            archive=archive,
-                            ignore_dependencies=ignore_dependencies,
-                            blacklisted_steps=blacklisted_steps,
-                            dependency_strategy=dependency_strategy)
+            purge_old=purge_old,
+            profile_id=profile_id,
+            archive=archive,
+            ignore_dependencies=ignore_dependencies,
+            blacklisted_steps=blacklisted_steps,
+            dependency_strategy=dependency_strategy)
         if profile_id is None:
             prefix = 'import-all-from-tar'
         else:
@@ -382,18 +403,21 @@ class SetupTool(Folder):
         return result
 
     security.declareProtected(ManagePortal, 'runExportStep')
+
     def runExportStep(self, step_id):
         """ See ISetupTool.
         """
         return self._doRunExportSteps([step_id])
 
     security.declareProtected(ManagePortal, 'runAllExportSteps')
+
     def runAllExportSteps(self):
         """ See ISetupTool.
         """
         return self._doRunExportSteps(self.listExportSteps())
 
     security.declareProtected(ManagePortal, 'createSnapshot')
+
     def createSnapshot(self, snapshot_id):
         """ See ISetupTool.
         """
@@ -418,13 +442,14 @@ class SetupTool(Folder):
                 'snapshot': context.getSnapshotFolder()}
 
     security.declareProtected(ManagePortal, 'compareConfigurations')
+
     def compareConfigurations(self,
                               lhs_context,
                               rhs_context,
                               missing_as_empty=False,
                               ignore_blanks=False,
                               skip=SKIPPED_FILES,
-                             ):
+                              ):
         """ See ISetupTool.
         """
         differ = ConfigDiff(lhs_context,
@@ -432,11 +457,12 @@ class SetupTool(Folder):
                             missing_as_empty,
                             ignore_blanks,
                             skip,
-                           )
+                            )
 
         return differ.compare()
 
     security.declareProtected(ManagePortal, 'markupComparison')
+
     def markupComparison(self, lines):
         """ See ISetupTool.
         """
@@ -481,7 +507,7 @@ class SetupTool(Folder):
 
         return '<pre>\n%s\n</pre>' % (
             '\n'.join([('<span class="%s">%s</span>' % (cl, escape(l)))
-                                  for cl, l in result]))
+                       for cl, l in result]))
 
     #
     #   ZMI
@@ -495,15 +521,16 @@ class SetupTool(Folder):
          {'label': 'Snapshots', 'action': 'manage_snapshots'},
          {'label': 'Comparison', 'action': 'manage_showDiff'},
          {'label': 'Manage', 'action': 'manage_stepRegistry'}) +
-        Folder.manage_options[3:]) # skip "View", "Properties"
+        Folder.manage_options[3:])  # skip "View", "Properties"
 
     security.declareProtected(ManagePortal, 'manage_tool')
     manage_tool = PageTemplateFile('sutProperties', _wwwdir)
 
     security.declareProtected(ManagePortal, 'manage_updateToolProperties')
+
     def manage_updateToolProperties(self, context_id,
-                                          exclude_global_steps=False,
-                                          RESPONSE=None):
+                                    exclude_global_steps=False,
+                                    RESPONSE=None):
         """ Update the tool's settings.
         """
         self.setExcludeGlobalSteps(exclude_global_steps)
@@ -511,12 +538,13 @@ class SetupTool(Folder):
 
         if RESPONSE is not None:
             RESPONSE.redirect('%s/manage_tool?manage_tabs_message=%s'
-                            % (self.absolute_url(), 'Properties+updated.'))
+                              % (self.absolute_url(), 'Properties+updated.'))
 
     security.declareProtected(ManagePortal, 'manage_importSteps')
     manage_importSteps = PageTemplateFile('sutImportSteps', _wwwdir)
 
     security.declareProtected(ManagePortal, 'manage_importSelectedSteps')
+
     def manage_importSelectedSteps(self, ids, run_dependencies,
                                    context_id=None):
         """ Import the steps selected by the user.
@@ -545,6 +573,7 @@ class SetupTool(Folder):
                                        messages=messages)
 
     security.declareProtected(ManagePortal, 'manage_importAllSteps')
+
     def manage_importAllSteps(self, context_id=None, dependency_strategy=None):
         """ Import all steps.
         """
@@ -560,6 +589,7 @@ class SetupTool(Folder):
                                        messages=result['messages'])
 
     security.declareProtected(ManagePortal, 'manage_importExtensions')
+
     def manage_importExtensions(self, RESPONSE, profile_ids=()):
         """ Import all steps for the selected extension profiles.
         """
@@ -567,7 +597,7 @@ class SetupTool(Folder):
         if len(profile_ids) == 0:
             message = 'Please select one or more extension profiles.'
             RESPONSE.redirect('%s/manage_tool?manage_tabs_message=%s'
-                                  % (self.absolute_url(), message))
+                              % (self.absolute_url(), message))
         else:
             message = 'Imported profiles: %s' % ', '.join(profile_ids)
 
@@ -579,9 +609,10 @@ class SetupTool(Folder):
                     detail['%s:%s' % (profile_id, k)] = v
 
             return self.manage_importSteps(manage_tabs_message=message,
-                                        messages=detail)
+                                           messages=detail)
 
     security.declareProtected(ManagePortal, 'manage_importTarball')
+
     def manage_importTarball(self, tarball):
         """ Import steps from the uploaded tarball.
         """
@@ -599,12 +630,13 @@ class SetupTool(Folder):
     manage_exportSteps = PageTemplateFile('sutExportSteps', _wwwdir)
 
     security.declareProtected(ManagePortal, 'manage_exportSelectedSteps')
+
     def manage_exportSelectedSteps(self, ids, RESPONSE):
         """ Export the steps selected by the user.
         """
         if not ids:
             RESPONSE.redirect('%s/manage_exportSteps?manage_tabs_message=%s'
-                             % (self.absolute_url(), 'No+steps+selected.'))
+                              % (self.absolute_url(), 'No+steps+selected.'))
 
         result = self._doRunExportSteps(ids)
         RESPONSE.setHeader('Content-type', 'application/x-gzip')
@@ -613,6 +645,7 @@ class SetupTool(Folder):
         return result['tarball']
 
     security.declareProtected(ManagePortal, 'manage_exportAllSteps')
+
     def manage_exportAllSteps(self, RESPONSE):
         """ Export all steps.
         """
@@ -632,6 +665,7 @@ class SetupTool(Folder):
     manage_snapshots = PageTemplateFile('sutSnapshots', _wwwdir)
 
     security.declareProtected(ManagePortal, 'listSnapshotInfo')
+
     def listSnapshotInfo(self):
         """ Return a list of mappings describing available snapshots.
 
@@ -654,6 +688,7 @@ class SetupTool(Folder):
         return result
 
     security.declareProtected(ManagePortal, 'listProfileInfo')
+
     def listProfileInfo(self, for_=None):
         """ Return a list of mappings describing registered profiles.
         Base profile is listed first, extensions are sorted.
@@ -681,6 +716,7 @@ class SetupTool(Folder):
         return base + ext
 
     security.declareProtected(ManagePortal, 'listContextInfos')
+
     def listContextInfos(self):
         """ List registered profiles and snapshots.
         """
@@ -692,27 +728,28 @@ class SetupTool(Folder):
             return 'unknown'
 
         s_infos = [{'id': 'snapshot-%s' % info['id'],
-                     'title': info['title'],
-                     'type': 'snapshot',
-                   }
-                    for info in self.listSnapshotInfo()]
+                    'title': info['title'],
+                    'type': 'snapshot',
+                    }
+                   for info in self.listSnapshotInfo()]
         s_infos.sort(key=itemgetter('title'))
         p_infos = [{'id': 'profile-%s' % info['id'],
                     'title': info['title'],
                     'type': readableType(info['type']),
-                   }
+                    }
                    for info in self.listProfileInfo()]
         p_infos.sort(key=itemgetter('title'))
 
         return tuple(s_infos + p_infos)
 
     security.declareProtected(ManagePortal, 'getProfileImportDate')
+
     def getProfileImportDate(self, profile_id):
         """ See ISetupTool.
         """
         prefix = ('import-all-%s-' % profile_id).replace(':', '_')
         candidates = [x for x in self.objectIds('File')
-                        if x[:-18] == prefix and x.endswith('.log')]
+                      if x[:-18] == prefix and x.endswith('.log')]
         if len(candidates) == 0:
             return None
         candidates.sort()
@@ -724,9 +761,10 @@ class SetupTool(Folder):
                                        stamp[8:10],
                                        stamp[10:12],
                                        stamp[12:14],
-                                      )
+                                       )
 
     security.declareProtected(ManagePortal, 'manage_createSnapshot')
+
     def manage_createSnapshot(self, RESPONSE, snapshot_id=None):
         """ Create a snapshot with the given ID.
 
@@ -738,7 +776,7 @@ class SetupTool(Folder):
         self.createSnapshot(snapshot_id)
 
         return RESPONSE.redirect('%s/manage_snapshots?manage_tabs_message=%s'
-                         % (self.absolute_url(), 'Snapshot+created.'))
+                                 % (self.absolute_url(), 'Snapshot+created.'))
 
     security.declareProtected(ManagePortal, 'manage_showDiff')
     manage_showDiff = PageTemplateFile('sutCompare', _wwwdir)
@@ -749,7 +787,7 @@ class SetupTool(Folder):
                             missing_as_empty,
                             ignore_blanks,
                             RESPONSE,
-                           ):
+                            ):
         """ Crack request vars and call compareConfigurations.
 
         o Return the result as a 'text/plain' stream, suitable for framing.
@@ -758,17 +796,18 @@ class SetupTool(Folder):
                                                        rhs,
                                                        missing_as_empty,
                                                        ignore_blanks,
-                                                      )
+                                                       )
         RESPONSE.setHeader('Content-Type', 'text/plain')
         return _PLAINTEXT_DIFF_HEADER % (lhs, rhs, comparison)
 
     security.declareProtected(ManagePortal, 'manage_compareConfigurations')
+
     def manage_compareConfigurations(self,
                                      lhs,
                                      rhs,
                                      missing_as_empty,
                                      ignore_blanks,
-                                    ):
+                                     ):
         """ Crack request vars and call compareConfigurations.
         """
         lhs_context = self._getImportContext(lhs)
@@ -778,12 +817,13 @@ class SetupTool(Folder):
                                           rhs_context,
                                           missing_as_empty,
                                           ignore_blanks,
-                                         )
+                                          )
 
     security.declareProtected(ManagePortal, 'manage_stepRegistry')
     manage_stepRegistry = PageTemplateFile('sutManage', _wwwdir)
 
     security.declareProtected(ManagePortal, 'manage_deleteImportSteps')
+
     def manage_deleteImportSteps(self, ids, request=None):
         """ Delete selected import steps.
         """
@@ -796,6 +836,7 @@ class SetupTool(Folder):
         request.RESPONSE.redirect("%s/manage_stepRegistry" % url)
 
     security.declareProtected(ManagePortal, 'manage_deleteExportSteps')
+
     def manage_deleteExportSteps(self, ids, request=None):
         """ Delete selected export steps.
         """
@@ -811,6 +852,7 @@ class SetupTool(Folder):
     # Upgrades management
     #
     security.declareProtected(ManagePortal, 'getLastVersionForProfile')
+
     def getLastVersionForProfile(self, profile_id):
         """Return the last upgraded version for the specified profile.
         """
@@ -821,6 +863,7 @@ class SetupTool(Folder):
         return version
 
     security.declareProtected(ManagePortal, 'setLastVersionForProfile')
+
     def setLastVersionForProfile(self, profile_id, version):
         """Set the last upgraded version for the specified profile.
         """
@@ -834,6 +877,7 @@ class SetupTool(Folder):
         self._profile_upgrade_versions = prof_versions
 
     security.declareProtected(ManagePortal, 'getVersionForProfile')
+
     def getVersionForProfile(self, profile_id):
         """Return the registered filesystem version for the specified
         profile.
@@ -841,6 +885,7 @@ class SetupTool(Folder):
         return self.getProfileInfo(profile_id).get('version', 'unknown')
 
     security.declareProtected(ManagePortal, 'profileExists')
+
     def profileExists(self, profile_id):
         """Check if a profile exists."""
         try:
@@ -851,10 +896,12 @@ class SetupTool(Folder):
             return True
 
     security.declareProtected(ManagePortal, "getProfileInfo")
+
     def getProfileInfo(self, profile_id):
         return _profile_registry.getProfileInfo(profile_id)
 
     security.declareProtected(ManagePortal, 'getDependenciesForProfile')
+
     def getDependenciesForProfile(self, profile_id):
         if profile_id.startswith("snapshot-"):
             return ()
@@ -867,12 +914,13 @@ class SetupTool(Folder):
             return ()
 
     security.declareProtected(ManagePortal, 'listProfilesWithUpgrades')
+
     def listProfilesWithUpgrades(self):
-        profiles = listProfilesWithUpgrades()
-        profiles.sort()
+        profiles = sorted(listProfilesWithUpgrades())
         return profiles
 
     security.declarePrivate('_massageUpgradeInfo')
+
     def _massageUpgradeInfo(self, info):
         """Add a couple of data points to the upgrade info dictionary.
         """
@@ -886,6 +934,7 @@ class SetupTool(Folder):
         return info
 
     security.declareProtected(ManagePortal, 'listUpgrades')
+
     def listUpgrades(self, profile_id, show_old=False):
         """Get the list of available upgrades.
         """
@@ -896,7 +945,7 @@ class SetupTool(Folder):
         upgrades = listUpgradeSteps(self, profile_id, source)
         res = []
         for info in upgrades:
-            if type(info) == list:
+            if isinstance(info, list):
                 subset = []
                 for subinfo in info:
                     subset.append(self._massageUpgradeInfo(subinfo))
@@ -906,6 +955,7 @@ class SetupTool(Folder):
         return res
 
     security.declareProtected(ManagePortal, 'manage_doUpgrades')
+
     def manage_doUpgrades(self, request=None):
         """Perform all selected upgrade steps.
         """
@@ -930,9 +980,10 @@ class SetupTool(Folder):
 
         url = self.absolute_url()
         request.RESPONSE.redirect("%s/manage_upgrades?saved=%s"
-                                    % (url, profile_id))
+                                  % (url, profile_id))
 
     security.declareProtected(ManagePortal, 'upgradeProfile')
+
     def upgradeProfile(self, profile_id, dest=None):
         """Upgrade a profile.
 
@@ -1001,6 +1052,7 @@ class SetupTool(Folder):
     #   Helper methods
     #
     security.declarePrivate('_getImportContext')
+
     def _getImportContext(self, context_id, should_purge=None, archive=None):
         """ Crack ID and generate appropriate import context.
 
@@ -1035,14 +1087,15 @@ class SetupTool(Folder):
 
         if archive is not None:
             return TarballImportContext(tool=self,
-                                       archive_bits=archive,
-                                       encoding='UTF8',
-                                       should_purge=should_purge,
-                                      )
+                                        archive_bits=archive,
+                                        encoding='UTF8',
+                                        should_purge=should_purge,
+                                        )
 
         raise KeyError('Unknown context "%s"' % context_id)
 
     security.declarePrivate('_updateImportStepsRegistry')
+
     def _updateImportStepsRegistry(self, context, encoding):
         """ Update our import steps registry from our profile.
         """
@@ -1067,9 +1120,10 @@ class SetupTool(Folder):
                                                dependencies=dependencies,
                                                title=title,
                                                description=description,
-                                              )
+                                               )
 
     security.declarePrivate('_updateExportStepsRegistry')
+
     def _updateExportStepsRegistry(self, context, encoding):
         """ Update our export steps registry from our profile.
         """
@@ -1090,9 +1144,10 @@ class SetupTool(Folder):
                                                handler=handler,
                                                title=title,
                                                description=description,
-                                              )
+                                               )
 
     security.declarePrivate('_doRunImportStep')
+
     def _doRunImportStep(self, step_id, context):
         """ Run a single import step, using a pre-built context.
         """
@@ -1113,6 +1168,7 @@ class SetupTool(Folder):
         return handler(context)
 
     security.declarePrivate('_doRunExportSteps')
+
     def _doRunExportSteps(self, steps):
         """ See ISetupTool.
         """
@@ -1141,11 +1197,12 @@ class SetupTool(Folder):
                 'filename': context.getArchiveFilename()}
 
     security.declareProtected(ManagePortal, 'getProfileDependencyChain')
+
     def getProfileDependencyChain(self, profile_id, seen=None):
         if seen is None:
             seen = set()
         elif profile_id in seen:
-            return [] # cycle break
+            return []  # cycle break
         seen.add(profile_id)
         chain = []
 
@@ -1158,6 +1215,7 @@ class SetupTool(Folder):
         return chain
 
     security.declarePrivate('_runImportStepsFromContext')
+
     def _runImportStepsFromContext(self,
                                    steps=None,
                                    purge_old=None,
@@ -1267,8 +1325,8 @@ class SetupTool(Folder):
                 else:
                     message = self._doRunImportStep(step, context)
                 message_list = filter(None, [message])
-                message_list.extend([ '%s: %s' % x[1:]
-                                      for x in context.listNotes() ])
+                message_list.extend(['%s: %s' % x[1:]
+                                     for x in context.listNotes()])
                 messages[step] = '\n'.join(message_list)
                 context.clearNotes()
 
@@ -1295,6 +1353,7 @@ class SetupTool(Folder):
         return data
 
     security.declarePrivate('_mangleTimestampName')
+
     def _mangleTimestampName(self, prefix, ext=None):
         """ Create a mangled ID using a timestamp.
         """
@@ -1310,6 +1369,7 @@ class SetupTool(Folder):
         return fmt % items
 
     security.declarePrivate('_createReport')
+
     def _createReport(self, basename, steps, messages):
         """ Record the results of a run.
         """
@@ -1341,7 +1401,7 @@ class SetupTool(Folder):
                     title='',
                     file=report,
                     content_type='text/plain'
-                   )
+                    )
 
         self._setObject(name, file)
 
@@ -1356,6 +1416,7 @@ Comparing configurations: '%s' and '%s'
 _TOOL_ID = 'setup_tool'
 
 addSetupToolForm = PageTemplateFile('toolAdd.zpt', _wwwdir)
+
 
 def addSetupTool(dispatcher, RESPONSE):
     """

--- a/Products/GenericSetup/upgrade.py
+++ b/Products/GenericSetup/upgrade.py
@@ -64,6 +64,7 @@ class UpgradeRegistry(object):
       - id -> step for single steps
       - id -> [ (id1, step1), (id2, step2) ] for nested steps
     """
+
     def __init__(self):
         self._registry = GlobalRegistryStorage(IUpgradeSteps)
 
@@ -102,12 +103,12 @@ class UpgradeRegistry(object):
             step = profile_steps.get(step_id, None)
             if step is None:
                 for key in profile_steps.keys():
-                    if type(profile_steps[key]) == list:
+                    if isinstance(profile_steps[key], list):
                         subs = dict(profile_steps[key])
                         step = subs.get(step_id, None)
                         if step is not None:
                             break
-            elif type(step) == list:
+            elif isinstance(step, list):
                 subs = dict(step)
                 step = subs.get(step_id, None)
             return step
@@ -119,6 +120,7 @@ class UpgradeEntity(object):
     """
     Base class for actions to be taken during an upgrade process.
     """
+
     def __init__(self, title, profile, source, dest, desc, checker=None,
                  sortkey=0):
         self.id = str(abs(hash('%s%s%s%s' % (title, source, dest, sortkey))))
@@ -156,6 +158,7 @@ class UpgradeEntity(object):
 class UpgradeStep(UpgradeEntity):
     """A step to upgrade a component.
     """
+
     def __init__(self, title, profile, source, dest, desc, handler,
                  checker=None, sortkey=0):
         super(UpgradeStep, self).__init__(title, profile, source, dest,
@@ -170,11 +173,12 @@ class UpgradeDepends(UpgradeEntity):
     """A specialized upgrade step that re-runs a particular import
     step from the profile.
     """
+
     def __init__(self, title, profile, source, dest, desc, import_profile=None,
                  import_steps=[], run_deps=False, purge=False, checker=None,
                  sortkey=0):
         super(UpgradeDepends, self).__init__(title, profile, source, dest,
-                                          desc, checker, sortkey)
+                                             desc, checker, sortkey)
         self.import_profile = import_profile
         self.import_steps = import_steps
         self.run_deps = run_deps
@@ -200,10 +204,12 @@ class UpgradeDepends(UpgradeEntity):
                                               purge_old=self.purge,
                                               ignore_dependencies=ign_deps)
 
+
 def _registerUpgradeStep(step):
     profile_id = step.profile
     profile_steps = _upgrade_registry.getUpgradeStepsForProfile(profile_id)
     profile_steps[step.id] = step
+
 
 def _registerNestedUpgradeStep(step, outer_id):
     profile_id = step.profile
@@ -211,6 +217,7 @@ def _registerNestedUpgradeStep(step, outer_id):
     nested_steps = profile_steps.get(outer_id, [])
     nested_steps.append((step.id, step))
     profile_steps[outer_id] = nested_steps
+
 
 def _extractStepInfo(tool, id, step, source):
     """Returns the info data structure for a given step.
@@ -227,11 +234,13 @@ def _extractStepInfo(tool, id, step, source):
         'description': step.description,
         'proposed': proposed,
         'sortkey': step.sortkey,
-        }
+    }
     return info
+
 
 def listProfilesWithUpgrades():
     return _upgrade_registry.keys()
+
 
 def listUpgradeSteps(tool, profile_id, source):
     """Lists upgrade steps available from a given version, for a given
@@ -246,7 +255,7 @@ def listUpgradeSteps(tool, profile_id, source):
                 continue
             normsrc = normalize_version(step.source)
             res.append(((normsrc, step.sortkey, info['proposed']), info))
-        else: # nested steps
+        else:  # nested steps
             nested = []
             outer_proposed = False
             for inner_id, inner_step in step:

--- a/Products/GenericSetup/utils.py
+++ b/Products/GenericSetup/utils.py
@@ -67,8 +67,8 @@ def _getDottedName(named):
     # remove leading underscore names if possible
 
     # Step 1: check if there is a short version
-    short_dotted = '.'.join([ n for n in dotted.split('.')
-                              if not n.startswith('_') ])
+    short_dotted = '.'.join([n for n in dotted.split('.')
+                             if not n.startswith('_')])
     if short_dotted == dotted:
         return dotted
 
@@ -87,6 +87,7 @@ def _getDottedName(named):
         return dotted
 
     return short_dotted
+
 
 def _resolveDottedName(dotted):
     __traceback_info__ = dotted
@@ -113,7 +114,7 @@ def _resolveDottedName(dotted):
             if not parts_copy:
                 return None
 
-    parts = parts[1:] # Funky semantics of __import__'s return value
+    parts = parts[1:]  # Funky semantics of __import__'s return value
 
     obj = module
 
@@ -124,6 +125,7 @@ def _resolveDottedName(dotted):
             return None
 
     return obj
+
 
 def _extractDocstring(func, default_title, default_description):
     try:
@@ -163,6 +165,7 @@ class ImportConfiguratorBase(Implicit):
         self._encoding = encoding
 
     security.declareProtected(ManagePortal, 'parseXML')
+
     def parseXML(self, xml):
         """ Pseudo API.
         """
@@ -202,7 +205,7 @@ class ImportConfiguratorBase(Implicit):
             if not name == '#text':
                 key = node_map[name].get(KEY, str(name))
                 info[key] = info.setdefault(key, ()) + (
-                                                    self._extractNode(child),)
+                    self._extractNode(child),)
 
             elif '#text' in node_map:
                 key = node_map['#text'].get(KEY, 'value')
@@ -230,26 +233,26 @@ class ImportConfiguratorBase(Implicit):
     def _getSharedImportMapping(self):
 
         return {
-          'object':
-            { 'i18n:domain':     {},
-              'name':            {KEY: 'id'},
-              'meta_type':       {},
-              'insert-before':   {},
-              'insert-after':    {},
-              'property':        {KEY: 'properties', DEFAULT: ()},
-              'object':          {KEY: 'objects', DEFAULT: ()},
-              'xmlns:i18n':      {} },
-          'property':
-            { 'name':            {KEY: 'id'},
-              '#text':           {KEY: 'value', DEFAULT: ''},
-              'element':         {KEY: 'elements', DEFAULT: ()},
-              'type':            {},
-              'select_variable': {},
-              'i18n:translate':  {} },
-          'element':
-            { 'value':           {KEY: None} },
-          'description':
-            { '#text':           {KEY: None, DEFAULT: ''} } }
+            'object':
+            {'i18n:domain': {},
+             'name': {KEY: 'id'},
+             'meta_type': {},
+             'insert-before': {},
+             'insert-after': {},
+             'property': {KEY: 'properties', DEFAULT: ()},
+             'object': {KEY: 'objects', DEFAULT: ()},
+             'xmlns:i18n': {}},
+            'property':
+            {'name': {KEY: 'id'},
+             '#text': {KEY: 'value', DEFAULT: ''},
+             'element': {KEY: 'elements', DEFAULT: ()},
+             'type': {},
+             'select_variable': {},
+             'i18n:translate': {}},
+            'element':
+            {'value': {KEY: None}},
+            'description':
+            {'#text': {KEY: None, DEFAULT: ''}}}
 
     def _convertToBoolean(self, val):
 
@@ -277,6 +280,7 @@ class ExportConfiguratorBase(Implicit):
         self._template = self._getExportTemplate()
 
     security.declareProtected(ManagePortal, 'generateXML')
+
     def generateXML(self, **kw):
         """ Pseudo API.
         """
@@ -289,6 +293,7 @@ InitializeClass(ExportConfiguratorBase)
 
 #
 ##############################################################################
+
 
 class _LineWrapper:
 
@@ -338,8 +343,7 @@ class _Element(Element):
 
         # move 'name', 'meta_type' and 'title' to the top, sort the rest
         attrs = self._get_attributes()
-        a_names = attrs.keys()
-        a_names.sort()
+        a_names = sorted(attrs.keys())
         if 'title' in a_names:
             a_names.remove('title')
             a_names.insert(0, 'title')
@@ -436,7 +440,7 @@ class NodeAdapterBase(object):
         for child in node.childNodes:
             if child.nodeName != '#text':
                 continue
-            lines = [ line.lstrip() for line in child.nodeValue.splitlines() ]
+            lines = [line.lstrip() for line in child.nodeValue.splitlines()]
             text += '\n'.join(lines)
         return text
 
@@ -516,7 +520,7 @@ class XMLAdapterBase(BodyAdapterBase):
 
     suffix = '.xml'
 
-    filename = '' # for error reporting during import
+    filename = ''  # for error reporting during import
 
 
 class ObjectManagerHelpers(object):
@@ -555,7 +559,7 @@ class ObjectManagerHelpers(object):
 
             obj_id = str(child.getAttribute('name'))
             if self._convertToBoolean(
-                child.getAttribute('remove') or 'False'):
+                    child.getAttribute('remove') or 'False'):
                 if obj_id in parent.objectIds():
                     parent._delObject(obj_id)
                 continue
@@ -628,10 +632,13 @@ class PropertyManagerHelpers(object):
             def __init__(self, real, properties):
                 self._real = real
                 self._properties = properties
+
             def p_self(self):
                 return self
+
             def v_self(self):
                 return self._real
+
             def propdict(self):
                 # PropertyManager method used by _initProperties
                 return dict([(p['id'], p) for p in self._properties])
@@ -705,7 +712,8 @@ class PropertyManagerHelpers(object):
                 elif prop_type in ('int', 'float'):
                     prop_value = 0
                 elif prop_type == 'date':
-                    prop_value = '1970/01/01 00:00:00 UTC' # DateTime(0) as UTC
+                    # DateTime(0) as UTC
+                    prop_value = '1970/01/01 00:00:00 UTC'
                 else:
                     prop_value = ''
                 self.context._updateProperty(prop_id, prop_value)
@@ -749,7 +757,7 @@ class PropertyManagerHelpers(object):
                 if sub.nodeName == 'element':
                     value = sub.getAttribute('value').encode(self._encoding)
                     if self._convertToBoolean(sub.getAttribute('remove')
-                                          or 'False'):
+                                              or 'False'):
                         remove_elements.append(value)
                         if value in new_elements:
                             new_elements.remove(value)
@@ -775,7 +783,7 @@ class PropertyManagerHelpers(object):
                 if isinstance(prop, (tuple, list)):
                     prop_value = (tuple([p for p in prop
                                          if p not in prop_value and
-                                            p not in remove_elements]) +
+                                         p not in remove_elements]) +
                                   tuple(prop_value))
 
             obj._updateProperty(prop_id, prop_value)
@@ -829,6 +837,7 @@ def exportObjects(obj, parent_path, context):
         for sub in obj.objectValues():
             exportObjects(sub, path + '/', context)
 
+
 def importObjects(obj, parent_path, context):
     """ Import subobjects recursively.
     """
@@ -841,7 +850,7 @@ def importObjects(obj, parent_path, context):
         filename = '%s%s' % (path, importer.suffix)
         body = context.readDataFile(filename)
         if body is not None:
-            importer.filename = filename # for error reporting
+            importer.filename = filename  # for error reporting
             importer.body = body
 
     if getattr(obj, 'objectValues', False):
@@ -851,11 +860,11 @@ def importObjects(obj, parent_path, context):
 
 def _computeTopologicalSort(steps):
     result = []
-    graph = [ (x['id'], x['dependencies']) for x in steps ]
+    graph = [(x['id'], x['dependencies']) for x in steps]
 
     unresolved = []
 
-    while 1:
+    while True:
         for node, edges in graph:
 
             after = -1
@@ -899,6 +908,7 @@ def _computeTopologicalSort(steps):
         unresolved = []
 
     return result
+
 
 def _getProductPath(product_name):
     """ Return the absolute path of the product's directory.

--- a/Products/GenericSetup/utils.py
+++ b/Products/GenericSetup/utils.py
@@ -216,7 +216,7 @@ class ImportConfiguratorBase(Implicit):
         for k, v in node_map.items():
             key = v.get(KEY, k)
 
-            if DEFAULT in v and not key in info:
+            if DEFAULT in v and key not in info:
                 if isinstance(v[DEFAULT], basestring):
                     info[key] = v[DEFAULT] % info
                 else:
@@ -756,8 +756,8 @@ class PropertyManagerHelpers(object):
             for sub in child.childNodes:
                 if sub.nodeName == 'element':
                     value = sub.getAttribute('value').encode(self._encoding)
-                    if self._convertToBoolean(sub.getAttribute('remove')
-                                              or 'False'):
+                    if self._convertToBoolean(sub.getAttribute('remove') or
+                                              'False'):
                         remove_elements.append(value)
                         if value in new_elements:
                             new_elements.remove(value)
@@ -776,8 +776,8 @@ class PropertyManagerHelpers(object):
                 # are converted to the right type
                 prop_value = self._getNodeText(child).encode(self._encoding)
 
-            if not self._convertToBoolean(child.getAttribute('purge')
-                                          or 'True'):
+            if not self._convertToBoolean(child.getAttribute('purge') or
+                                          'True'):
                 # If the purge attribute is False, merge sequences
                 prop = obj.getProperty(prop_id)
                 if isinstance(prop, (tuple, list)):

--- a/Products/GenericSetup/zcml.py
+++ b/Products/GenericSetup/zcml.py
@@ -24,7 +24,8 @@ from Products.GenericSetup.registry import _import_step_registry
 from Products.GenericSetup.registry import _export_step_registry
 from Products.GenericSetup.registry import _profile_registry
 
-#### genericsetup:registerProfile
+# genericsetup:registerProfile
+
 
 class IRegisterProfileDirective(Interface):
 
@@ -85,10 +86,10 @@ def registerProfile(_context, name=u'default', title=None, description=None,
         discriminator=('registerProfile', product, name),
         callable=_profile_registry.registerProfile,
         args=(name, title, description, directory, product, provides, for_)
-        )
+    )
 
 
-#### genericsetup:exportStep
+# genericsetup:exportStep
 
 class IExportStepDirective(Interface):
     name = PythonIdentifier(
@@ -112,17 +113,16 @@ class IExportStepDirective(Interface):
         required=True)
 
 
-
 def exportStep(context, name, handler, title=None, description=None):
 
     context.action(
         discriminator=('exportStep', name),
         callable=_export_step_registry.registerStep,
         args=(name, handler, title, description),
-        )
+    )
 
 
-#### genericsetup:importStep
+# genericsetup:importStep
 
 class IImportStepDirective(Interface):
 
@@ -181,10 +181,10 @@ class importStep:
             callable=_import_step_registry.registerStep,
             args=(self.name, None, self.handler, self.dependencies, self.title,
                   self.description),
-            )
+        )
 
 
-#### genericsetup:upgradeStep
+# genericsetup:upgradeStep
 
 import zope.schema
 import zope.configuration
@@ -192,6 +192,7 @@ from upgrade import UpgradeStep
 from upgrade import UpgradeDepends
 from upgrade import _registerUpgradeStep
 from upgrade import _registerNestedUpgradeStep
+
 
 class IUpgradeStepsDirective(Interface):
 
@@ -258,33 +259,33 @@ class IUpgradeDependsSubDirective(Interface):
     title = zope.schema.TextLine(
         title=u"Title",
         required=True,
-        )
+    )
 
     description = zope.schema.TextLine(
         title=u"Upgrade dependency description",
         required=False,
-        )
+    )
 
     import_profile = zope.schema.TextLine(
         title=u"GenericSetup profile id to load, if not the same as the "
-               u"current profile.",
+        u"current profile.",
         required=False)
 
     import_steps = zope.configuration.fields.Tokens(
         title=u"Import steps to rerun",
         required=False,
         value_type=zope.schema.TextLine(title=u"Import step"),
-        )
+    )
 
     run_deps = zope.schema.Bool(
         title=u"Run import step dependencies?",
         required=False,
-        )
+    )
 
     purge = zope.schema.Bool(
         title=u"Import steps w/ purge=True?",
         required=False,
-        )
+    )
 
 
 class IUpgradeDependsDirective(IUpgradeStepsDirective,
@@ -303,7 +304,8 @@ def upgradeStep(_context, title, profile, handler, description=None,
         discriminator=('upgradeStep', source, destination, handler, sortkey),
         callable=_registerUpgradeStep,
         args=(step,),
-        )
+    )
+
 
 def upgradeDepends(_context, title, profile, description=None,
                    import_profile=None, import_steps=[], source='*',
@@ -317,7 +319,7 @@ def upgradeDepends(_context, title, profile, description=None,
                        str(import_steps), checker, sortkey),
         callable=_registerUpgradeStep,
         args=(step,),
-        )
+    )
 
 
 class upgradeSteps(object):
@@ -347,7 +349,7 @@ class upgradeSteps(object):
                            self.sortkey),
             callable=_registerNestedUpgradeStep,
             args=(step, self.id),
-            )
+        )
 
     def upgradeDepends(self, _context, title, description=None,
                        import_profile=None, import_steps=[], run_deps=False,
@@ -364,7 +366,7 @@ class upgradeSteps(object):
                            import_profile, str(import_steps), self.sortkey),
             callable=_registerNestedUpgradeStep,
             args=(step, self.id)
-            )
+        )
 
     def __call__(self):
         return ()


### PR DESCRIPTION
When running pep8 on the GenericSetup code, I got about 6000 errors, of which 5000 were in the tests. This is a distraction (at least for me) when working on GenericSetup code.

Let's have a top ten of most common errors in the code, from 10 to 1:

```
  31  E201 whitespace after '{'
  31  E261 at least two spaces before inline comment
  84  E127 continuation line over-indented for visual indent
 112  E124 closing bracket does not match visual indentation
 115  E302 expected 2 blank lines, found 1
 336  E202 whitespace before ']'
 340  E201 whitespace after '['
 359  E203 whitespace before ','
2212  E202 whitespace before ')'
2317  E201 whitespace after '('
```

I used the autopep8 command to fix a lot of these. I had to undo one in tool.py that led to a test failure, but otherwise autopep8 was a big help. Then maybe about twenty manual changes were needed, so that was easy enough.
For the record, the command that I used was `autopep8 -i --ignore E309,W690 --aggressive . -r`
