### PR TITLE
pep8 in tests, very minor in other code

### DIFF
--- a/Products/GenericSetup/MailHost/exportimport.py
+++ b/Products/GenericSetup/MailHost/exportimport.py
@@ -48,7 +48,7 @@ class MailHostXMLAdapter(XMLAdapterBase):
             smtp_pwd = ''
         node.setAttribute('smtp_pwd', smtp_pwd)
 
-        #Older MH instances won't have 'smtp_queue' in instance dict
+        # Older MH instances won't have 'smtp_queue' in instance dict
         smtp_queue = bool(getattr(self.context, 'smtp_queue', False))
         node.setAttribute('smtp_queue', str(smtp_queue))
 
@@ -68,7 +68,7 @@ class MailHostXMLAdapter(XMLAdapterBase):
         self.context.smtp_uid = node.getAttribute('smtp_uid').encode('utf-8')
         self.context.smtp_pwd = node.getAttribute('smtp_pwd').encode('utf-8')
 
-        #Older MH instances won't have 'smtp_queue' in instance dict
+        # Older MH instances won't have 'smtp_queue' in instance dict
         if 'smtp_queue' in self.context.__dict__:
             if node.hasAttribute('smtp_queue'):
                 queue = node.getAttribute('smtp_queue')

--- a/Products/GenericSetup/MailHost/tests/test_exportimport.py
+++ b/Products/GenericSetup/MailHost/tests/test_exportimport.py
@@ -94,9 +94,9 @@ class MailHostXMLAdapterTestsWithQueue(BodyAdapterTestCase, unittest.TestCase):
         self.assertEqual(obj.smtp_queue, True)
         self.assertEqual(type(obj.smtp_queue_directory), str)
         self.assertEqual(obj.smtp_queue_directory, '/tmp/mailqueue')
-        
+
     def test_body_get(self):
-        #Default Correctly Handled in MailHostXMLAdapterTests
+        # Default Correctly Handled in MailHostXMLAdapterTests
         pass
 
     def setUp(self):

--- a/Products/GenericSetup/PluginIndexes/exportimport.py
+++ b/Products/GenericSetup/PluginIndexes/exportimport.py
@@ -194,6 +194,6 @@ class TopicIndexNodeAdapter(NodeAdapterBase):
                 importer = queryMultiAdapter((set, self.environ), INode)
                 importer.node = child
         # Let the filtered sets handle themselves:  we have no state
-        #self.context.clear()
+        # self.context.clear()
 
     node = property(_exportNode, _importNode)

--- a/Products/GenericSetup/ZCTextIndex/exportimport.py
+++ b/Products/GenericSetup/ZCTextIndex/exportimport.py
@@ -58,7 +58,7 @@ class ZCLexiconNodeAdapter(NodeAdapterBase):
         pipeline = tuple(pipeline)
         if self.context._pipeline != pipeline:
             self.context._pipeline = pipeline
-            #clear lexicon
+            # clear lexicon
             self.context._wids = OIBTree()
             self.context._words = IOBTree()
             self.context.length = Length()

--- a/Products/GenericSetup/ZCatalog/tests/test_exportimport.py
+++ b/Products/GenericSetup/ZCatalog/tests/test_exportimport.py
@@ -115,6 +115,7 @@ _ZCTEXT_XML = """\
  </index>
 """
 
+
 class ZCatalogXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
 
     layer = ExportImportZCMLLayer

--- a/Products/GenericSetup/__init__.py
+++ b/Products/GenericSetup/__init__.py
@@ -27,6 +27,7 @@ BASE, EXTENSION, profile_registry  # pyflakes
 security = ModuleSecurityInfo('Products.GenericSetup')
 security.declareProtected(ManagePortal, 'profile_registry')
 
+
 def initialize(context):
 
     import tool

--- a/Products/GenericSetup/browser/manage.py
+++ b/Products/GenericSetup/browser/manage.py
@@ -14,7 +14,6 @@ class ImportStepsView(BrowserView):
         steps=[step for step in steps if step['invalid']]
         return steps
 
-
     def doubleSteps(self):
         steps=set(self.tool_registry.listSteps())
         globals=set(self.global_registry.listSteps())
@@ -24,10 +23,8 @@ class ImportStepsView(BrowserView):
         return steps
 
 
-
 class ExportStepsView(ImportStepsView):
     def __init__(self, context, request):
         BrowserView.__init__(self, context, request)
         self.global_registry=_export_step_registry
         self.tool_registry=context.getExportStepRegistry()
-

--- a/Products/GenericSetup/browser/utils.py
+++ b/Products/GenericSetup/browser/utils.py
@@ -13,6 +13,7 @@
 """GenericSetup browser view utils.
 """
 
+
 class AddWithPresettingsViewBase:
 
     """Base class for add views with selectable presettings.

--- a/Products/GenericSetup/components.py
+++ b/Products/GenericSetup/components.py
@@ -529,6 +529,7 @@ def importComponentRegistry(context):
             logger = context.getLogger('componentregistry')
             logger.debug("Nothing to import")
 
+
 def exportComponentRegistry(context):
     """Export local components.
     """

--- a/Products/GenericSetup/content.py
+++ b/Products/GenericSetup/content.py
@@ -33,8 +33,11 @@ from Products.GenericSetup.utils import _resolveDottedName
 #
 #   setup_tool handlers
 #
+
+
 def exportSiteStructure(context):
     IFilesystemExporter(context.getSite()).export(context, 'structure', True)
+
 
 def importSiteStructure(context):
     IFilesystemImporter(context.getSite()).import_(context, 'structure', True)
@@ -225,7 +228,7 @@ class FolderishExporterImporter(object):
     def _mustPreserve(self):
         return [x for x in self.context.objectItems()
                         if ISetupTool.providedBy(x[1])]
- 
+
 
 def _globtest(globpattern, namelist):
     """ Filter names in 'namelist', returning those which match 'globpattern'.
@@ -275,6 +278,7 @@ class CSVAwareFileAdapter(object):
             stream = StringIO(data)
             self.context.put_csv(stream)
 
+
 class INIAwareFileAdapter(object):
     """ Exporter/importer for content whose "natural" representation is an
         '.ini' file.
@@ -308,6 +312,7 @@ class INIAwareFileAdapter(object):
             logger.info('no .ini file for %s/%s' % (subdir, cid))
         else:
             self.context.put_ini(data)
+
 
 class SimpleINIAware(object):
     """ Exporter/importer for content which doesn't know from INI.
@@ -344,6 +349,7 @@ class SimpleINIAware(object):
             else:
                 context._updateProperty(option, value)
 
+
 class FauxDAVRequest:
 
     def __init__(self, **kw):
@@ -360,11 +366,13 @@ class FauxDAVRequest:
     def get_header(self, key, default=None):
         return self._headers.get(key, default)
 
+
 class FauxDAVResponse:
     def setHeader(self, key, value, lock=False):
         pass  # stub this out to mollify webdav.Resource
     def setStatus(self, value, reason=None):
         pass  # stub this out to mollify webdav.Resource
+
 
 class DAVAwareFileAdapter(object):
     """ Exporter/importer for content who handle their own FTP / DAV PUTs.

--- a/Products/GenericSetup/context.py
+++ b/Products/GenericSetup/context.py
@@ -139,21 +139,18 @@ class BaseContext(SetupEnviron):
 
     security.declareProtected( ManagePortal, 'getSite' )
     def getSite( self ):
-
         """ See ISetupContext.
         """
         return aq_self(self._site)
 
     security.declareProtected( ManagePortal, 'getSetupTool' )
     def getSetupTool( self ):
-
         """ See ISetupContext.
         """
         return self._tool
 
     security.declareProtected( ManagePortal, 'getEncoding' )
     def getEncoding( self ):
-
         """ See ISetupContext.
         """
         return self._encoding
@@ -166,14 +163,12 @@ class BaseContext(SetupEnviron):
 
     security.declareProtected( ManagePortal, 'listNotes' )
     def listNotes(self):
-
         """ See ISetupContext.
         """
         return self._messages[:]
 
     security.declareProtected( ManagePortal, 'clearNotes' )
     def clearNotes(self):
-
         """ See ISetupContext.
         """
         self._messages[:] = []
@@ -200,7 +195,6 @@ class DirectoryImportContext( BaseContext ):
 
     security.declareProtected( ManagePortal, 'openDataFile' )
     def openDataFile( self, filename, subdir=None ):
-
         """ See IImportContext.
         """
         if subdir is None:
@@ -215,7 +209,6 @@ class DirectoryImportContext( BaseContext ):
 
     security.declareProtected( ManagePortal, 'readDataFile' )
     def readDataFile( self, filename, subdir=None ):
-
         """ See IImportContext.
         """
         result = None
@@ -227,7 +220,6 @@ class DirectoryImportContext( BaseContext ):
 
     security.declareProtected( ManagePortal, 'getLastModified' )
     def getLastModified( self, path ):
-
         """ See IImportContext.
         """
         full_path = os.path.join( self._profile_path, path )
@@ -239,7 +231,6 @@ class DirectoryImportContext( BaseContext ):
 
     security.declareProtected( ManagePortal, 'isDirectory' )
     def isDirectory( self, path ):
-
         """ See IImportContext.
         """
         full_path = os.path.join( self._profile_path, path )
@@ -252,7 +243,6 @@ class DirectoryImportContext( BaseContext ):
     security.declareProtected( ManagePortal, 'listDirectory' )
     def listDirectory(self, path, skip=SKIPPED_FILES,
                       skip_suffixes=SKIPPED_SUFFIXES):
-
         """ See IImportContext.
         """
         if path is None:
@@ -289,7 +279,6 @@ class DirectoryExportContext( BaseContext ):
 
     security.declareProtected( ManagePortal, 'openDataFile' )
     def openDataFile( self, filename, content_type, subdir=None ):
-
         """ See IChunkableExportContext.
         """
         if subdir is None:
@@ -308,7 +297,6 @@ class DirectoryExportContext( BaseContext ):
 
     security.declareProtected( ManagePortal, 'writeDataFile' )
     def writeDataFile( self, filename, text, content_type, subdir=None ):
-
         """ See IExportContext.
         """
         if isinstance(text, unicode):
@@ -337,7 +325,6 @@ class TarballImportContext( BaseContext ):
         self._should_purge = bool( should_purge )
 
     def readDataFile( self, filename, subdir=None ):
-
         """ See IImportContext.
         """
         if subdir is not None:
@@ -351,14 +338,12 @@ class TarballImportContext( BaseContext ):
         return file.read()
 
     def getLastModified( self, path ):
-
         """ See IImportContext.
         """
         info = self._getTarInfo( path )
         return info and DateTime(info.mtime) or None
 
     def isDirectory( self, path ):
-
         """ See IImportContext.
         """
         info = self._getTarInfo( path )
@@ -368,7 +353,6 @@ class TarballImportContext( BaseContext ):
 
     def listDirectory(self, path, skip=SKIPPED_FILES,
                       skip_suffixes=SKIPPED_SUFFIXES):
-
         """ See IImportContext.
         """
         if path is None:  # root is special case:  no leading '/'
@@ -400,7 +384,6 @@ class TarballImportContext( BaseContext ):
         return names
 
     def shouldPurge( self ):
-
         """ See IImportContext.
         """
         return self._should_purge
@@ -441,7 +424,6 @@ class TarballExportContext( BaseContext ):
 
     security.declareProtected( ManagePortal, 'writeDataFile' )
     def writeDataFile( self, filename, text, content_type, subdir=None ):
-
         """ See IExportContext.
         """
         if subdir is not None:
@@ -478,7 +460,6 @@ class TarballExportContext( BaseContext ):
 
     security.declareProtected( ManagePortal, 'getArchive' )
     def getArchive( self ):
-
         """ Close the archive, and return it as a big string.
         """
         self._archive.close()
@@ -486,7 +467,6 @@ class TarballExportContext( BaseContext ):
 
     security.declareProtected( ManagePortal, 'getArchiveFilename' )
     def getArchiveFilename( self ):
-
         """ Close the archive, and return it as a big string.
         """
         return self._archive_filename
@@ -507,7 +487,6 @@ class SnapshotExportContext( BaseContext ):
 
     security.declareProtected( ManagePortal, 'writeDataFile' )
     def writeDataFile( self, filename, text, content_type, subdir=None ):
-
         """ See IExportContext.
         """
         if subdir is not None:
@@ -531,14 +510,12 @@ class SnapshotExportContext( BaseContext ):
 
     security.declareProtected( ManagePortal, 'getSnapshotURL' )
     def getSnapshotURL( self ):
-
         """ See IExportContext.
         """
         return '%s/%s' % ( self._tool.absolute_url(), self._snapshot_id )
 
     security.declareProtected( ManagePortal, 'getSnapshotFolder' )
     def getSnapshotFolder( self ):
-
         """ See IExportContext.
         """
         return self._ensureSnapshotsFolder()
@@ -582,7 +559,6 @@ class SnapshotExportContext( BaseContext ):
 
     security.declarePrivate( '_ensureSnapshotsFolder' )
     def _ensureSnapshotsFolder( self, subdir=None ):
-
         """ Ensure that the appropriate snapshot folder exists.
         """
         path = [ 'snapshots', self._snapshot_id ]
@@ -625,7 +601,6 @@ class SnapshotImportContext( BaseContext ):
 
     security.declareProtected( ManagePortal, 'readDataFile' )
     def readDataFile( self, filename, subdir=None ):
-
         """ See IImportContext.
         """
         if subdir is not None:
@@ -654,7 +629,6 @@ class SnapshotImportContext( BaseContext ):
 
     security.declareProtected( ManagePortal, 'getLastModified' )
     def getLastModified( self, path ):
-
         """ See IImportContext.
         """
         try:
@@ -673,7 +647,6 @@ class SnapshotImportContext( BaseContext ):
 
     security.declareProtected( ManagePortal, 'isDirectory' )
     def isDirectory( self, path ):
-
         """ See IImportContext.
         """
         try:
@@ -687,7 +660,6 @@ class SnapshotImportContext( BaseContext ):
 
     security.declareProtected( ManagePortal, 'listDirectory' )
     def listDirectory(self, path, skip=(), skip_suffixes=()):
-
         """ See IImportContext.
         """
         try:
@@ -711,7 +683,6 @@ class SnapshotImportContext( BaseContext ):
 
     security.declareProtected( ManagePortal, 'shouldPurge' )
     def shouldPurge( self ):
-
         """ See IImportContext.
         """
         return self._should_purge
@@ -721,7 +692,6 @@ class SnapshotImportContext( BaseContext ):
     #
     security.declarePrivate( '_getSnapshotFolder' )
     def _getSnapshotFolder( self, subdir=None ):
-
         """ Return the appropriate snapshot (sub)folder.
         """
         path = [ 'snapshots', self._snapshot_id ]

--- a/Products/GenericSetup/differ.py
+++ b/Products/GenericSetup/differ.py
@@ -23,6 +23,7 @@ from Products.GenericSetup.interfaces import SKIPPED_FILES
 
 BLANKS_REGEX = re.compile( r'^\s*$' )
 
+
 def unidiff( a
            , b
            , filename_a='original'

--- a/Products/GenericSetup/interfaces.py
+++ b/Products/GenericSetup/interfaces.py
@@ -50,17 +50,14 @@ class ISetupContext(ISetupEnviron):
     """ Context used for export / import plugins.
     """
     def getSite():
-
         """ Return the site object being configured / dumped.
         """
 
     def getSetupTool():
-
         """ Return the site object being configured / dumped.
         """
 
     def getEncoding():
-
         """ Get the encoding used for configuration data within the site.
 
         o Return None if the data should not be encoded.
@@ -76,10 +73,10 @@ class ISetupContext(ISetupEnviron):
         """ Clear all notes recorded by this context.
         """
 
+
 class IImportContext( ISetupContext ):
 
     def readDataFile( filename, subdir=None ):
-
         """ Search the current configuration for the requested file.
 
         o 'filename' is the name (without path elements) of the file.
@@ -92,7 +89,6 @@ class IImportContext( ISetupContext ):
         """
 
     def getLastModified( path ):
-
         """ Return the modification timestamp of the item at 'path'.
 
         o Result will be a DateTime instance.
@@ -109,7 +105,6 @@ class IImportContext( ISetupContext ):
         """
 
     def isDirectory( path ):
-
         """ Test whether path points to a directory / folder.
 
         o If the context is filesystem based, check that 'path' points to
@@ -123,7 +118,6 @@ class IImportContext( ISetupContext ):
         """
 
     def listDirectory( path, skip=SKIPPED_FILES ):
-
         """ List IDs of the contents of a  directory / folder.
 
         o Omit names in 'skip'.
@@ -131,10 +125,10 @@ class IImportContext( ISetupContext ):
         o If 'path' does not point to a directory / folder, return None.
         """
 
+
 class IChunkableImportContext( IImportContext ):
 
     def openDataFile( filename, subdir=None ):
-
         """ Open a datafile for reading from the specified location.
 
         o 'filename' is the unqualified name of the file.
@@ -147,12 +141,12 @@ class IChunkableImportContext( IImportContext ):
           for calling 'close' on it.
         """
 
+
 class IImportPlugin( IPseudoInterface ):
 
     """ Signature for callables used to import portions of site configuration.
     """
     def __call__( context ):
-
         """ Perform the setup step.
 
         o Return a message describing the work done.
@@ -160,10 +154,10 @@ class IImportPlugin( IPseudoInterface ):
         o 'context' must implement IImportContext.
         """
 
+
 class IExportContext( ISetupContext ):
 
     def writeDataFile( filename, text, content_type, subdir=None ):
-
         """ Write data into the specified location.
 
         o 'filename' is the unqualified name of the file.
@@ -177,10 +171,10 @@ class IExportContext( ISetupContext ):
           "root" of the target.
         """
 
+
 class IChunkableExportContext( IExportContext ):
 
     def openDataFile( filename, content_type, subdir=None ):
-
         """ Open a datafile for writing into the specified location.
 
         o 'filename' is the unqualified name of the file.
@@ -195,12 +189,12 @@ class IChunkableExportContext( IExportContext ):
           for calling 'close' on it.
         """
 
+
 class IExportPlugin( IPseudoInterface ):
 
     """ Signature for callables used to export portions of site configuration.
     """
     def __call__( context ):
-
         """ Write export data for the site wrapped by context.
 
         o Return a message describing the work done.
@@ -209,26 +203,24 @@ class IExportPlugin( IPseudoInterface ):
           its 'writeDataFile' method for each file to be exported.
         """
 
+
 class IStepRegistry( Interface ):
 
     """ Base interface for step registries.
     """
     def listSteps():
-
         """ Return a sequence of IDs of registered steps.
 
         o Order is not significant.
         """
 
     def listStepMetadata():
-
         """ Return a sequence of mappings describing registered steps.
 
         o Mappings will be ordered alphabetically.
         """
 
     def getStepMetadata( key, default=None ):
-
         """ Return a mapping of metadata for the step identified by 'key'.
 
         o Return 'default' if no such step is registered.
@@ -237,23 +229,21 @@ class IStepRegistry( Interface ):
         """
 
     def generateXML():
-
         """ Return a round-trippable XML representation of the registry.
 
         o 'handler' values are serialized using their dotted names.
         """
 
     def parseXML( text ):
-
         """ Parse 'text'.
         """
+
 
 class IImportStepRegistry( IStepRegistry ):
 
     """ API for import step registry.
     """
     def sortSteps():
-
         """ Return a sequence of registered step IDs
 
         o Sequence is sorted topologically by dependency, with the dependent
@@ -261,12 +251,10 @@ class IImportStepRegistry( IStepRegistry ):
         """
 
     def checkComplete():
-
         """ Return a sequence of ( node, edge ) tuples for unsatisifed deps.
         """
 
     def getStep( key, default=None ):
-
         """ Return the IImportPlugin registered for 'key'.
 
         o Return 'default' if no such step is registered.
@@ -311,19 +299,18 @@ class IImportStepRegistry( IStepRegistry ):
           the handler is used, or default to ''.
         """
 
+
 class IExportStepRegistry( IStepRegistry ):
 
     """ API for export step registry.
     """
     def getStep( key, default=None ):
-
         """ Return the IExportPlugin registered for 'key'.
 
         o Return 'default' if no such step is registered.
         """
 
     def registerStep( id, handler, title=None, description=None ):
-
         """ Register an export step.
 
         o 'id' is the unique identifier for this step
@@ -339,17 +326,16 @@ class IExportStepRegistry( IStepRegistry ):
           the step is used, or default to ''.
         """
 
+
 class IToolsetRegistry( Interface ):
 
     """ API for toolset registry.
     """
     def listForbiddenTools():
-
         """ Return a list of IDs of tools which must be removed, if present.
         """
 
     def addForbiddenTool(tool_id ):
-
         """ Add 'tool_id' to the list of forbidden tools.
 
         o Raise KeyError if 'tool_id' is already in the list.
@@ -358,12 +344,10 @@ class IToolsetRegistry( Interface ):
         """
 
     def listRequiredTools():
-
         """ Return a list of IDs of tools which must be present.
         """
 
     def getRequiredToolInfo( tool_id ):
-
         """ Return a mapping describing a partiuclar required tool.
 
         o Keys include:
@@ -376,12 +360,10 @@ class IToolsetRegistry( Interface ):
         """
 
     def listRequiredToolInfo():
-
         """ Return a list of IDs of tools which must be present.
         """
 
     def addRequiredTool( tool_id, dotted_name ):
-
         """ Add a tool to our "required" list.
 
         o 'tool_id' is the tool's ID.
@@ -393,12 +375,12 @@ class IToolsetRegistry( Interface ):
         o Raise ValueError if 'tool_id' is in the "forbidden" list.
         """
 
+
 class IProfileRegistry( Interface ):
 
     """ API for profile registry.
     """
     def getProfileInfo( profile_id, for_=None ):
-
         """ Return a mapping describing a registered filesystem profile.
 
         o Keys include:
@@ -424,7 +406,6 @@ class IProfileRegistry( Interface ):
         """
 
     def listProfiles( for_=None ):
-
         """ Return a list of IDs for registered profiles.
 
         o 'for_', if passed, should be the interface specifying the "site
@@ -435,7 +416,6 @@ class IProfileRegistry( Interface ):
         """
 
     def listProfileInfo( for_=None ):
-
         """ Return a list of mappings describing registered profiles.
 
         o See 'getProfileInfo' for a description of the mappings' keys.
@@ -470,13 +450,13 @@ class IProfileRegistry( Interface ):
           If 'None', the profile might be used in any site.
         """
 
+
 class ISetupTool( Interface ):
 
     """ API for SetupTool.
     """
 
     def getEncoding():
-
         """ Get the encoding used for configuration data within the site.
 
         o Return None if the data should not be encoded.
@@ -501,28 +481,23 @@ class ISetupTool( Interface ):
         """
 
     def applyContext( context, encoding=None ):
-
         """ Update the tool from the supplied context, without modifying its
             "permanent" ID.
         """
 
     def getImportStepRegistry():
-
         """ Return the IImportStepRegistry for the tool.
         """
 
     def getExportStepRegistry():
-
         """ Return the IExportStepRegistry for the tool.
         """
 
     def getToolsetRegistry():
-
         """ Return the IToolsetRegistry for the tool.
         """
 
     def getProfileDependencyChain( profile_id ):
-
         """Return a list of dependencies for a profile.
 
         The list is ordered by install order, with the requested profile as
@@ -531,7 +506,6 @@ class ISetupTool( Interface ):
 
     def runImportStepFromProfile(profile_id, step_id,
                                  run_dependencies=True, purge_old=None):
-
         """ Execute a given setup step from the given profile.
 
         o 'profile_id' must be a valid ID of a registered profile;
@@ -557,7 +531,6 @@ class ISetupTool( Interface ):
     def runAllImportStepsFromProfile(profile_id, purge_old=None,
                                      ignore_dependencies=False,
                                      blacklisted_steps=None):
-
         """ Run all setup steps for the given profile in dependency order.
 
         o 'profile_id' must be a valid ID of a registered profile;
@@ -583,7 +556,6 @@ class ISetupTool( Interface ):
         """
 
     def runExportStep( step_id ):
-
         """ Generate a tarball containing artifacts from one export step.
 
         o 'step_id' identifies the export step.
@@ -599,7 +571,6 @@ class ISetupTool( Interface ):
         """
 
     def runAllExportSteps():
-
         """ Generate a tarball containing artifacts from all export steps.
 
         o Return a mapping, with keys:
@@ -613,7 +584,6 @@ class ISetupTool( Interface ):
         """
 
     def createSnapshot( snapshot_id ):
-
         """ Create a snapshot folder using all steps.
 
         o 'snapshot_id' is the ID of the new folder.
@@ -735,6 +705,7 @@ class IFilesystemExporter(Interface):
           IFilesystemExporter.
         """
 
+
 class IFilesystemImporter(Interface):
     """ Plugin interface for site structure export.
     """
@@ -752,12 +723,14 @@ class IFilesystemImporter(Interface):
           interacting with the context).
         """
 
+
 class IContentFactory(Interface):
     """ Adapter interface for factories specific to a container.
     """
     def __call__(id):
         """ Return a new instance, seated in the context under 'id'.
         """
+
 
 class IContentFactoryName(Interface):
     """ Adapter interface for finding the name of the ICF for an object.
@@ -769,6 +742,7 @@ class IContentFactoryName(Interface):
           container which would create an "empty" instance of the same
           type as our context.
         """
+
 
 class ICSVAware(Interface):
     """ Interface for objects which dump / load 'text/comma-separated-values'.
@@ -788,6 +762,7 @@ class ICSVAware(Interface):
           CSV text parseable by the 'csv.reader'.
         """
 
+
 class IINIAware(Interface):
     """ Interface for objects which dump / load INI-format files..
     """
@@ -805,6 +780,7 @@ class IINIAware(Interface):
         o 'stream_or_text' must be either a string, or else a stream
           directly parseable by ConfigParser.
         """
+
 
 class IDAVAware(Interface):
     """ Interface for objects which handle their own FTP / DAV operations.
@@ -825,6 +801,7 @@ class IDAVAware(Interface):
           method, whose headers (e.g., "Content-Type") may affect the
           processing of the body.
         """
+
 
 class IBeforeProfileImportEvent(Interface):
     """ An event which is fired before (part of) a profile is imported.
@@ -863,17 +840,21 @@ class IComponentsHandlerBlacklist(Interface):
         the export and import handlers.
         """
 
+
 class IProfile(Interface):
     """ Named profile.
     """
+
 
 class IImportStep(Interface):
     """ Named import step.
     """
 
+
 class IExportStep(Interface):
     """ Named export step.
     """
+
 
 class IUpgradeSteps(Interface):
     """ Named upgrade steps.

--- a/Products/GenericSetup/metadata.py
+++ b/Products/GenericSetup/metadata.py
@@ -47,7 +47,7 @@ class ProfileMetadata( ImportConfiguratorBase ):
         self._encoding = encoding
 
     def __call__( self ):
-        
+
         full_path = os.path.join( self._path, METADATA_XML )
         if not os.path.exists( full_path ):
             return {}

--- a/Products/GenericSetup/rolemap.py
+++ b/Products/GenericSetup/rolemap.py
@@ -30,8 +30,8 @@ from Products.GenericSetup.utils import CONVERTER, DEFAULT, KEY
 #
 _FILENAME = 'rolemap.xml'
 
-def importRolemap( context ):
 
+def importRolemap( context ):
     """ Import roles / permission map from an XML file.
 
     o 'context' must implement IImportContext.
@@ -106,7 +106,6 @@ def importRolemap( context ):
 
 
 def exportRolemap( context ):
-
     """ Export roles / permission map as an XML file
 
     o 'context' must implement IExportContext.
@@ -149,14 +148,12 @@ class RolemapExportConfigurator(ExportConfiguratorBase):
 
     security.declareProtected( ManagePortal, 'listRoles' )
     def listRoles( self ):
-
         """ List the valid role IDs for our site.
         """
         return self._site.valid_roles()
 
     security.declareProtected( ManagePortal, 'listPermissions' )
     def listPermissions( self ):
-
         """ List permissions for export.
 
         o Returns a sqeuence of mappings describing locally-modified

--- a/Products/GenericSetup/tests/common.py
+++ b/Products/GenericSetup/tests/common.py
@@ -29,28 +29,28 @@ from Products.GenericSetup.testing import DummyLogger
 
 class DOMComparator:
 
-    def _compareDOM( self, found_text, expected_text, debug=False ):
+    def _compareDOM(self, found_text, expected_text, debug=False):
 
-        found_lines = [ x.strip() for x in found_text.splitlines() ]
-        found_text = '\n'.join( filter( None, found_lines ) )
+        found_lines = [x.strip() for x in found_text.splitlines()]
+        found_text = '\n'.join(filter(None, found_lines))
 
-        expected_lines = [ x.strip() for x in expected_text.splitlines() ]
-        expected_text = '\n'.join( filter( None, expected_lines ) )
+        expected_lines = [x.strip() for x in expected_text.splitlines()]
+        expected_text = '\n'.join(filter(None, expected_lines))
 
         from xml.dom.minidom import parseString
-        found = parseString( found_text )
-        expected = parseString( expected_text )
+        found = parseString(found_text)
+        expected = parseString(expected_text)
         fxml = found.toxml()
         exml = expected.toxml()
 
         if fxml != exml:
 
             if debug:
-                zipped = zip( fxml, exml )
-                diff = [ ( i, zipped[i][0], zipped[i][1] )
-                        for i in range( len( zipped ) )
+                zipped = zip(fxml, exml)
+                diff = [(i, zipped[i][0], zipped[i][1])
+                        for i in range(len(zipped))
                         if zipped[i][0] != zipped[i][1]
-                    ]
+                        ]
                 # Ugly, but it will do.
                 print 'Diff:'
                 print diff
@@ -63,7 +63,7 @@ class DOMComparator:
             print exml
             print
 
-        self.assertEqual( found.toxml(), expected.toxml() )
+        self.assertEqual(found.toxml(), expected.toxml())
 
 
 class BaseRegistryTests(ZopeTestCase, DOMComparator):
@@ -72,29 +72,30 @@ class BaseRegistryTests(ZopeTestCase, DOMComparator):
         self.root = self.app
         newSecurityManager(None, UnrestrictedUser('god', '', ['Manager'], ''))
 
-    def _makeOne( self, *args, **kw ):
+    def _makeOne(self, *args, **kw):
         # Derived classes must implement _getTargetClass
-        return self._getTargetClass()( *args, **kw )
+        return self._getTargetClass()(*args, **kw)
 
 
-def _clearTestDirectory( root_path ):
+def _clearTestDirectory(root_path):
 
-    if os.path.exists( root_path ):
-        shutil.rmtree( root_path )
+    if os.path.exists(root_path):
+        shutil.rmtree(root_path)
 
-def _makeTestFile( filename, root_path, contents ):
 
-    path, filename = os.path.split( filename )
+def _makeTestFile(filename, root_path, contents):
 
-    subdir = os.path.join( root_path, path )
+    path, filename = os.path.split(filename)
 
-    if not os.path.exists( subdir ):
-        os.makedirs( subdir )
+    subdir = os.path.join(root_path, path)
 
-    fqpath = os.path.join( subdir, filename )
+    if not os.path.exists(subdir):
+        os.makedirs(subdir)
 
-    file = open( fqpath, 'wb' )
-    file.write( contents )
+    fqpath = os.path.join(subdir, filename)
+
+    file = open(fqpath, 'wb')
+    file.write(contents)
     file.close()
     return fqpath
 
@@ -111,71 +112,71 @@ class FilesystemTestBase(ZopeTestCase):
         return _makeTestFile(filename, self._PROFILE_PATH, contents)
 
 
-class TarballTester( DOMComparator ):
+class TarballTester(DOMComparator):
 
-    def _verifyTarballContents( self, fileish, toc_list, when=None ):
+    def _verifyTarballContents(self, fileish, toc_list, when=None):
 
-        fileish.seek( 0L )
-        tarfile = TarFile.open( 'foo.tar.gz', fileobj=fileish, mode='r:gz' )
+        fileish.seek(0L)
+        tarfile = TarFile.open('foo.tar.gz', fileobj=fileish, mode='r:gz')
         items = tarfile.getnames()
         items.sort()
         toc_list.sort()
 
-        self.assertEqual( len( items ), len( toc_list ) )
-        for i in range( len( items ) ):
-            self.assertEqual( items[ i ].rstrip('/'), toc_list[ i ] )
+        self.assertEqual(len(items), len(toc_list))
+        for i in range(len(items)):
+            self.assertEqual(items[i].rstrip('/'), toc_list[i])
 
         if when is not None:
             for tarinfo in tarfile:
-                self.failIf( tarinfo.mtime < when )
+                self.failIf(tarinfo.mtime < when)
 
-    def _verifyTarballEntry( self, fileish, entry_name, data ):
+    def _verifyTarballEntry(self, fileish, entry_name, data):
 
-        fileish.seek( 0L )
-        tarfile = TarFile.open( 'foo.tar.gz', fileobj=fileish, mode='r:gz' )
-        extract = tarfile.extractfile( entry_name )
+        fileish.seek(0L)
+        tarfile = TarFile.open('foo.tar.gz', fileobj=fileish, mode='r:gz')
+        extract = tarfile.extractfile(entry_name)
         found = extract.read()
-        self.assertEqual( found, data )
+        self.assertEqual(found, data)
 
-    def _verifyTarballEntryXML( self, fileish, entry_name, data ):
+    def _verifyTarballEntryXML(self, fileish, entry_name, data):
 
-        fileish.seek( 0L )
-        tarfile = TarFile.open( 'foo.tar.gz', fileobj=fileish, mode='r:gz' )
-        extract = tarfile.extractfile( entry_name )
+        fileish.seek(0L)
+        tarfile = TarFile.open('foo.tar.gz', fileobj=fileish, mode='r:gz')
+        extract = tarfile.extractfile(entry_name)
         found = extract.read()
-        self._compareDOM( found, data )
+        self._compareDOM(found, data)
 
 
 class DummyExportContext:
 
     implements(IExportContext)
 
-    def __init__( self, site, tool=None ):
+    def __init__(self, site, tool=None):
         self._site = site
         self._tool = tool
         self._wrote = []
         self._notes = []
 
-    def getSite( self ):
+    def getSite(self):
         return self._site
 
-    def getSetupTool( self ):
+    def getSetupTool(self):
         return self._tool
 
     def getLogger(self, name):
         return DummyLogger(name, self._notes)
 
-    def writeDataFile( self, filename, text, content_type, subdir=None ):
+    def writeDataFile(self, filename, text, content_type, subdir=None):
         if subdir is not None:
-            filename = '%s/%s' % ( subdir, filename )
-        self._wrote.append( ( filename, text, content_type ) )
+            filename = '%s/%s' % (subdir, filename)
+        self._wrote.append((filename, text, content_type))
 
 
 class DummyImportContext:
 
     implements(IImportContext)
 
-    def __init__( self, site, purge=True, encoding=None, tool=None ):
+    def __init__(self, site, purge=True, encoding=None, tool=None):
         self._site = site
         self._tool = tool
         self._purge = purge
@@ -183,31 +184,31 @@ class DummyImportContext:
         self._files = {}
         self._notes = []
 
-    def getSite( self ):
+    def getSite(self):
         return self._site
 
-    def getSetupTool( self ):
+    def getSetupTool(self):
         return self._tool
 
-    def getEncoding( self ):
+    def getEncoding(self):
         return self._encoding
 
     def getLogger(self, name):
         return DummyLogger(name, self._notes)
 
-    def readDataFile( self, filename, subdir=None ):
+    def readDataFile(self, filename, subdir=None):
 
         if subdir is not None:
-            filename = '/'.join( (subdir, filename) )
+            filename = '/'.join((subdir, filename))
 
-        return self._files.get( filename )
+        return self._files.get(filename)
 
-    def shouldPurge( self ):
+    def shouldPurge(self):
 
         return self._purge
 
 
-def dummy_handler( context ):
+def dummy_handler(context):
 
     pass
 
@@ -218,4 +219,3 @@ class SecurityRequestTest(ZopeTestCase):
     def setUp(self):
         ZopeTestCase.setUp(self)
         self.root = self.app
-

--- a/Products/GenericSetup/tests/common.py
+++ b/Products/GenericSetup/tests/common.py
@@ -116,10 +116,9 @@ class TarballTester(DOMComparator):
 
     def _verifyTarballContents(self, fileish, toc_list, when=None):
 
-        fileish.seek(0L)
+        fileish.seek(0)
         tarfile = TarFile.open('foo.tar.gz', fileobj=fileish, mode='r:gz')
-        items = tarfile.getnames()
-        items.sort()
+        items = sorted(tarfile.getnames())
         toc_list.sort()
 
         self.assertEqual(len(items), len(toc_list))
@@ -132,7 +131,7 @@ class TarballTester(DOMComparator):
 
     def _verifyTarballEntry(self, fileish, entry_name, data):
 
-        fileish.seek(0L)
+        fileish.seek(0)
         tarfile = TarFile.open('foo.tar.gz', fileobj=fileish, mode='r:gz')
         extract = tarfile.extractfile(entry_name)
         found = extract.read()
@@ -140,7 +139,7 @@ class TarballTester(DOMComparator):
 
     def _verifyTarballEntryXML(self, fileish, entry_name, data):
 
-        fileish.seek(0L)
+        fileish.seek(0)
         tarfile = TarFile.open('foo.tar.gz', fileobj=fileish, mode='r:gz')
         extract = tarfile.extractfile(entry_name)
         found = extract.read()

--- a/Products/GenericSetup/tests/conformance.py
+++ b/Products/GenericSetup/tests/conformance.py
@@ -16,104 +16,116 @@ Derived testcase classes should define '_getTargetClass()', which must
 return the class being tested for conformance.
 """
 
+
 class ConformsToISetupContext:
 
-    def test_ISetupContext_conformance( self ):
+    def test_ISetupContext_conformance(self):
 
         from Products.GenericSetup.interfaces import ISetupContext
         from zope.interface.verify import verifyClass
 
-        verifyClass( ISetupContext, self._getTargetClass() )
+        verifyClass(ISetupContext, self._getTargetClass())
+
 
 class ConformsToIImportContext:
 
-    def test_IImportContext_conformance( self ):
+    def test_IImportContext_conformance(self):
 
         from Products.GenericSetup.interfaces import IImportContext
         from zope.interface.verify import verifyClass
 
-        verifyClass( IImportContext, self._getTargetClass() )
+        verifyClass(IImportContext, self._getTargetClass())
+
 
 class ConformsToIExportContext:
 
-    def test_IExportContext_conformance( self ):
+    def test_IExportContext_conformance(self):
 
         from Products.GenericSetup.interfaces import IExportContext
         from zope.interface.verify import verifyClass
 
-        verifyClass( IExportContext, self._getTargetClass() )
+        verifyClass(IExportContext, self._getTargetClass())
+
 
 class ConformsToIChunkableExportContext:
 
-    def test_IChunkableExportContext_conformance( self ):
+    def test_IChunkableExportContext_conformance(self):
 
         from Products.GenericSetup.interfaces import IChunkableExportContext
         from zope.interface.verify import verifyClass
 
-        verifyClass( IChunkableExportContext, self._getTargetClass() )
+        verifyClass(IChunkableExportContext, self._getTargetClass())
+
 
 class ConformsToIChunkableImportContext:
 
-    def test_IChunkableImportContext_conformance( self ):
+    def test_IChunkableImportContext_conformance(self):
 
         from Products.GenericSetup.interfaces import IChunkableImportContext
         from zope.interface.verify import verifyClass
 
-        verifyClass( IChunkableImportContext, self._getTargetClass() )
+        verifyClass(IChunkableImportContext, self._getTargetClass())
+
 
 class ConformsToIStepRegistry:
 
-    def test_IStepRegistry_conformance( self ):
+    def test_IStepRegistry_conformance(self):
 
         from Products.GenericSetup.interfaces import IStepRegistry
         from zope.interface.verify import verifyClass
 
-        verifyClass( IStepRegistry, self._getTargetClass() )
+        verifyClass(IStepRegistry, self._getTargetClass())
+
 
 class ConformsToIImportStepRegistry:
 
-    def test_IImportStepRegistry_conformance( self ):
+    def test_IImportStepRegistry_conformance(self):
 
         from Products.GenericSetup.interfaces import IImportStepRegistry
         from zope.interface.verify import verifyClass
 
-        verifyClass( IImportStepRegistry, self._getTargetClass() )
+        verifyClass(IImportStepRegistry, self._getTargetClass())
+
 
 class ConformsToIExportStepRegistry:
 
-    def test_IExportStepRegistry_conformance( self ):
+    def test_IExportStepRegistry_conformance(self):
 
         from Products.GenericSetup.interfaces import IExportStepRegistry
         from zope.interface.verify import verifyClass
 
-        verifyClass( IExportStepRegistry, self._getTargetClass() )
+        verifyClass(IExportStepRegistry, self._getTargetClass())
+
 
 class ConformsToIToolsetRegistry:
 
-    def test_IToolsetRegistry_conformance( self ):
+    def test_IToolsetRegistry_conformance(self):
 
         from Products.GenericSetup.interfaces import IToolsetRegistry
         from zope.interface.verify import verifyClass
 
-        verifyClass( IToolsetRegistry, self._getTargetClass() )
+        verifyClass(IToolsetRegistry, self._getTargetClass())
+
 
 class ConformsToIProfileRegistry:
 
-    def test_IProfileRegistry_conformance( self ):
+    def test_IProfileRegistry_conformance(self):
 
         from Products.GenericSetup.interfaces import IProfileRegistry
         from zope.interface.verify import verifyClass
 
-        verifyClass( IProfileRegistry, self._getTargetClass() )
+        verifyClass(IProfileRegistry, self._getTargetClass())
+
 
 class ConformsToISetupTool:
 
-    def test_ISetupTool_conformance( self ):
+    def test_ISetupTool_conformance(self):
 
         from Products.GenericSetup.interfaces import ISetupTool
         from zope.interface.verify import verifyClass
 
-        verifyClass( ISetupTool, self._getTargetClass() )
+        verifyClass(ISetupTool, self._getTargetClass())
+
 
 class ConformsToIContentFactory:
 
@@ -122,7 +134,8 @@ class ConformsToIContentFactory:
         from Products.GenericSetup.interfaces import IContentFactory
         from zope.interface.verify import verifyClass
 
-        verifyClass( IContentFactory, self._getTargetClass() )
+        verifyClass(IContentFactory, self._getTargetClass())
+
 
 class ConformsToIContentFactoryName:
 
@@ -131,7 +144,8 @@ class ConformsToIContentFactoryName:
         from Products.GenericSetup.interfaces import IContentFactoryName
         from zope.interface.verify import verifyClass
 
-        verifyClass( IContentFactoryName, self._getTargetClass() )
+        verifyClass(IContentFactoryName, self._getTargetClass())
+
 
 class ConformsToIFilesystemExporter:
 
@@ -140,7 +154,8 @@ class ConformsToIFilesystemExporter:
         from Products.GenericSetup.interfaces import IFilesystemExporter
         from zope.interface.verify import verifyClass
 
-        verifyClass( IFilesystemExporter, self._getTargetClass() )
+        verifyClass(IFilesystemExporter, self._getTargetClass())
+
 
 class ConformsToIFilesystemImporter:
 
@@ -149,7 +164,8 @@ class ConformsToIFilesystemImporter:
         from Products.GenericSetup.interfaces import IFilesystemImporter
         from zope.interface.verify import verifyClass
 
-        verifyClass( IFilesystemImporter, self._getTargetClass() )
+        verifyClass(IFilesystemImporter, self._getTargetClass())
+
 
 class ConformsToIINIAware:
 
@@ -158,7 +174,8 @@ class ConformsToIINIAware:
         from Products.GenericSetup.interfaces import IINIAware
         from zope.interface.verify import verifyClass
 
-        verifyClass (IINIAware, self._getTargetClass() )
+        verifyClass(IINIAware, self._getTargetClass())
+
 
 class ConformsToICSVAware:
 
@@ -167,7 +184,8 @@ class ConformsToICSVAware:
         from Products.GenericSetup.interfaces import ICSVAware
         from zope.interface.verify import verifyClass
 
-        verifyClass( ICSVAware, self._getTargetClass() )
+        verifyClass(ICSVAware, self._getTargetClass())
+
 
 class ConformsToIDAVAware:
 
@@ -176,4 +194,4 @@ class ConformsToIDAVAware:
         from Products.GenericSetup.interfaces import IDAVAware
         from zope.interface.verify import verifyClass
 
-        verifyClass( IDAVAware, self._getTargetClass() )
+        verifyClass(IDAVAware, self._getTargetClass())

--- a/Products/GenericSetup/tests/faux_objects.py
+++ b/Products/GenericSetup/tests/faux_objects.py
@@ -21,6 +21,7 @@ from zope.interface import implements
 class TestSimpleItem(SimpleItem):
     pass
 
+
 class TestSimpleItemWithProperties(SimpleItem, PropertyManager):
     pass
 
@@ -30,6 +31,8 @@ four,five,six
 """
 
 from Products.GenericSetup.interfaces import ICSVAware
+
+
 class TestCSVAware(SimpleItem):
     implements(ICSVAware)
     _was_put = None
@@ -48,6 +51,8 @@ description = %s
 """
 
 from Products.GenericSetup.interfaces import IINIAware
+
+
 class TestINIAware(SimpleItem):
     implements(IINIAware)
     _was_put = None
@@ -68,6 +73,8 @@ Description: %s
 """
 
 from Products.GenericSetup.interfaces import IDAVAware
+
+
 class TestDAVAware(SimpleItem):
     implements(IDAVAware)
     _was_put = None

--- a/Products/GenericSetup/tests/test_components.py
+++ b/Products/GenericSetup/tests/test_components.py
@@ -55,6 +55,7 @@ except ImportError:
     # Avoid generating a spurious dependency
     PersistentComponents = None
 
+
 def createComponentRegistry(context):
     enableSite(context, iface=IObjectManagerSite)
 
@@ -66,17 +67,20 @@ def createComponentRegistry(context):
     components._components = components
     context.setSiteManager(components)
 
+
 class IDummyInterface(Interface):
     """A dummy interface."""
 
     def verify():
         """Returns True."""
 
+
 class IDummyInterface2(Interface):
     """A second dummy interface."""
 
     def verify():
         """Returns True."""
+
 
 class DummyUtility(object):
     """A dummy utility."""
@@ -86,17 +90,20 @@ class DummyUtility(object):
     def verify(self):
         return True
 
+
 class IAnotherDummy(Interface):
     """A third dummy interface."""
 
     def inc():
         """Increments handle count"""
 
+
 class IAnotherDummy2(Interface):
     """A second dummy interface."""
 
     def verify():
         """Returns True."""
+
 
 class DummyObject(object):
     """A dummy object to pass to the handler."""
@@ -107,6 +114,7 @@ class DummyObject(object):
 
     def inc(self):
         self.handled += 1
+
 
 class DummyAdapter(object):
     """A dummy adapter."""
@@ -119,10 +127,12 @@ class DummyAdapter(object):
     def verify(self):
         return True
 
+
 def dummy_handler(context):
     """A dummy event handler."""
-    
+
     context.inc()
+
 
 class DummyTool(SimpleItem):
     """A dummy tool."""
@@ -133,6 +143,7 @@ class DummyTool(SimpleItem):
     security = ClassSecurityInfo()
 
     security.declarePublic('verify')
+
     def verify(self):
         return True
 
@@ -148,6 +159,7 @@ class DummyTool2(SimpleItem):
     security = ClassSecurityInfo()
 
     security.declarePublic('verify')
+
     def verify(self):
         return True
 
@@ -258,16 +270,16 @@ class ComponentRegistryXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
         util.__name__ = name
         util.__parent__ = aq_base(obj)
         obj._setObject(name, aq_base(util),
-            set_owner=False, suppress_events=True)
+                       set_owner=False, suppress_events=True)
         obj.registerUtility(aq_base(obj[name]), IDummyInterface)
 
         util = DummyUtility()
         name = ('Products.GenericSetup.tests.test_components.'
-                    'IDummyInterface2-foo')
+                'IDummyInterface2-foo')
         util.__name__ = name
         util.__parent__ = aq_base(obj)
         obj._setObject(name, aq_base(util),
-            set_owner=False, suppress_events=True)
+                       set_owner=False, suppress_events=True)
         obj.registerUtility(aq_base(obj[name]), IDummyInterface2, name=u'foo')
 
         tool = aq_base(obj.aq_parent['dummy_tool'])
@@ -287,7 +299,7 @@ class ComponentRegistryXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
 
         dummy = DummyObject()
         results = [adap.verify() for adap in
-                        subscribers([dummy], IAnotherDummy2)]
+                   subscribers([dummy], IAnotherDummy2)]
         self.assertEquals(results, [True])
 
         dummy = DummyObject()
@@ -299,7 +311,7 @@ class ComponentRegistryXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
         self.failUnless(util.verify())
         self.failUnless(util.__parent__ == obj)
         name = ('Products.GenericSetup.tests.test_components.'
-                    'IDummyInterface2-foo')
+                'IDummyInterface2-foo')
         self.assertEquals(util.__name__, name)
         self.failUnless(name in obj.objectIds())
 
@@ -407,7 +419,7 @@ class ComponentRegistryXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
 
         dummy = DummyObject()
         results = [adap.verify() for adap in
-                        subscribers([dummy], IAnotherDummy2)]
+                   subscribers([dummy], IAnotherDummy2)]
         self.assertEquals(results, [])
 
         dummy = DummyObject()
@@ -416,7 +428,7 @@ class ComponentRegistryXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
 
         util = queryUtility(IDummyInterface2, name=u'foo')
         name = ('Products.GenericSetup.tests.test_components.'
-                    'IDummyInterface2-foo')
+                'IDummyInterface2-foo')
         self.failUnless(util is None)
         self.failIf(name in obj.objectIds())
 
@@ -460,11 +472,11 @@ if PersistentComponents is not None:
     def test_suite():
         # reimport to make sure tests are run from Products
         from Products.GenericSetup.tests.test_components \
-                import ComponentRegistryXMLAdapterTests
+            import ComponentRegistryXMLAdapterTests
 
         return unittest.TestSuite((
             unittest.makeSuite(ComponentRegistryXMLAdapterTests),
-            ))
+        ))
 else:
     def test_suite():
         return unittest.TestSuite()

--- a/Products/GenericSetup/tests/test_content.py
+++ b/Products/GenericSetup/tests/test_content.py
@@ -104,7 +104,7 @@ class SimpleINIAwareTests(unittest.TestCase, ConformsToIINIAware):
         adapter = self._getTargetClass()(context)
         adapter.put_ini('''\
 [DEFAULT]
-int_prop = 13 
+int_prop = 13
 \nfloat_prop = 2.818
 \ndate_prop = %s''' % DATESTR2)
         self.assertEqual(len(context.propertyIds()), 3)
@@ -148,15 +148,15 @@ class FolderishExporterImporterTests(unittest.TestCase):
         from Products.GenericSetup.interfaces import IDAVAware
 
         from Products.GenericSetup.content import \
-             SimpleINIAware
+            SimpleINIAware
         from Products.GenericSetup.content import \
-             FolderishExporterImporter
+            FolderishExporterImporter
         from Products.GenericSetup.content import \
-             CSVAwareFileAdapter
+            CSVAwareFileAdapter
         from Products.GenericSetup.content import \
-             INIAwareFileAdapter
+            INIAwareFileAdapter
         from Products.GenericSetup.content import \
-             DAVAwareFileAdapter
+            DAVAwareFileAdapter
 
         sm = getSiteManager()
 
@@ -204,7 +204,6 @@ class FolderishExporterImporterTests(unittest.TestCase):
                            (IDAVAware,),
                            IFilesystemImporter,
                            )
-
 
     def test_export_empty_site(self):
         from Products.GenericSetup.tests.common import DummyExportContext
@@ -333,7 +332,7 @@ class FolderishExporterImporterTests(unittest.TestCase):
             self.assertEqual(objects[index][0], ITEM_IDS[index])
             self.assertEqual(objects[index][1], dotted)
 
-            filename, text, content_type = context._wrote[index+2]
+            filename, text, content_type = context._wrote[index + 2]
             self.assertEqual(filename, 'structure/%s.ini' % ITEM_IDS[index])
             object = site._getOb(ITEM_IDS[index])
             self.assertEqual(text.strip(),
@@ -370,7 +369,7 @@ class FolderishExporterImporterTests(unittest.TestCase):
         exporter = self._getExporter()
         exporter(context)
 
-        self.assertEqual(len(context._wrote), 2 + (2 *len(FOLDER_IDS)))
+        self.assertEqual(len(context._wrote), 2 + (2 * len(FOLDER_IDS)))
         filename, text, content_type = context._wrote[0]
         self.assertEqual(filename, 'structure/.objects')
         self.assertEqual(content_type, 'text/comma-separated-values')
@@ -499,14 +498,14 @@ class FolderishExporterImporterTests(unittest.TestCase):
         for id in FOLDER_IDS:
             context._files['structure/%s/.objects' % id] = ''
             context._files['structure/%s/.properties' % id] = (
-                _PROPERTIES_TEMPLATE % id )
+                _PROPERTIES_TEMPLATE % id)
 
         _ROOT_OBJECTS = '\n'.join(['%s,%s' % (id, dotted)
-                                        for id in FOLDER_IDS])
+                                   for id in FOLDER_IDS])
 
         context._files['structure/.objects'] = _ROOT_OBJECTS
         context._files['structure/.properties'] = (
-                _PROPERTIES_TEMPLATE % 'Test Site')
+            _PROPERTIES_TEMPLATE % 'Test Site')
 
         importer = self._getImporter()
         importer(context)
@@ -528,13 +527,13 @@ class FolderishExporterImporterTests(unittest.TestCase):
         context = DummyImportContext(site)
         # We want to add 'baz' to 'foo', without losing 'bar'
         context._files['structure/.objects'] = '\n'.join(
-                            ['%s,%s' % (x, dotted) for x in ITEM_IDS])
+            ['%s,%s' % (x, dotted) for x in ITEM_IDS])
         for index in range(len(ITEM_IDS)):
             id = ITEM_IDS[index]
             context._files[
-                    'structure/%s.ini' % id] = KNOWN_INI % ('Title: %s' % id,
-                                                            'xyzzy',
-                                                           )
+                'structure/%s.ini' % id] = KNOWN_INI % ('Title: %s' % id,
+                                                        'xyzzy',
+                                                        )
         importer = self._getImporter()
         importer(context)
 
@@ -555,7 +554,7 @@ class FolderishExporterImporterTests(unittest.TestCase):
         context = DummyImportContext(site)
         # We want to add 'baz' to 'foo', without losing 'bar'
         context._files['structure/.objects'] = '\n'.join(
-                            ['%s,%s' % (x, dotted) for x in ('no_adapter',)])
+            ['%s,%s' % (x, dotted) for x in ('no_adapter',)])
         importer = self._getImporter()
         importer(context)
 
@@ -582,9 +581,9 @@ class FolderishExporterImporterTests(unittest.TestCase):
         for index in range(len(ITEM_IDS)):
             id = ITEM_IDS[index]
             context._files[
-                    'structure/%s.ini' % id] = KNOWN_INI % ('Title: %s' % id,
-                                                            'xyzzy',
-                                                           )
+                'structure/%s.ini' % id] = KNOWN_INI % ('Title: %s' % id,
+                                                        'xyzzy',
+                                                        )
         importer = self._getImporter()
         importer(context)
 
@@ -604,13 +603,13 @@ class FolderishExporterImporterTests(unittest.TestCase):
         context = DummyImportContext(site)
         # We want to add 'baz' to 'foo', without losing 'bar'
         context._files['structure/.objects'] = '\n'.join(
-                                ['%s,Unknown Type' % x for x in ITEM_IDS])
+            ['%s,Unknown Type' % x for x in ITEM_IDS])
         for index in range(len(ITEM_IDS)):
             id = ITEM_IDS[index]
             context._files[
-                    'structure/%s.ini' % id] = KNOWN_INI % ('Title: %s' % id,
-                                                            'xyzzy',
-                                                           )
+                'structure/%s.ini' % id] = KNOWN_INI % ('Title: %s' % id,
+                                                        'xyzzy',
+                                                        )
 
         importer = self._getImporter()
         importer(context)
@@ -698,10 +697,10 @@ class FolderishExporterImporterTests(unittest.TestCase):
         context = DummyImportContext(site)
         # We want to add 'baz' to 'foo', without losing 'bar'
         context._files['structure/.objects'
-                      ] = 'foo,%s' % _getDottedName(foo.__class__)
+                       ] = 'foo,%s' % _getDottedName(foo.__class__)
         context._files['structure/.preserve'] = '*'
         context._files['structure/foo/.objects'
-                      ] = 'baz,%s' % _getDottedName(bar.__class__)
+                       ] = 'baz,%s' % _getDottedName(bar.__class__)
         context._files['structure/foo/.preserve'] = '*'
         context._files['structure/foo/baz/.objects'] = ''
 
@@ -732,18 +731,18 @@ class Test_globpattern(unittest.TestCase):
 
     def test_simple(self):
         self._checkResults('b*', self.NAMELIST,
-                            [x for x in self.NAMELIST if x.startswith('b')])
+                           [x for x in self.NAMELIST if x.startswith('b')])
 
     def test_multiple(self):
         self._checkResults('b*\n*x', self.NAMELIST,
-                            [x for x in self.NAMELIST
-                                if x.startswith('b') or x.endswith('x')])
+                           [x for x in self.NAMELIST
+                            if x.startswith('b') or x.endswith('x')])
 
 
 class CSVAwareFileAdapterTests(unittest.TestCase,
                                ConformsToIFilesystemExporter,
                                ConformsToIFilesystemImporter,
-                              ):
+                               ):
 
     def _getTargetClass(self):
         from Products.GenericSetup.content import CSVAwareFileAdapter
@@ -794,6 +793,7 @@ Title = %s
 Description = This is a test
 """
 
+
 class INIAwareFileAdapterTests(unittest.TestCase,
                                ConformsToIFilesystemExporter,
                                ConformsToIFilesystemImporter,
@@ -827,7 +827,7 @@ class INIAwareFileAdapterTests(unittest.TestCase,
         adapter = self._makeOne(ini_file)
         context = DummyImportContext(None)
         context._files['subpath/to/ini_file.html.ini'] = (
-                        KNOWN_INI % ('Title: ini_file', 'abc'))
+            KNOWN_INI % ('Title: ini_file', 'abc'))
 
         adapter.import_(context, 'subpath/to')
         text = ini_file._was_put
@@ -883,6 +883,7 @@ def _makePropertied(id):
 
     return propertied
 
+
 def _makeCSVAware(id, csv=None):
     from Products.GenericSetup.tests.faux_objects import TestCSVAware
 
@@ -930,7 +931,7 @@ def _makeFolder(id):
 
     folder = Folder(id)
     directlyProvides(folder, providedBy(folder)
-                             + IObjectManager + IPropertyManager)
+                     + IObjectManager + IPropertyManager)
 
     return folder
 
@@ -939,6 +940,7 @@ def _parseCSV(text):
     from csv import reader
     from StringIO import StringIO
     return [x for x in reader(StringIO(text))]
+
 
 def _parseINI(text):
     from ConfigParser import ConfigParser

--- a/Products/GenericSetup/tests/test_context.py
+++ b/Products/GenericSetup/tests/test_context.py
@@ -1,4 +1,4 @@
-#encoding: utf-8
+# encoding: utf-8
 ##############################################################################
 #
 # Copyright (c) 2004 Zope Foundation and Contributors.
@@ -38,82 +38,81 @@ from conformance import ConformsToIChunkableExportContext
 from conformance import ConformsToIChunkableImportContext
 
 
-class DummySite( Folder ):
+class DummySite(Folder):
 
     pass
 
-class DummyTool( Folder ):
+
+class DummyTool(Folder):
 
     pass
+
 
 class DummyPdataStreamIterator:
-    
+
     pass
 
 
-class DirectoryImportContextTests( FilesystemTestBase
-                                 , ConformsToISetupContext
-                                 , ConformsToIImportContext
-                                 , ConformsToIChunkableImportContext
-                                 ):
+class DirectoryImportContextTests(FilesystemTestBase, ConformsToISetupContext, ConformsToIImportContext, ConformsToIChunkableImportContext
+                                  ):
 
     _PROFILE_PATH = '/tmp/ICTTexts'
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.context import DirectoryImportContext
         return DirectoryImportContext
 
-    def test_getLogger( self ):
+    def test_getLogger(self):
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
+        self.assertEqual(len(ctx.listNotes()), 0)
 
         logger = ctx.getLogger('foo')
         logger.info('bar')
 
-        self.assertEqual( len( ctx.listNotes() ), 1 )
+        self.assertEqual(len(ctx.listNotes()), 1)
         level, component, message = ctx.listNotes()[0]
-        self.assertEqual( level, logging.INFO )
-        self.assertEqual( component, 'foo' )
-        self.assertEqual( message, 'bar' )
+        self.assertEqual(level, logging.INFO)
+        self.assertEqual(component, 'foo')
+        self.assertEqual(message, 'bar')
 
         ctx.clearNotes()
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
-    def test_readDataFile_nonesuch( self ):
+    def test_readDataFile_nonesuch(self):
 
         FILENAME = 'nonesuch.txt'
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.readDataFile( FILENAME ), None )
+        self.assertEqual(ctx.readDataFile(FILENAME), None)
 
-    def test_readDataFile_simple( self ):
+    def test_readDataFile_simple(self):
 
         from string import printable
 
         FILENAME = 'simple.txt'
-        self._makeFile( FILENAME, printable )
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.readDataFile( FILENAME ), printable )
+        self.assertEqual(ctx.readDataFile(FILENAME), printable)
 
-    def test_readDataFile_subdir( self ):
+    def test_readDataFile_subdir(self):
 
         from string import printable
 
         FILENAME = 'subdir/nested.txt'
-        self._makeFile( FILENAME, printable )
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.readDataFile( FILENAME ), printable )
+        self.assertEqual(ctx.readDataFile(FILENAME), printable)
 
     def test_getLastModified_nonesuch(self):
         FILENAME = 'nonesuch.txt'
@@ -166,291 +165,287 @@ class DirectoryImportContextTests( FilesystemTestBase
         self.assertTrue(isinstance(lm, DateTime))
         self.assertEqual(lm, DateTime(WHEN))
 
-    def test_isDirectory_nonesuch( self ):
+    def test_isDirectory_nonesuch(self):
 
         FILENAME = 'nonesuch.txt'
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.isDirectory( FILENAME ), None )
+        self.assertEqual(ctx.isDirectory(FILENAME), None)
 
-    def test_isDirectory_simple( self ):
+    def test_isDirectory_simple(self):
 
         from string import printable
 
         FILENAME = 'simple.txt'
-        self._makeFile( FILENAME, printable )
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.isDirectory( FILENAME ), False )
+        self.assertEqual(ctx.isDirectory(FILENAME), False)
 
-    def test_isDirectory_nested( self ):
+    def test_isDirectory_nested(self):
 
         from string import printable
 
         SUBDIR = 'subdir'
-        FILENAME = os.path.join( SUBDIR, 'nested.txt' )
-        self._makeFile( FILENAME, printable )
+        FILENAME = os.path.join(SUBDIR, 'nested.txt')
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.isDirectory( FILENAME ), False )
+        self.assertEqual(ctx.isDirectory(FILENAME), False)
 
-    def test_isDirectory_directory( self ):
+    def test_isDirectory_directory(self):
 
         from string import printable
 
         SUBDIR = 'subdir'
-        FILENAME = os.path.join( SUBDIR, 'nested.txt' )
-        self._makeFile( FILENAME, printable )
+        FILENAME = os.path.join(SUBDIR, 'nested.txt')
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.isDirectory( SUBDIR ), True )
+        self.assertEqual(ctx.isDirectory(SUBDIR), True)
 
-    def test_listDirectory_nonesuch( self ):
+    def test_listDirectory_nonesuch(self):
 
         FILENAME = 'nonesuch.txt'
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.listDirectory( FILENAME ), None )
+        self.assertEqual(ctx.listDirectory(FILENAME), None)
 
-    def test_listDirectory_root( self ):
+    def test_listDirectory_root(self):
 
         from string import printable
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
         FILENAME = 'simple.txt'
-        self._makeFile( FILENAME, printable )
+        self._makeFile(FILENAME, printable)
 
-        self.assertEqual( len( ctx.listDirectory( None ) ), 1 )
-        self.failUnless( FILENAME in ctx.listDirectory( None ) )
+        self.assertEqual(len(ctx.listDirectory(None)), 1)
+        self.failUnless(FILENAME in ctx.listDirectory(None))
 
-    def test_listDirectory_simple( self ):
+    def test_listDirectory_simple(self):
 
         from string import printable
 
         FILENAME = 'simple.txt'
-        self._makeFile( FILENAME, printable )
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.listDirectory( FILENAME ), None )
+        self.assertEqual(ctx.listDirectory(FILENAME), None)
 
-    def test_listDirectory_nested( self ):
+    def test_listDirectory_nested(self):
 
         from string import printable
 
         SUBDIR = 'subdir'
-        FILENAME = os.path.join( SUBDIR, 'nested.txt' )
-        self._makeFile( FILENAME, printable )
+        FILENAME = os.path.join(SUBDIR, 'nested.txt')
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        self.assertEqual( ctx.listDirectory( FILENAME ), None )
+        self.assertEqual(ctx.listDirectory(FILENAME), None)
 
-    def test_listDirectory_single( self ):
+    def test_listDirectory_single(self):
 
         from string import printable
 
         SUBDIR = 'subdir'
-        FILENAME = os.path.join( SUBDIR, 'nested.txt' )
-        self._makeFile( FILENAME, printable )
+        FILENAME = os.path.join(SUBDIR, 'nested.txt')
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        names = ctx.listDirectory( SUBDIR )
-        self.assertEqual( len( names ), 1 )
-        self.failUnless( 'nested.txt' in names )
+        names = ctx.listDirectory(SUBDIR)
+        self.assertEqual(len(names), 1)
+        self.failUnless('nested.txt' in names)
 
-    def test_listDirectory_multiple( self ):
+    def test_listDirectory_multiple(self):
 
         from string import printable
         SUBDIR = 'subdir'
-        FILENAME = os.path.join( SUBDIR, 'nested.txt' )
-        self._makeFile( FILENAME, printable )
-        self._makeFile( os.path.join( SUBDIR, 'another.txt' ), 'ABC' )
+        FILENAME = os.path.join(SUBDIR, 'nested.txt')
+        self._makeFile(FILENAME, printable)
+        self._makeFile(os.path.join(SUBDIR, 'another.txt'), 'ABC')
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        names = ctx.listDirectory( SUBDIR )
-        self.assertEqual( len( names ), 2 )
-        self.failUnless( 'nested.txt' in names )
-        self.failUnless( 'another.txt' in names )
+        names = ctx.listDirectory(SUBDIR)
+        self.assertEqual(len(names), 2)
+        self.failUnless('nested.txt' in names)
+        self.failUnless('another.txt' in names)
 
-    def test_listDirectory_skip_implicit( self ):
+    def test_listDirectory_skip_implicit(self):
 
         from string import printable
         SUBDIR = 'subdir'
-        FILENAME = os.path.join( SUBDIR, 'nested.txt' )
-        self._makeFile( FILENAME, printable )
-        self._makeFile( os.path.join( SUBDIR, 'another.txt' ), 'ABC' )
-        self._makeFile( os.path.join( SUBDIR, 'another.txt~' ), '123' )
-        self._makeFile( os.path.join( SUBDIR, 'CVS/skip.txt' ), 'DEF' )
-        self._makeFile( os.path.join( SUBDIR, '.svn/skip.txt' ), 'GHI' )
+        FILENAME = os.path.join(SUBDIR, 'nested.txt')
+        self._makeFile(FILENAME, printable)
+        self._makeFile(os.path.join(SUBDIR, 'another.txt'), 'ABC')
+        self._makeFile(os.path.join(SUBDIR, 'another.txt~'), '123')
+        self._makeFile(os.path.join(SUBDIR, 'CVS/skip.txt'), 'DEF')
+        self._makeFile(os.path.join(SUBDIR, '.svn/skip.txt'), 'GHI')
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        names = ctx.listDirectory( SUBDIR )
-        self.assertEqual( len( names ), 2 )
-        self.failUnless( 'nested.txt' in names )
-        self.failUnless( 'another.txt' in names )
-        self.failIf( 'another.txt~' in names )
-        self.failIf( 'CVS' in names )
-        self.failIf( '.svn' in names )
+        names = ctx.listDirectory(SUBDIR)
+        self.assertEqual(len(names), 2)
+        self.failUnless('nested.txt' in names)
+        self.failUnless('another.txt' in names)
+        self.failIf('another.txt~' in names)
+        self.failIf('CVS' in names)
+        self.failIf('.svn' in names)
 
-    def test_listDirectory_skip_explicit( self ):
+    def test_listDirectory_skip_explicit(self):
 
         from string import printable
         SUBDIR = 'subdir'
-        FILENAME = os.path.join( SUBDIR, 'nested.txt' )
-        self._makeFile( FILENAME, printable )
-        self._makeFile( os.path.join( SUBDIR, 'another.txt' ), 'ABC' )
-        self._makeFile( os.path.join( SUBDIR, 'another.bak' ), '123' )
-        self._makeFile( os.path.join( SUBDIR, 'CVS/skip.txt' ), 'DEF' )
-        self._makeFile( os.path.join( SUBDIR, '.svn/skip.txt' ), 'GHI' )
+        FILENAME = os.path.join(SUBDIR, 'nested.txt')
+        self._makeFile(FILENAME, printable)
+        self._makeFile(os.path.join(SUBDIR, 'another.txt'), 'ABC')
+        self._makeFile(os.path.join(SUBDIR, 'another.bak'), '123')
+        self._makeFile(os.path.join(SUBDIR, 'CVS/skip.txt'), 'DEF')
+        self._makeFile(os.path.join(SUBDIR, '.svn/skip.txt'), 'GHI')
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
         names = ctx.listDirectory(SUBDIR, skip=('nested.txt',),
                                   skip_suffixes=('.bak',))
-        self.assertEqual( len( names ), 3 )
-        self.failIf( 'nested.txt' in names )
-        self.failIf( 'nested.bak' in names )
-        self.failUnless( 'another.txt' in names )
-        self.failUnless( 'CVS' in names )
-        self.failUnless( '.svn' in names )
+        self.assertEqual(len(names), 3)
+        self.failIf('nested.txt' in names)
+        self.failIf('nested.bak' in names)
+        self.failUnless('another.txt' in names)
+        self.failUnless('CVS' in names)
+        self.failUnless('.svn' in names)
 
 
-class DirectoryExportContextTests( FilesystemTestBase
-                                 , ConformsToISetupContext
-                                 , ConformsToIExportContext
-                                 , ConformsToIChunkableExportContext
-                                 ):
+class DirectoryExportContextTests(FilesystemTestBase, ConformsToISetupContext, ConformsToIExportContext, ConformsToIChunkableExportContext
+                                  ):
 
     _PROFILE_PATH = '/tmp/ECTTexts'
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.context import DirectoryExportContext
         return DirectoryExportContext
 
-    def test_getLogger( self ):
+    def test_getLogger(self):
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
+        self.assertEqual(len(ctx.listNotes()), 0)
 
         logger = ctx.getLogger('foo')
         logger.info('bar')
 
-        self.assertEqual( len( ctx.listNotes() ), 1 )
+        self.assertEqual(len(ctx.listNotes()), 1)
         level, component, message = ctx.listNotes()[0]
-        self.assertEqual( level, logging.INFO )
-        self.assertEqual( component, 'foo' )
-        self.assertEqual( message, 'bar' )
+        self.assertEqual(level, logging.INFO)
+        self.assertEqual(component, 'foo')
+        self.assertEqual(message, 'bar')
 
         ctx.clearNotes()
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
-    def test_writeDataFile_simple( self ):
+    def test_writeDataFile_simple(self):
 
         from string import printable, digits
         FILENAME = 'simple.txt'
-        fqname = self._makeFile( FILENAME, printable )
+        fqname = self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        ctx.writeDataFile( FILENAME, digits, 'text/plain' )
+        ctx.writeDataFile(FILENAME, digits, 'text/plain')
 
-        self.assertEqual( open( fqname, 'rb' ).read(), digits )
+        self.assertEqual(open(fqname, 'rb').read(), digits)
 
-    def test_writeDataFile_unicode( self ):
+    def test_writeDataFile_unicode(self):
 
         from string import printable
         text = u'Kein Weltraum links vom Gerät'
         FILENAME = 'unicode.txt'
-        self._makeFile( FILENAME, printable )
+        self._makeFile(FILENAME, printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
         self.assertRaises(ValueError, ctx.writeDataFile,
-                          FILENAME, text, 'text/plain' )
+                          FILENAME, text, 'text/plain')
         text = u'No umlauts'
         self.assertRaises(ValueError, ctx.writeDataFile,
-                          FILENAME, text, 'text/plain' )
+                          FILENAME, text, 'text/plain')
 
-    def test_writeDataFile_new_subdir( self ):
+    def test_writeDataFile_new_subdir(self):
         from string import digits
 
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
-        fqname = os.path.join( self._PROFILE_PATH, SUBDIR, FILENAME )
+        fqname = os.path.join(self._PROFILE_PATH, SUBDIR, FILENAME)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        ctx.writeDataFile( FILENAME, digits, 'text/plain', SUBDIR )
+        ctx.writeDataFile(FILENAME, digits, 'text/plain', SUBDIR)
 
-        self.assertEqual( open( fqname, 'rb' ).read(), digits )
+        self.assertEqual(open(fqname, 'rb').read(), digits)
 
-    def test_writeDataFile_overwrite( self ):
+    def test_writeDataFile_overwrite(self):
 
         from string import printable, digits
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
-        fqname = self._makeFile( os.path.join( SUBDIR, FILENAME )
-                               , printable )
+        fqname = self._makeFile(os.path.join(SUBDIR, FILENAME), printable)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        ctx.writeDataFile( FILENAME, digits, 'text/plain', SUBDIR )
+        ctx.writeDataFile(FILENAME, digits, 'text/plain', SUBDIR)
 
-        self.assertEqual( open( fqname, 'rb' ).read(), digits )
+        self.assertEqual(open(fqname, 'rb').read(), digits)
 
-    def test_writeDataFile_existing_subdir( self ):
+    def test_writeDataFile_existing_subdir(self):
 
         from string import printable, digits
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
-        self._makeFile( os.path.join( SUBDIR, 'another.txt' ), printable )
-        fqname = os.path.join( self._PROFILE_PATH, SUBDIR, FILENAME )
+        self._makeFile(os.path.join(SUBDIR, 'another.txt'), printable)
+        fqname = os.path.join(self._PROFILE_PATH, SUBDIR, FILENAME)
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._makeOne( site, self._PROFILE_PATH )
+        ctx = self._makeOne(site, self._PROFILE_PATH)
 
-        ctx.writeDataFile( FILENAME, digits, 'text/plain', SUBDIR )
+        ctx.writeDataFile(FILENAME, digits, 'text/plain', SUBDIR)
 
-        self.assertEqual( open( fqname, 'rb' ).read(), digits )
+        self.assertEqual(open(fqname, 'rb').read(), digits)
 
 
 class TarballImportContextTests(ZopeTestCase, ConformsToISetupContext,
                                 ConformsToIImportContext):
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.context import TarballImportContext
         return TarballImportContext
 
-    def _makeOne( self, file_dict={}, mod_time=None, *args, **kw ):
+    def _makeOne(self, file_dict={}, mod_time=None, *args, **kw):
 
         archive_stream = StringIO()
         archive = TarFile.open('test.tar.gz', 'w:gz', archive_stream)
@@ -475,7 +470,8 @@ class TarballImportContextTests(ZopeTestCase, ConformsToISetupContext,
                 parents.pop()
             _addOneMember(filename, data, modtime)
 
-        file_items = file_dict.items() or [('dummy', '')] # empty archive barfs
+        file_items = file_dict.items() or [(
+            'dummy', '')]  # empty archive barfs
 
         if mod_time is None:
             mod_time = time.time()
@@ -487,83 +483,82 @@ class TarballImportContextTests(ZopeTestCase, ConformsToISetupContext,
         bits = archive_stream.getvalue()
 
         site = DummySite('site').__of__(self.app)
-        site._setObject( 'setup_tool', Folder( 'setup_tool' ) )
-        tool = site._getOb( 'setup_tool' )
+        site._setObject('setup_tool', Folder('setup_tool'))
+        tool = site._getOb('setup_tool')
 
-        ctx = self._getTargetClass()( tool, bits, *args, **kw )
+        ctx = self._getTargetClass()(tool, bits, *args, **kw)
 
-        return site, tool, ctx.__of__( tool )
+        return site, tool, ctx.__of__(tool)
 
-    def test_getLogger( self ):
+    def test_getLogger(self):
 
         site, tool, ctx = self._makeOne()
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
         logger = ctx.getLogger('foo')
         logger.info('bar')
 
-        self.assertEqual( len( ctx.listNotes() ), 1 )
+        self.assertEqual(len(ctx.listNotes()), 1)
         level, component, message = ctx.listNotes()[0]
-        self.assertEqual( level, logging.INFO )
-        self.assertEqual( component, 'foo' )
-        self.assertEqual( message, 'bar' )
+        self.assertEqual(level, logging.INFO)
+        self.assertEqual(component, 'foo')
+        self.assertEqual(message, 'bar')
 
         ctx.clearNotes()
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
-    def test_ctorparms( self ):
+    def test_ctorparms(self):
 
         ENCODING = 'latin-1'
-        site, tool, ctx = self._makeOne( encoding=ENCODING
-                                       , should_purge=True
-                                       )
+        site, tool, ctx = self._makeOne(encoding=ENCODING, should_purge=True
+                                        )
 
-        self.assertEqual( ctx.getEncoding(), ENCODING )
-        self.assertEqual( ctx.shouldPurge(), True )
+        self.assertEqual(ctx.getEncoding(), ENCODING)
+        self.assertEqual(ctx.shouldPurge(), True)
 
-    def test_empty( self ):
+    def test_empty(self):
 
         site, tool, ctx = self._makeOne()
 
-        self.assertEqual( ctx.getSite(), site )
-        self.assertEqual( ctx.getEncoding(), None )
-        self.assertEqual( ctx.shouldPurge(), False )
+        self.assertEqual(ctx.getSite(), site)
+        self.assertEqual(ctx.getEncoding(), None)
+        self.assertEqual(ctx.shouldPurge(), False)
 
         # These methods are all specified to return 'None' for non-existing
         # paths / entities
-        self.assertEqual( ctx.isDirectory( 'nonesuch/path' ), None )
-        self.assertEqual( ctx.listDirectory( 'nonesuch/path' ), None )
+        self.assertEqual(ctx.isDirectory('nonesuch/path'), None)
+        self.assertEqual(ctx.listDirectory('nonesuch/path'), None)
 
-    def test_readDataFile_nonesuch( self ):
+    def test_readDataFile_nonesuch(self):
 
         FILENAME = 'nonesuch.txt'
 
         site, tool, ctx = self._makeOne()
 
-        self.assertEqual( ctx.readDataFile( FILENAME ), None )
-        self.assertEqual( ctx.readDataFile( FILENAME, 'subdir' ), None )
+        self.assertEqual(ctx.readDataFile(FILENAME), None)
+        self.assertEqual(ctx.readDataFile(FILENAME, 'subdir'), None)
 
-    def test_readDataFile_simple( self ):
+    def test_readDataFile_simple(self):
 
         from string import printable
 
         FILENAME = 'simple.txt'
 
-        site, tool, ctx = self._makeOne( { FILENAME: printable } )
+        site, tool, ctx = self._makeOne({FILENAME: printable})
 
-        self.assertEqual( ctx.readDataFile( FILENAME ), printable )
+        self.assertEqual(ctx.readDataFile(FILENAME), printable)
 
-    def test_readDataFile_subdir( self ):
+    def test_readDataFile_subdir(self):
 
         from string import printable
 
         FILENAME = 'subdir.txt'
         SUBDIR = 'subdir'
 
-        site, tool, ctx = self._makeOne( { '%s/%s' % (SUBDIR, FILENAME):
-                                            printable } )
+        site, tool, ctx = self._makeOne({'%s/%s' % (SUBDIR, FILENAME):
+                                         printable})
 
-        self.assertEqual( ctx.readDataFile( FILENAME, SUBDIR ), printable )
+        self.assertEqual(ctx.readDataFile(FILENAME, SUBDIR), printable)
 
     def test_getLastModified_nonesuch(self):
         FILENAME = 'nonesuch.txt'
@@ -608,225 +603,222 @@ class TarballImportContextTests(ZopeTestCase, ConformsToISetupContext,
         self.assertTrue(isinstance(lm, DateTime))
         self.assertEqual(lm, DateTime(WHEN))
 
-    def test_isDirectory_nonesuch( self ):
+    def test_isDirectory_nonesuch(self):
 
         FILENAME = 'nonesuch.txt'
 
         site, tool, ctx = self._makeOne()
 
-        self.assertEqual( ctx.isDirectory( FILENAME ), None )
+        self.assertEqual(ctx.isDirectory(FILENAME), None)
 
-    def test_isDirectory_simple( self ):
+    def test_isDirectory_simple(self):
 
         from string import printable
 
         FILENAME = 'simple.txt'
 
-        site, tool, ctx = self._makeOne( { FILENAME: printable } )
+        site, tool, ctx = self._makeOne({FILENAME: printable})
 
-        self.assertEqual( ctx.isDirectory( FILENAME ), False )
+        self.assertEqual(ctx.isDirectory(FILENAME), False)
 
-    def test_isDirectory_nested( self ):
-
-        from string import printable
-
-        SUBDIR = 'subdir'
-        FILENAME = 'nested.txt'
-        PATH = '%s/%s' % ( SUBDIR, FILENAME )
-
-        site, tool, ctx = self._makeOne( { PATH: printable } )
-
-        self.assertEqual( ctx.isDirectory( PATH ), False )
-
-    def test_isDirectory_subdir( self ):
+    def test_isDirectory_nested(self):
 
         from string import printable
 
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
-        PATH = '%s/%s' % ( SUBDIR, FILENAME )
+        PATH = '%s/%s' % (SUBDIR, FILENAME)
 
-        site, tool, ctx = self._makeOne( { PATH: printable } )
+        site, tool, ctx = self._makeOne({PATH: printable})
 
-        self.assertEqual( ctx.isDirectory( SUBDIR ), True )
+        self.assertEqual(ctx.isDirectory(PATH), False)
 
-    def test_listDirectory_nonesuch( self ):
+    def test_isDirectory_subdir(self):
+
+        from string import printable
+
+        SUBDIR = 'subdir'
+        FILENAME = 'nested.txt'
+        PATH = '%s/%s' % (SUBDIR, FILENAME)
+
+        site, tool, ctx = self._makeOne({PATH: printable})
+
+        self.assertEqual(ctx.isDirectory(SUBDIR), True)
+
+    def test_listDirectory_nonesuch(self):
 
         SUBDIR = 'nonesuch/path'
 
         site, tool, ctx = self._makeOne()
 
-        self.assertEqual( ctx.listDirectory( SUBDIR ), None )
+        self.assertEqual(ctx.listDirectory(SUBDIR), None)
 
-    def test_listDirectory_root( self ):
-
-        from string import printable
-
-        FILENAME = 'simple.txt'
-
-        site, tool, ctx = self._makeOne( { FILENAME: printable } )
-
-        self.assertEqual( len( ctx.listDirectory( None ) ), 1 )
-        self.failUnless( FILENAME in ctx.listDirectory( None ) )
-
-    def test_listDirectory_simple( self ):
+    def test_listDirectory_root(self):
 
         from string import printable
 
         FILENAME = 'simple.txt'
 
-        site, tool, ctx = self._makeOne( { FILENAME: printable } )
+        site, tool, ctx = self._makeOne({FILENAME: printable})
 
-        self.assertEqual( ctx.listDirectory( FILENAME ), None )
+        self.assertEqual(len(ctx.listDirectory(None)), 1)
+        self.failUnless(FILENAME in ctx.listDirectory(None))
 
-    def test_listDirectory_nested( self ):
+    def test_listDirectory_simple(self):
+
+        from string import printable
+
+        FILENAME = 'simple.txt'
+
+        site, tool, ctx = self._makeOne({FILENAME: printable})
+
+        self.assertEqual(ctx.listDirectory(FILENAME), None)
+
+    def test_listDirectory_nested(self):
 
         from string import printable
 
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
-        PATH = '%s/%s' % ( SUBDIR, FILENAME )
+        PATH = '%s/%s' % (SUBDIR, FILENAME)
 
-        site, tool, ctx = self._makeOne( { PATH: printable } )
+        site, tool, ctx = self._makeOne({PATH: printable})
 
-        self.assertEqual( ctx.listDirectory( PATH ), None )
+        self.assertEqual(ctx.listDirectory(PATH), None)
 
-    def test_listDirectory_single( self ):
+    def test_listDirectory_single(self):
 
         from string import printable
 
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
-        PATH = '%s/%s' % ( SUBDIR, FILENAME )
+        PATH = '%s/%s' % (SUBDIR, FILENAME)
 
-        site, tool, ctx = self._makeOne( { PATH: printable } )
+        site, tool, ctx = self._makeOne({PATH: printable})
 
-        names = ctx.listDirectory( SUBDIR )
-        self.assertEqual( len( names ), 1 )
-        self.failUnless( FILENAME in names )
+        names = ctx.listDirectory(SUBDIR)
+        self.assertEqual(len(names), 1)
+        self.failUnless(FILENAME in names)
 
-    def test_listDirectory_multiple( self ):
-
-        from string import printable, uppercase
-
-        SUBDIR = 'subdir'
-        FILENAME1 = 'nested.txt'
-        PATH1 = '%s/%s' % ( SUBDIR, FILENAME1 )
-        FILENAME2 = 'another.txt'
-        PATH2 = '%s/%s' % ( SUBDIR, FILENAME2 )
-
-        site, tool, ctx = self._makeOne( { PATH1: printable
-                                         , PATH2: uppercase
-                                         } )
-                                             
-        names = ctx.listDirectory( SUBDIR )
-        self.assertEqual( len( names ), 2 )
-        self.failUnless( FILENAME1 in names )
-        self.failUnless( FILENAME2 in names )
-
-    def test_listDirectory_skip( self ):
+    def test_listDirectory_multiple(self):
 
         from string import printable, uppercase
 
         SUBDIR = 'subdir'
         FILENAME1 = 'nested.txt'
-        PATH1 = '%s/%s' % ( SUBDIR, FILENAME1 )
+        PATH1 = '%s/%s' % (SUBDIR, FILENAME1)
         FILENAME2 = 'another.txt'
-        PATH2 = '%s/%s' % ( SUBDIR, FILENAME2 )
+        PATH2 = '%s/%s' % (SUBDIR, FILENAME2)
+
+        site, tool, ctx = self._makeOne({PATH1: printable, PATH2: uppercase
+                                         })
+
+        names = ctx.listDirectory(SUBDIR)
+        self.assertEqual(len(names), 2)
+        self.failUnless(FILENAME1 in names)
+        self.failUnless(FILENAME2 in names)
+
+    def test_listDirectory_skip(self):
+
+        from string import printable, uppercase
+
+        SUBDIR = 'subdir'
+        FILENAME1 = 'nested.txt'
+        PATH1 = '%s/%s' % (SUBDIR, FILENAME1)
+        FILENAME2 = 'another.txt'
+        PATH2 = '%s/%s' % (SUBDIR, FILENAME2)
         FILENAME3 = 'another.bak'
-        PATH3 = '%s/%s' % ( SUBDIR, FILENAME3 )
+        PATH3 = '%s/%s' % (SUBDIR, FILENAME3)
 
-        site, tool, ctx = self._makeOne( { PATH1: printable
-                                         , PATH2: uppercase
-                                         , PATH3: 'xyz'
-                                         } )
+        site, tool, ctx = self._makeOne({PATH1: printable, PATH2: uppercase, PATH3: 'xyz'
+                                         })
 
         names = ctx.listDirectory(SUBDIR, skip=(FILENAME1,),
                                   skip_suffixes=('.bak',))
-        self.assertEqual( len( names ), 1 )
-        self.failIf( FILENAME1 in names )
-        self.failUnless( FILENAME2 in names )
-        self.failIf( FILENAME3 in names )
+        self.assertEqual(len(names), 1)
+        self.failIf(FILENAME1 in names)
+        self.failUnless(FILENAME2 in names)
+        self.failIf(FILENAME3 in names)
 
 
 class TarballExportContextTests(ZopeTestCase, ConformsToISetupContext,
                                 ConformsToIExportContext, TarballTester):
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.context import TarballExportContext
         return TarballExportContext
 
-    def test_getLogger( self ):
+    def test_getLogger(self):
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._getTargetClass()( site )
+        ctx = self._getTargetClass()(site)
 
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
         logger = ctx.getLogger('foo')
         logger.info('bar')
 
-        self.assertEqual( len( ctx.listNotes() ), 1 )
+        self.assertEqual(len(ctx.listNotes()), 1)
         level, component, message = ctx.listNotes()[0]
-        self.assertEqual( level, logging.INFO )
-        self.assertEqual( component, 'foo' )
-        self.assertEqual( message, 'bar' )
+        self.assertEqual(level, logging.INFO)
+        self.assertEqual(component, 'foo')
+        self.assertEqual(message, 'bar')
 
         ctx.clearNotes()
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
-    def test_writeDataFile_simple( self ):
+    def test_writeDataFile_simple(self):
 
         from string import printable
-        now = long( time.time() )
+        now = long(time.time())
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._getTargetClass()( site )
+        ctx = self._getTargetClass()(site)
 
-        ctx.writeDataFile( 'foo.txt', printable, 'text/plain' )
+        ctx.writeDataFile('foo.txt', printable, 'text/plain')
 
-        fileish = StringIO( ctx.getArchive() )
+        fileish = StringIO(ctx.getArchive())
 
-        self._verifyTarballContents( fileish, [ 'foo.txt' ], now )
-        self._verifyTarballEntry( fileish, 'foo.txt', printable )
+        self._verifyTarballContents(fileish, ['foo.txt'], now)
+        self._verifyTarballEntry(fileish, 'foo.txt', printable)
 
-    def test_writeDataFile_umluats( self ):
+    def test_writeDataFile_umluats(self):
 
         text = u'Kein Weltraum links vom Gerät'
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._getTargetClass()( site )
+        ctx = self._getTargetClass()(site)
 
         self.assertRaises(ValueError, ctx.writeDataFile,
-                          'foo.txt', text, 'text/plain' )
+                          'foo.txt', text, 'text/plain')
         text = u'No umlauts'
         self.assertRaises(ValueError, ctx.writeDataFile,
-                          'foo.txt', text, 'text/plain' )
+                          'foo.txt', text, 'text/plain')
 
-    def test_writeDataFile_multiple( self ):
+    def test_writeDataFile_multiple(self):
 
         from string import printable
         from string import digits
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._getTargetClass()( site )
+        ctx = self._getTargetClass()(site)
 
-        ctx.writeDataFile( 'foo.txt', printable, 'text/plain' )
-        ctx.writeDataFile( 'bar.txt', digits, 'text/plain' )
+        ctx.writeDataFile('foo.txt', printable, 'text/plain')
+        ctx.writeDataFile('bar.txt', digits, 'text/plain')
 
-        fileish = StringIO( ctx.getArchive() )
+        fileish = StringIO(ctx.getArchive())
 
-        self._verifyTarballContents( fileish, [ 'foo.txt', 'bar.txt' ] )
-        self._verifyTarballEntry( fileish, 'foo.txt', printable )
-        self._verifyTarballEntry( fileish, 'bar.txt', digits )
+        self._verifyTarballContents(fileish, ['foo.txt', 'bar.txt'])
+        self._verifyTarballEntry(fileish, 'foo.txt', printable)
+        self._verifyTarballEntry(fileish, 'bar.txt', digits)
 
-    def test_writeDataFile_PdataStreamIterator( self ):
+    def test_writeDataFile_PdataStreamIterator(self):
 
         from string import printable
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._getTargetClass()( site )
+        ctx = self._getTargetClass()(site)
 
         fp = tempfile.TemporaryFile()
         fp.write(printable)
@@ -834,137 +826,136 @@ class TarballExportContextTests(ZopeTestCase, ConformsToISetupContext,
         pData = DummyPdataStreamIterator()
         pData.file = fp
         pData.size = len(printable)
-        ctx.writeDataFile( 'foo.txt', pData, 'text/plain' )
+        ctx.writeDataFile('foo.txt', pData, 'text/plain')
 
-        fileish = StringIO( ctx.getArchive() )
+        fileish = StringIO(ctx.getArchive())
 
-        self._verifyTarballContents( fileish, [ 'foo.txt' ] )
-        self._verifyTarballEntry( fileish, 'foo.txt', printable)
+        self._verifyTarballContents(fileish, ['foo.txt'])
+        self._verifyTarballEntry(fileish, 'foo.txt', printable)
 
-    def test_writeDataFile_subdir( self ):
+    def test_writeDataFile_subdir(self):
 
         from string import printable
         from string import digits
 
         site = DummySite('site').__of__(self.app)
-        ctx = self._getTargetClass()( site )
+        ctx = self._getTargetClass()(site)
 
-        ctx.writeDataFile( 'foo.txt', printable, 'text/plain' )
-        ctx.writeDataFile( 'bar/baz.txt', digits, 'text/plain' )
+        ctx.writeDataFile('foo.txt', printable, 'text/plain')
+        ctx.writeDataFile('bar/baz.txt', digits, 'text/plain')
 
-        fileish = StringIO( ctx.getArchive() )
+        fileish = StringIO(ctx.getArchive())
 
-        self._verifyTarballContents( fileish,
-                                     ['foo.txt', 'bar', 'bar/baz.txt'] )
-        self._verifyTarballEntry( fileish, 'foo.txt', printable )
-        self._verifyTarballEntry( fileish, 'bar/baz.txt', digits )
+        self._verifyTarballContents(fileish,
+                                    ['foo.txt', 'bar', 'bar/baz.txt'])
+        self._verifyTarballEntry(fileish, 'foo.txt', printable)
+        self._verifyTarballEntry(fileish, 'bar/baz.txt', digits)
 
 
 class SnapshotExportContextTests(ZopeTestCase, ConformsToISetupContext,
                                  ConformsToIExportContext):
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.context import SnapshotExportContext
         return SnapshotExportContext
 
-    def _makeOne( self, *args, **kw ):
+    def _makeOne(self, *args, **kw):
 
-        return self._getTargetClass()( *args, **kw )
+        return self._getTargetClass()(*args, **kw)
 
-    def test_getLogger( self ):
+    def test_getLogger(self):
 
         site = DummySite('site').__of__(self.app)
-        site.setup_tool = DummyTool( 'setup_tool' )
+        site.setup_tool = DummyTool('setup_tool')
         tool = site.setup_tool
-        ctx = self._makeOne( tool, 'simple' )
+        ctx = self._makeOne(tool, 'simple')
 
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
         logger = ctx.getLogger('foo')
         logger.info('bar')
 
-        self.assertEqual( len( ctx.listNotes() ), 1 )
+        self.assertEqual(len(ctx.listNotes()), 1)
         level, component, message = ctx.listNotes()[0]
-        self.assertEqual( level, logging.INFO )
-        self.assertEqual( component, 'foo' )
-        self.assertEqual( message, 'bar' )
+        self.assertEqual(level, logging.INFO)
+        self.assertEqual(component, 'foo')
+        self.assertEqual(message, 'bar')
 
         ctx.clearNotes()
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
-    def test_writeDataFile_simple_image( self ):
+    def test_writeDataFile_simple_image(self):
 
         from OFS.Image import Image
         FILENAME = 'simple.txt'
         CONTENT_TYPE = 'image/png'
-        png_filename = os.path.join( os.path.split( __file__ )[0]
-                                   , 'simple.png' )
-        png_file = open( png_filename, 'rb' )
+        png_filename = os.path.join(os.path.split(__file__)[0], 'simple.png')
+        png_file = open(png_filename, 'rb')
         png_data = png_file.read()
         png_file.close()
 
         site = DummySite('site').__of__(self.app)
-        site.setup_tool = DummyTool( 'setup_tool' )
+        site.setup_tool = DummyTool('setup_tool')
         tool = site.setup_tool
-        ctx = self._makeOne( tool, 'simple' )
+        ctx = self._makeOne(tool, 'simple')
 
-        ctx.writeDataFile( FILENAME, png_data, CONTENT_TYPE )
+        ctx.writeDataFile(FILENAME, png_data, CONTENT_TYPE)
 
-        snapshot = tool.snapshots._getOb( 'simple' )
+        snapshot = tool.snapshots._getOb('simple')
 
-        self.assertEqual( len( snapshot.objectIds() ), 1 )
-        self.failUnless( FILENAME in snapshot.objectIds() )
+        self.assertEqual(len(snapshot.objectIds()), 1)
+        self.failUnless(FILENAME in snapshot.objectIds())
 
-        fileobj = snapshot._getOb( FILENAME )
+        fileobj = snapshot._getOb(FILENAME)
 
-        self.assertEqual( fileobj.getId(), FILENAME )
-        self.assertEqual( fileobj.meta_type, Image.meta_type )
-        self.assertEqual( fileobj.getContentType(), CONTENT_TYPE )
-        self.assertEqual( fileobj.data, png_data )
+        self.assertEqual(fileobj.getId(), FILENAME)
+        self.assertEqual(fileobj.meta_type, Image.meta_type)
+        self.assertEqual(fileobj.getContentType(), CONTENT_TYPE)
+        self.assertEqual(fileobj.data, png_data)
 
-    def test_writeDataFile_simple_plain_text( self ):
+    def test_writeDataFile_simple_plain_text(self):
 
         from string import digits
         FILENAME = 'simple.txt'
         CONTENT_TYPE = 'text/plain'
 
         site = DummySite('site').__of__(self.app)
-        site.setup_tool = DummyTool( 'setup_tool' )
+        site.setup_tool = DummyTool('setup_tool')
         tool = site.setup_tool
-        ctx = self._makeOne( tool, 'simple' )
+        ctx = self._makeOne(tool, 'simple')
 
-        ctx.writeDataFile( FILENAME, digits, CONTENT_TYPE )
+        ctx.writeDataFile(FILENAME, digits, CONTENT_TYPE)
 
-        snapshot = tool.snapshots._getOb( 'simple' )
+        snapshot = tool.snapshots._getOb('simple')
 
-        self.assertEqual( len( snapshot.objectIds() ), 1 )
-        self.failUnless( FILENAME in snapshot.objectIds() )
+        self.assertEqual(len(snapshot.objectIds()), 1)
+        self.failUnless(FILENAME in snapshot.objectIds())
 
-        fileobj = snapshot._getOb( FILENAME )
+        fileobj = snapshot._getOb(FILENAME)
 
-        self.assertEqual( fileobj.getId(), FILENAME )
-        self.assertEqual( fileobj.meta_type, File.meta_type )
-        self.assertEqual( fileobj.getContentType(), CONTENT_TYPE )
-        self.assertEqual( str( fileobj ), digits )
+        self.assertEqual(fileobj.getId(), FILENAME)
+        self.assertEqual(fileobj.meta_type, File.meta_type)
+        self.assertEqual(fileobj.getContentType(), CONTENT_TYPE)
+        self.assertEqual(str(fileobj), digits)
 
-    def test_writeDataFile_simple_plain_text_unicode( self ):
+    def test_writeDataFile_simple_plain_text_unicode(self):
         FILENAME = 'simple.txt'
         CONTENT_TYPE = 'text/plain'
         CONTENT = u'Unicode, with non-ASCII: %s.' % unichr(150)
 
         site = DummySite('site').__of__(self.app)
-        site.setup_tool = DummyTool( 'setup_tool' )
+        site.setup_tool = DummyTool('setup_tool')
         tool = site.setup_tool
-        ctx = self._makeOne( tool, 'simple', 'latin_1' )
+        ctx = self._makeOne(tool, 'simple', 'latin_1')
 
         self.assertRaises(ValueError, ctx.writeDataFile,
-                          FILENAME, CONTENT, CONTENT_TYPE )
+                          FILENAME, CONTENT, CONTENT_TYPE)
         CONTENT = u'No unicode chars'
         self.assertRaises(ValueError, ctx.writeDataFile,
-                          FILENAME, CONTENT, CONTENT_TYPE )
+                          FILENAME, CONTENT, CONTENT_TYPE)
 
-    def test_writeDataFile_simple_xml( self ):
+    def test_writeDataFile_simple_xml(self):
 
         from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
         FILENAME = 'simple.xml'
@@ -972,25 +963,25 @@ class SnapshotExportContextTests(ZopeTestCase, ConformsToISetupContext,
         _XML = """<?xml version="1.0"?><simple />"""
 
         site = DummySite('site').__of__(self.app)
-        site.setup_tool = DummyTool( 'setup_tool' )
+        site.setup_tool = DummyTool('setup_tool')
         tool = site.setup_tool
-        ctx = self._makeOne( tool, 'simple' )
+        ctx = self._makeOne(tool, 'simple')
 
-        ctx.writeDataFile( FILENAME, _XML, CONTENT_TYPE )
+        ctx.writeDataFile(FILENAME, _XML, CONTENT_TYPE)
 
-        snapshot = tool.snapshots._getOb( 'simple' )
+        snapshot = tool.snapshots._getOb('simple')
 
-        self.assertEqual( len( snapshot.objectIds() ), 1 )
-        self.failUnless( FILENAME in snapshot.objectIds() )
+        self.assertEqual(len(snapshot.objectIds()), 1)
+        self.failUnless(FILENAME in snapshot.objectIds())
 
-        template = snapshot._getOb( FILENAME )
+        template = snapshot._getOb(FILENAME)
 
-        self.assertEqual( template.getId(), FILENAME )
-        self.assertEqual( template.meta_type, ZopePageTemplate.meta_type )
-        self.assertEqual( template.read(), _XML )
-        self.failIf( template.html() )
+        self.assertEqual(template.getId(), FILENAME)
+        self.assertEqual(template.meta_type, ZopePageTemplate.meta_type)
+        self.assertEqual(template.read(), _XML)
+        self.failIf(template.html())
 
-    def test_writeDataFile_subdir_dtml( self ):
+    def test_writeDataFile_subdir_dtml(self):
 
         from OFS.DTMLDocument import DTMLDocument
         FILENAME = 'simple.dtml'
@@ -998,28 +989,28 @@ class SnapshotExportContextTests(ZopeTestCase, ConformsToISetupContext,
         _HTML = """<html><body><h1>HTML</h1></body></html>"""
 
         site = DummySite('site').__of__(self.app)
-        site.setup_tool = DummyTool( 'setup_tool' )
+        site.setup_tool = DummyTool('setup_tool')
         tool = site.setup_tool
-        ctx = self._makeOne( tool, 'simple' )
+        ctx = self._makeOne(tool, 'simple')
 
-        ctx.writeDataFile( FILENAME, _HTML, CONTENT_TYPE, 'sub1' )
+        ctx.writeDataFile(FILENAME, _HTML, CONTENT_TYPE, 'sub1')
 
-        snapshot = tool.snapshots._getOb( 'simple' )
-        sub1 = snapshot._getOb( 'sub1' )
+        snapshot = tool.snapshots._getOb('simple')
+        sub1 = snapshot._getOb('sub1')
 
-        self.assertEqual( len( sub1.objectIds() ), 1 )
-        self.failUnless( FILENAME in sub1.objectIds() )
+        self.assertEqual(len(sub1.objectIds()), 1)
+        self.failUnless(FILENAME in sub1.objectIds())
 
-        template = sub1._getOb( FILENAME )
+        template = sub1._getOb(FILENAME)
 
-        self.assertEqual( template.getId(), FILENAME )
-        self.assertEqual( template.meta_type, DTMLDocument.meta_type )
-        self.assertEqual( template.read(), _HTML )
+        self.assertEqual(template.getId(), FILENAME)
+        self.assertEqual(template.meta_type, DTMLDocument.meta_type)
+        self.assertEqual(template.read(), _HTML)
 
-        ctx.writeDataFile( 'sub1/%s2' % FILENAME, _HTML, CONTENT_TYPE)
-        self.assertEqual( len( sub1.objectIds() ), 2 )
+        ctx.writeDataFile('sub1/%s2' % FILENAME, _HTML, CONTENT_TYPE)
+        self.assertEqual(len(sub1.objectIds()), 2)
 
-    def test_writeDataFile_nested_subdirs_html( self ):
+    def test_writeDataFile_nested_subdirs_html(self):
 
         from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
         FILENAME = 'simple.html'
@@ -1027,168 +1018,159 @@ class SnapshotExportContextTests(ZopeTestCase, ConformsToISetupContext,
         _HTML = """<html><body><h1>HTML</h1></body></html>"""
 
         site = DummySite('site').__of__(self.app)
-        site.setup_tool = DummyTool( 'setup_tool' )
+        site.setup_tool = DummyTool('setup_tool')
         tool = site.setup_tool
-        ctx = self._makeOne( tool, 'simple' )
+        ctx = self._makeOne(tool, 'simple')
 
-        ctx.writeDataFile( FILENAME, _HTML, CONTENT_TYPE, 'sub1/sub2' )
+        ctx.writeDataFile(FILENAME, _HTML, CONTENT_TYPE, 'sub1/sub2')
 
-        snapshot = tool.snapshots._getOb( 'simple' )
-        sub1 = snapshot._getOb( 'sub1' )
-        sub2 = sub1._getOb( 'sub2' )
+        snapshot = tool.snapshots._getOb('simple')
+        sub1 = snapshot._getOb('sub1')
+        sub2 = sub1._getOb('sub2')
 
-        self.assertEqual( len( sub2.objectIds() ), 1 )
-        self.failUnless( FILENAME in sub2.objectIds() )
+        self.assertEqual(len(sub2.objectIds()), 1)
+        self.failUnless(FILENAME in sub2.objectIds())
 
-        template = sub2._getOb( FILENAME )
+        template = sub2._getOb(FILENAME)
 
-        self.assertEqual( template.getId(), FILENAME )
-        self.assertEqual( template.meta_type, ZopePageTemplate.meta_type )
-        self.assertEqual( template.read(), _HTML )
-        self.failUnless( template.html() )
+        self.assertEqual(template.getId(), FILENAME)
+        self.assertEqual(template.meta_type, ZopePageTemplate.meta_type)
+        self.assertEqual(template.read(), _HTML)
+        self.failUnless(template.html())
 
-    def test_writeDataFile_multiple( self ):
+    def test_writeDataFile_multiple(self):
 
         from string import printable
         from string import digits
 
         site = DummySite('site').__of__(self.app)
-        site.setup_tool = DummyTool( 'setup_tool' )
+        site.setup_tool = DummyTool('setup_tool')
         tool = site.setup_tool
-        ctx = self._makeOne( tool, 'multiple' )
+        ctx = self._makeOne(tool, 'multiple')
 
-        ctx.writeDataFile( 'foo.txt', printable, 'text/plain' )
-        ctx.writeDataFile( 'bar.txt', digits, 'text/plain' )
+        ctx.writeDataFile('foo.txt', printable, 'text/plain')
+        ctx.writeDataFile('bar.txt', digits, 'text/plain')
 
-        snapshot = tool.snapshots._getOb( 'multiple' )
+        snapshot = tool.snapshots._getOb('multiple')
 
-        self.assertEqual( len( snapshot.objectIds() ), 2 )
+        self.assertEqual(len(snapshot.objectIds()), 2)
 
-        for id in [ 'foo.txt', 'bar.txt' ]:
-            self.failUnless( id in snapshot.objectIds() )
+        for id in ['foo.txt', 'bar.txt']:
+            self.failUnless(id in snapshot.objectIds())
 
 
 class SnapshotImportContextTests(ZopeTestCase, ConformsToISetupContext,
                                  ConformsToIImportContext):
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.context import SnapshotImportContext
         return SnapshotImportContext
 
-    def _makeOne( self, context_id, *args, **kw ):
+    def _makeOne(self, context_id, *args, **kw):
 
         site = DummySite('site').__of__(self.app)
-        site._setObject( 'setup_tool', Folder( 'setup_tool' ) )
-        tool = site._getOb( 'setup_tool' )
+        site._setObject('setup_tool', Folder('setup_tool'))
+        tool = site._getOb('setup_tool')
 
-        tool._setObject( 'snapshots', Folder( 'snapshots' ) )
-        tool.snapshots._setObject( context_id, Folder( context_id ) )
+        tool._setObject('snapshots', Folder('snapshots'))
+        tool.snapshots._setObject(context_id, Folder(context_id))
 
-        ctx = self._getTargetClass()( tool, context_id, *args, **kw )
+        ctx = self._getTargetClass()(tool, context_id, *args, **kw)
 
-        return site, tool, ctx.__of__( tool )
+        return site, tool, ctx.__of__(tool)
 
-    def _makeFile( self
-                 , tool
-                 , snapshot_id
-                 , filename
-                 , contents
-                 , content_type='text/plain'
-                 , mod_time=None
-                 , subdir=None
-                 ):
+    def _makeFile(self, tool, snapshot_id, filename, contents, content_type='text/plain', mod_time=None, subdir=None
+                  ):
 
-        snapshots = tool._getOb( 'snapshots' )
-        folder = snapshots._getOb( snapshot_id )
+        snapshots = tool._getOb('snapshots')
+        folder = snapshots._getOb(snapshot_id)
 
         if subdir is not None:
 
-            for element in subdir.split( '/' ):
+            for element in subdir.split('/'):
 
                 try:
-                    folder = folder._getOb( element )
+                    folder = folder._getOb(element)
                 except AttributeError:
-                    folder._setObject( element, Folder( element ) )
-                    folder = folder._getOb( element )
+                    folder._setObject(element, Folder(element))
+                    folder = folder._getOb(element)
 
-        file = File( filename, '', contents, content_type )
-        folder._setObject( filename, file )
+        file = File(filename, '', contents, content_type)
+        folder._setObject(filename, file)
 
         if mod_time is not None:
             mod_time = DateTime(mod_time).timeTime()
             folder._faux_mod_time = file._faux_mod_time = mod_time
 
-        return folder._getOb( filename )
+        return folder._getOb(filename)
 
-    def test_getLogger( self ):
+    def test_getLogger(self):
 
         SNAPSHOT_ID = 'note'
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
 
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
         logger = ctx.getLogger('foo')
         logger.info('bar')
 
-        self.assertEqual( len( ctx.listNotes() ), 1 )
+        self.assertEqual(len(ctx.listNotes()), 1)
         level, component, message = ctx.listNotes()[0]
-        self.assertEqual( level, logging.INFO )
-        self.assertEqual( component, 'foo' )
-        self.assertEqual( message, 'bar' )
+        self.assertEqual(level, logging.INFO)
+        self.assertEqual(component, 'foo')
+        self.assertEqual(message, 'bar')
 
         ctx.clearNotes()
-        self.assertEqual( len( ctx.listNotes() ), 0 )
+        self.assertEqual(len(ctx.listNotes()), 0)
 
-    def test_ctorparms( self ):
+    def test_ctorparms(self):
 
         SNAPSHOT_ID = 'ctorparms'
         ENCODING = 'latin-1'
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID
-                                       , encoding=ENCODING
-                                       , should_purge=True
-                                       )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID, encoding=ENCODING, should_purge=True
+                                        )
 
-        self.assertEqual( ctx.getEncoding(), ENCODING )
-        self.assertEqual( ctx.shouldPurge(), True )
+        self.assertEqual(ctx.getEncoding(), ENCODING)
+        self.assertEqual(ctx.shouldPurge(), True)
 
-    def test_empty( self ):
+    def test_empty(self):
 
         SNAPSHOT_ID = 'empty'
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
 
-        self.assertEqual( ctx.getSite(), site )
-        self.assertEqual( ctx.getEncoding(), None )
-        self.assertEqual( ctx.shouldPurge(), False )
+        self.assertEqual(ctx.getSite(), site)
+        self.assertEqual(ctx.getEncoding(), None)
+        self.assertEqual(ctx.shouldPurge(), False)
 
         # These methods are all specified to return 'None' for non-existing
         # paths / entities
-        self.assertEqual( ctx.isDirectory( 'nonesuch/path' ), None )
-        self.assertEqual( ctx.listDirectory( 'nonesuch/path' ), None )
+        self.assertEqual(ctx.isDirectory('nonesuch/path'), None)
+        self.assertEqual(ctx.listDirectory('nonesuch/path'), None)
 
-    def test_readDataFile_nonesuch( self ):
+    def test_readDataFile_nonesuch(self):
 
         SNAPSHOT_ID = 'readDataFile_nonesuch'
         FILENAME = 'nonesuch.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
 
-        self.assertEqual( ctx.readDataFile( FILENAME ), None )
-        self.assertEqual( ctx.readDataFile( FILENAME, 'subdir' ), None )
+        self.assertEqual(ctx.readDataFile(FILENAME), None)
+        self.assertEqual(ctx.readDataFile(FILENAME, 'subdir'), None)
 
-    def test_readDataFile_simple( self ):
+    def test_readDataFile_simple(self):
 
         from string import printable
 
         SNAPSHOT_ID = 'readDataFile_simple'
         FILENAME = 'simple.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable)
 
-        self.assertEqual( ctx.readDataFile( FILENAME ), printable )
+        self.assertEqual(ctx.readDataFile(FILENAME), printable)
 
-    def test_readDataFile_Pdata( self ):
+    def test_readDataFile_Pdata(self):
 
         from string import printable
         from OFS.Image import Pdata
@@ -1196,12 +1178,12 @@ class SnapshotImportContextTests(ZopeTestCase, ConformsToISetupContext,
         SNAPSHOT_ID = 'readDataFile_Pdata'
         FILENAME = 'pdata.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, Pdata(printable) )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, Pdata(printable))
 
-        self.assertEqual( ctx.readDataFile( FILENAME ), printable )
+        self.assertEqual(ctx.readDataFile(FILENAME), printable)
 
-    def test_readDataFile_subdir( self ):
+    def test_readDataFile_subdir(self):
 
         from string import printable
 
@@ -1209,13 +1191,12 @@ class SnapshotImportContextTests(ZopeTestCase, ConformsToISetupContext,
         FILENAME = 'subdir.txt'
         SUBDIR = 'subdir'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable
-                      , subdir=SUBDIR )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable, subdir=SUBDIR)
 
-        self.assertEqual( ctx.readDataFile( FILENAME, SUBDIR ), printable )
-        self.assertEqual( ctx.readDataFile( '%s/%s' % (SUBDIR, FILENAME) ),
-                                            printable )
+        self.assertEqual(ctx.readDataFile(FILENAME, SUBDIR), printable)
+        self.assertEqual(ctx.readDataFile('%s/%s' % (SUBDIR, FILENAME)),
+                         printable)
 
     def test_getLastModified_nonesuch(self):
         FILENAME = 'nonesuch.txt'
@@ -1268,43 +1249,42 @@ class SnapshotImportContextTests(ZopeTestCase, ConformsToISetupContext,
         self.assertTrue(isinstance(lm, DateTime))
         self.assertEqual(lm, DateTime(WHEN))
 
-    def test_isDirectory_nonesuch( self ):
+    def test_isDirectory_nonesuch(self):
 
         SNAPSHOT_ID = 'isDirectory_nonesuch'
         FILENAME = 'nonesuch.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
 
-        self.assertEqual( ctx.isDirectory( FILENAME ), None )
+        self.assertEqual(ctx.isDirectory(FILENAME), None)
 
-    def test_isDirectory_simple( self ):
+    def test_isDirectory_simple(self):
 
         from string import printable
 
         SNAPSHOT_ID = 'isDirectory_simple'
         FILENAME = 'simple.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable)
 
-        self.assertEqual( ctx.isDirectory( FILENAME ), False )
+        self.assertEqual(ctx.isDirectory(FILENAME), False)
 
-    def test_isDirectory_nested( self ):
+    def test_isDirectory_nested(self):
 
         from string import printable
 
         SNAPSHOT_ID = 'isDirectory_nested'
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
-        PATH = '%s/%s' % ( SUBDIR, FILENAME )
+        PATH = '%s/%s' % (SUBDIR, FILENAME)
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable
-                             , subdir=SUBDIR )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable, subdir=SUBDIR)
 
-        self.assertEqual( ctx.isDirectory( PATH ), False )
+        self.assertEqual(ctx.isDirectory(PATH), False)
 
-    def test_isDirectory_subdir( self ):
+    def test_isDirectory_subdir(self):
 
         from string import printable
 
@@ -1312,78 +1292,75 @@ class SnapshotImportContextTests(ZopeTestCase, ConformsToISetupContext,
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable
-                             , subdir=SUBDIR )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable, subdir=SUBDIR)
 
-        self.assertEqual( ctx.isDirectory( SUBDIR ), True )
+        self.assertEqual(ctx.isDirectory(SUBDIR), True)
 
-    def test_listDirectory_nonesuch( self ):
+    def test_listDirectory_nonesuch(self):
 
         SNAPSHOT_ID = 'listDirectory_nonesuch'
         SUBDIR = 'nonesuch/path'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
 
-        self.assertEqual( ctx.listDirectory( SUBDIR ), None )
+        self.assertEqual(ctx.listDirectory(SUBDIR), None)
 
-    def test_listDirectory_root( self ):
+    def test_listDirectory_root(self):
 
         from string import printable
 
         SNAPSHOT_ID = 'listDirectory_root'
         FILENAME = 'simple.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable)
 
-        self.assertEqual( len( ctx.listDirectory( None ) ), 1 )
-        self.failUnless( FILENAME in ctx.listDirectory( None ) )
+        self.assertEqual(len(ctx.listDirectory(None)), 1)
+        self.failUnless(FILENAME in ctx.listDirectory(None))
 
-    def test_listDirectory_simple( self ):
+    def test_listDirectory_simple(self):
 
         from string import printable
 
         SNAPSHOT_ID = 'listDirectory_simple'
         FILENAME = 'simple.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable)
 
-        self.assertEqual( ctx.listDirectory( FILENAME ), None )
+        self.assertEqual(ctx.listDirectory(FILENAME), None)
 
-    def test_listDirectory_nested( self ):
-
-        from string import printable
-
-        SNAPSHOT_ID = 'listDirectory_nested'
-        SUBDIR = 'subdir'
-        FILENAME = 'nested.txt'
-        PATH = '%s/%s' % ( SUBDIR, FILENAME )
-
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable
-                             , subdir=SUBDIR )
-
-        self.assertEqual( ctx.listDirectory( PATH ), None )
-
-    def test_listDirectory_single( self ):
+    def test_listDirectory_nested(self):
 
         from string import printable
 
         SNAPSHOT_ID = 'listDirectory_nested'
         SUBDIR = 'subdir'
         FILENAME = 'nested.txt'
+        PATH = '%s/%s' % (SUBDIR, FILENAME)
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME, printable
-                             , subdir=SUBDIR )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable, subdir=SUBDIR)
 
-        names = ctx.listDirectory( SUBDIR )
-        self.assertEqual( len( names ), 1 )
-        self.failUnless( FILENAME in names )
+        self.assertEqual(ctx.listDirectory(PATH), None)
 
-    def test_listDirectory_multiple( self ):
+    def test_listDirectory_single(self):
+
+        from string import printable
+
+        SNAPSHOT_ID = 'listDirectory_nested'
+        SUBDIR = 'subdir'
+        FILENAME = 'nested.txt'
+
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME, printable, subdir=SUBDIR)
+
+        names = ctx.listDirectory(SUBDIR)
+        self.assertEqual(len(names), 1)
+        self.failUnless(FILENAME in names)
+
+    def test_listDirectory_multiple(self):
 
         from string import printable, uppercase
 
@@ -1392,18 +1369,16 @@ class SnapshotImportContextTests(ZopeTestCase, ConformsToISetupContext,
         FILENAME1 = 'nested.txt'
         FILENAME2 = 'another.txt'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME1, printable
-                              , subdir=SUBDIR )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME2, uppercase
-                              , subdir=SUBDIR )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME1, printable, subdir=SUBDIR)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME2, uppercase, subdir=SUBDIR)
 
-        names = ctx.listDirectory( SUBDIR )
-        self.assertEqual( len( names ), 2 )
-        self.failUnless( FILENAME1 in names )
-        self.failUnless( FILENAME2 in names )
+        names = ctx.listDirectory(SUBDIR)
+        self.assertEqual(len(names), 2)
+        self.failUnless(FILENAME1 in names)
+        self.failUnless(FILENAME2 in names)
 
-    def test_listDirectory_skip( self ):
+    def test_listDirectory_skip(self):
 
         from string import printable, uppercase
 
@@ -1413,28 +1388,25 @@ class SnapshotImportContextTests(ZopeTestCase, ConformsToISetupContext,
         FILENAME2 = 'another.txt'
         FILENAME3 = 'another.bak'
 
-        site, tool, ctx = self._makeOne( SNAPSHOT_ID )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME1, printable
-                              , subdir=SUBDIR )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME2, uppercase
-                              , subdir=SUBDIR )
-        self._makeFile( tool, SNAPSHOT_ID, FILENAME3, 'abc'
-                              , subdir=SUBDIR )
+        site, tool, ctx = self._makeOne(SNAPSHOT_ID)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME1, printable, subdir=SUBDIR)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME2, uppercase, subdir=SUBDIR)
+        self._makeFile(tool, SNAPSHOT_ID, FILENAME3, 'abc', subdir=SUBDIR)
 
         names = ctx.listDirectory(SUBDIR, skip=(FILENAME1,),
                                   skip_suffixes=('.bak',))
-        self.assertEqual( len( names ), 1 )
-        self.failIf( FILENAME1 in names )
-        self.failUnless( FILENAME2 in names )
-        self.failIf( FILENAME3 in names )
+        self.assertEqual(len(names), 1)
+        self.failIf(FILENAME1 in names)
+        self.failUnless(FILENAME2 in names)
+        self.failIf(FILENAME3 in names)
 
 
 def test_suite():
     return unittest.TestSuite((
-        unittest.makeSuite( DirectoryImportContextTests ),
-        unittest.makeSuite( DirectoryExportContextTests ),
-        unittest.makeSuite( TarballImportContextTests ),
-        unittest.makeSuite( TarballExportContextTests ),
-        unittest.makeSuite( SnapshotExportContextTests ),
-        unittest.makeSuite( SnapshotImportContextTests ),
-        ))
+        unittest.makeSuite(DirectoryImportContextTests),
+        unittest.makeSuite(DirectoryExportContextTests),
+        unittest.makeSuite(TarballImportContextTests),
+        unittest.makeSuite(TarballExportContextTests),
+        unittest.makeSuite(SnapshotExportContextTests),
+        unittest.makeSuite(SnapshotImportContextTests),
+    ))

--- a/Products/GenericSetup/tests/test_differ.py
+++ b/Products/GenericSetup/tests/test_differ.py
@@ -24,61 +24,59 @@ from OFS.Image import File
 PYTHON27 = sys.version_info[:2] >= (2, 7)
 
 
-class DummySite( Folder ):
+class DummySite(Folder):
 
     pass
 
 
-class Test_unidiff( unittest.TestCase ):
+class Test_unidiff(unittest.TestCase):
 
-    def test_unidiff_both_text( self ):
-
-        from Products.GenericSetup.differ import unidiff
-
-        diff_lines = unidiff( ONE_FOUR, ZERO_FOUR )
-        diff_text = '\n'.join( diff_lines )
-        if PYTHON27:
-            self.assertEqual( diff_text, DIFF_TEXT_27 )
-        else:
-            self.assertEqual( diff_text, DIFF_TEXT )
-
-    def test_unidiff_both_lines( self ):
+    def test_unidiff_both_text(self):
 
         from Products.GenericSetup.differ import unidiff
 
-        diff_lines = unidiff( ONE_FOUR.splitlines(), ZERO_FOUR.splitlines() )
-        diff_text = '\n'.join( diff_lines )
+        diff_lines = unidiff(ONE_FOUR, ZERO_FOUR)
+        diff_text = '\n'.join(diff_lines)
         if PYTHON27:
-            self.assertEqual( diff_text, DIFF_TEXT_27 )
+            self.assertEqual(diff_text, DIFF_TEXT_27)
         else:
-            self.assertEqual( diff_text, DIFF_TEXT )
+            self.assertEqual(diff_text, DIFF_TEXT)
 
-    def test_unidiff_mixed( self ):
+    def test_unidiff_both_lines(self):
 
         from Products.GenericSetup.differ import unidiff
 
-        diff_lines = unidiff( ONE_FOUR, ZERO_FOUR.splitlines() )
-        diff_text = '\n'.join( diff_lines )
+        diff_lines = unidiff(ONE_FOUR.splitlines(), ZERO_FOUR.splitlines())
+        diff_text = '\n'.join(diff_lines)
         if PYTHON27:
-            self.assertEqual( diff_text, DIFF_TEXT_27 )
+            self.assertEqual(diff_text, DIFF_TEXT_27)
         else:
-            self.assertEqual( diff_text, DIFF_TEXT )
+            self.assertEqual(diff_text, DIFF_TEXT)
 
-    def test_unidiff_ignore_blanks( self ):
+    def test_unidiff_mixed(self):
 
         from Products.GenericSetup.differ import unidiff
 
-        double_spaced = ONE_FOUR.replace( '\n', '\n\n' )
-        diff_lines = unidiff( double_spaced
-                            , ZERO_FOUR.splitlines()
-                            , ignore_blanks=True
-                            )
-
-        diff_text = '\n'.join( diff_lines )
+        diff_lines = unidiff(ONE_FOUR, ZERO_FOUR.splitlines())
+        diff_text = '\n'.join(diff_lines)
         if PYTHON27:
-            self.assertEqual( diff_text, DIFF_TEXT_27 )
+            self.assertEqual(diff_text, DIFF_TEXT_27)
         else:
-            self.assertEqual( diff_text, DIFF_TEXT )
+            self.assertEqual(diff_text, DIFF_TEXT)
+
+    def test_unidiff_ignore_blanks(self):
+
+        from Products.GenericSetup.differ import unidiff
+
+        double_spaced = ONE_FOUR.replace('\n', '\n\n')
+        diff_lines = unidiff(double_spaced, ZERO_FOUR.splitlines(), ignore_blanks=True
+                             )
+
+        diff_text = '\n'.join(diff_lines)
+        if PYTHON27:
+            self.assertEqual(diff_text, DIFF_TEXT_27)
+        else:
+            self.assertEqual(diff_text, DIFF_TEXT)
 
 ZERO_FOUR = """\
 zero
@@ -124,264 +122,258 @@ class ConfigDiffTests(ZopeTestCase):
     site = None
     tool = None
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.differ import ConfigDiff
         return ConfigDiff
 
-    def _makeOne( self, lhs, rhs, *args, **kw ):
+    def _makeOne(self, lhs, rhs, *args, **kw):
 
-        return self._getTargetClass()( lhs, rhs, *args, **kw )
+        return self._getTargetClass()(lhs, rhs, *args, **kw)
 
-    def _makeSite( self ):
+    def _makeSite(self):
 
         if self.site is not None:
             return
 
         site = self.site = DummySite('site').__of__(self.app)
-        site._setObject( 'setup_tool', Folder( 'setup_tool' ) )
-        self.tool = tool = site._getOb( 'setup_tool' )
+        site._setObject('setup_tool', Folder('setup_tool'))
+        self.tool = tool = site._getOb('setup_tool')
 
-        tool._setObject( 'snapshots', Folder( 'snapshots' ) )
+        tool._setObject('snapshots', Folder('snapshots'))
 
-    def _makeContext( self, context_id ):
+    def _makeContext(self, context_id):
 
         from Products.GenericSetup.context import SnapshotImportContext
 
         self._makeSite()
 
         if context_id not in self.tool.snapshots.objectIds():
-            self.tool.snapshots._setObject( context_id, Folder( context_id ) )
+            self.tool.snapshots._setObject(context_id, Folder(context_id))
 
-        ctx = SnapshotImportContext( self.tool, context_id )
+        ctx = SnapshotImportContext(self.tool, context_id)
 
-        return ctx.__of__( self.tool )
+        return ctx.__of__(self.tool)
 
-    def _makeDirectory( self, snapshot_id, subdir ):
+    def _makeDirectory(self, snapshot_id, subdir):
 
         self._makeSite()
-        folder = self.tool.snapshots._getOb( snapshot_id )
+        folder = self.tool.snapshots._getOb(snapshot_id)
 
-        for element in subdir.split( '/' ):
+        for element in subdir.split('/'):
 
             try:
-                folder = folder._getOb( element )
+                folder = folder._getOb(element)
             except AttributeError:
-                folder._setObject( element, Folder( element ) )
-                folder = folder._getOb( element )
+                folder._setObject(element, Folder(element))
+                folder = folder._getOb(element)
 
         return folder
 
-    def _makeFile( self
-                 , snapshot_id
-                 , filename
-                 , contents
-                 , content_type='text/plain'
-                 , mod_time=None
-                 , subdir=None
-                 ):
+    def _makeFile(self, snapshot_id, filename, contents, content_type='text/plain', mod_time=None, subdir=None
+                  ):
 
         self._makeSite()
         snapshots = self.tool.snapshots
-        snapshot = snapshots._getOb( snapshot_id )
+        snapshot = snapshots._getOb(snapshot_id)
 
         if subdir is not None:
-            folder = self._makeDirectory( snapshot_id, subdir )
+            folder = self._makeDirectory(snapshot_id, subdir)
         else:
             folder = snapshot
 
-        file = File( filename, '', contents, content_type )
-        folder._setObject( filename, file )
+        file = File(filename, '', contents, content_type)
+        folder._setObject(filename, file)
 
         if mod_time is not None:
             folder._faux_mod_time = file._faux_mod_time = mod_time
 
-        return folder._getOb( filename )
+        return folder._getOb(filename)
 
-    def test_compare_empties( self ):
+    def test_compare_empties(self):
 
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
 
-        cd = self._makeOne( lhs, rhs )
-
-        diffs = cd.compare()
-
-        self.assertEqual( diffs, '' )
-
-    def test_compare_identical( self ):
-
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
-
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF' )
-        self._makeFile( 'lhs', 'again.txt', 'GHIJKL', subdir='sub' )
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF' )
-        self._makeFile( 'rhs', 'again.txt', 'GHIJKL', subdir='sub' )
-
-        cd = self._makeOne( lhs, rhs )
+        cd = self._makeOne(lhs, rhs)
 
         diffs = cd.compare()
 
-        self.assertEqual( diffs, '' )
+        self.assertEqual(diffs, '')
 
-    def test_compare_changed_file( self ):
+    def test_compare_identical(self):
 
-        BEFORE = DateTime( '2004-01-01T00:00:00Z' )
-        AFTER = DateTime( '2004-02-29T23:59:59Z' )
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
 
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
+        self._makeFile('lhs', 'test.txt', 'ABCDEF')
+        self._makeFile('lhs', 'again.txt', 'GHIJKL', subdir='sub')
+        self._makeFile('rhs', 'test.txt', 'ABCDEF')
+        self._makeFile('rhs', 'again.txt', 'GHIJKL', subdir='sub')
 
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF\nWXYZ', mod_time=BEFORE )
-        self._makeFile( 'lhs', 'again.txt', 'GHIJKL', subdir='sub' )
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF\nQRST', mod_time=AFTER )
-        self._makeFile( 'rhs', 'again.txt', 'GHIJKL', subdir='sub' )
-
-        cd = self._makeOne( lhs, rhs )
+        cd = self._makeOne(lhs, rhs)
 
         diffs = cd.compare()
 
-        if PYTHON27:
-            self.assertEqual( diffs, TEST_TXT_DIFFS_27 % ( BEFORE, AFTER ) )
-        else:
-            self.assertEqual( diffs, TEST_TXT_DIFFS % ( BEFORE, AFTER ) )
+        self.assertEqual(diffs, '')
 
-    def test_compare_changed_file_ignore_blanks( self ):
+    def test_compare_changed_file(self):
 
-        BEFORE = DateTime( '2004-01-01T00:00:00Z' )
-        AFTER = DateTime( '2004-02-29T23:59:59Z' )
+        BEFORE = DateTime('2004-01-01T00:00:00Z')
+        AFTER = DateTime('2004-02-29T23:59:59Z')
 
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
 
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF\nWXYZ', mod_time=BEFORE )
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF\n\n\nWXYZ', mod_time=AFTER )
+        self._makeFile('lhs', 'test.txt', 'ABCDEF\nWXYZ', mod_time=BEFORE)
+        self._makeFile('lhs', 'again.txt', 'GHIJKL', subdir='sub')
+        self._makeFile('rhs', 'test.txt', 'ABCDEF\nQRST', mod_time=AFTER)
+        self._makeFile('rhs', 'again.txt', 'GHIJKL', subdir='sub')
 
-        cd = self._makeOne( lhs, rhs, ignore_blanks=True )
-
-        diffs = cd.compare()
-
-        self.assertEqual( diffs, '' )
-
-    def test_compare_changed_file_explicit_skip( self ):
-
-        BEFORE = DateTime( '2004-01-01T00:00:00Z' )
-        AFTER = DateTime( '2004-02-29T23:59:59Z' )
-
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
-
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF\nWXYZ', subdir='skipme'
-                      , mod_time=BEFORE )
-        self._makeFile( 'lhs', 'again.txt', 'GHIJKL', subdir='sub' )
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF\nQRST', subdir='skipme'
-                      , mod_time=AFTER )
-        self._makeFile( 'rhs', 'again.txt', 'GHIJKL', subdir='sub' )
-
-        cd = self._makeOne( lhs, rhs, skip=[ 'skipme' ] )
-
-        diffs = cd.compare()
-
-        self.assertEqual( diffs, '' )
-
-    def test_compare_changed_file_implicit_skip( self ):
-
-        BEFORE = DateTime( '2004-01-01T00:00:00Z' )
-        AFTER = DateTime( '2004-02-29T23:59:59Z' )
-
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
-
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF\nWXYZ', subdir='CVS'
-                      , mod_time=BEFORE )
-        self._makeFile( 'lhs', 'again.txt', 'GHIJKL', subdir='.svn'
-                      , mod_time=BEFORE )
-
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF\nQRST', subdir='CVS'
-                      , mod_time=AFTER )
-        self._makeFile( 'rhs', 'again.txt', 'MNOPQR', subdir='.svn'
-                      , mod_time=AFTER )
-
-        cd = self._makeOne( lhs, rhs )
-
-        diffs = cd.compare()
-
-        self.assertEqual( diffs, '' )
-
-    def test_compare_added_file_no_missing_as_empty( self ):
-
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
-
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF\nWXYZ' )
-        self._makeDirectory( 'lhs', subdir='sub' )
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF\nWXYZ' )
-        self._makeFile( 'rhs', 'again.txt', 'GHIJKL', subdir='sub' )
-
-        cd = self._makeOne( lhs, rhs )
-
-        diffs = cd.compare()
-
-        self.assertEqual( diffs, ADDED_FILE_DIFFS_NO_MAE )
-
-    def test_compare_added_file_missing_as_empty( self ):
-
-        AFTER = DateTime( '2004-02-29T23:59:59Z' )
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
-
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF\nWXYZ' )
-        self._makeDirectory( 'lhs', subdir='sub' )
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF\nWXYZ' )
-        self._makeFile( 'rhs', 'again.txt', 'GHIJKL', subdir='sub'
-                      , mod_time=AFTER )
-
-        cd = self._makeOne( lhs, rhs, missing_as_empty=True )
+        cd = self._makeOne(lhs, rhs)
 
         diffs = cd.compare()
 
         if PYTHON27:
-            self.assertEqual( diffs, ADDED_FILE_DIFFS_MAE_27 % AFTER )
+            self.assertEqual(diffs, TEST_TXT_DIFFS_27 % (BEFORE, AFTER))
         else:
-            self.assertEqual( diffs, ADDED_FILE_DIFFS_MAE % AFTER )
+            self.assertEqual(diffs, TEST_TXT_DIFFS % (BEFORE, AFTER))
 
-    def test_compare_removed_file_no_missing_as_empty( self ):
+    def test_compare_changed_file_ignore_blanks(self):
 
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
+        BEFORE = DateTime('2004-01-01T00:00:00Z')
+        AFTER = DateTime('2004-02-29T23:59:59Z')
 
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF\nWXYZ' )
-        self._makeFile( 'lhs', 'again.txt', 'GHIJKL', subdir='sub' )
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF\nWXYZ' )
-        self._makeDirectory( 'rhs', subdir='sub' )
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
 
-        cd = self._makeOne( lhs, rhs )
+        self._makeFile('lhs', 'test.txt', 'ABCDEF\nWXYZ', mod_time=BEFORE)
+        self._makeFile('rhs', 'test.txt', 'ABCDEF\n\n\nWXYZ', mod_time=AFTER)
+
+        cd = self._makeOne(lhs, rhs, ignore_blanks=True)
 
         diffs = cd.compare()
 
-        self.assertEqual( diffs, REMOVED_FILE_DIFFS_NO_MAE )
+        self.assertEqual(diffs, '')
 
-    def test_compare_removed_file_missing_as_empty( self ):
+    def test_compare_changed_file_explicit_skip(self):
 
-        BEFORE = DateTime( '2004-01-01T00:00:00Z' )
-        lhs = self._makeContext( 'lhs' )
-        rhs = self._makeContext( 'rhs' )
+        BEFORE = DateTime('2004-01-01T00:00:00Z')
+        AFTER = DateTime('2004-02-29T23:59:59Z')
 
-        self._makeFile( 'lhs', 'test.txt', 'ABCDEF\nWXYZ' )
-        self._makeFile( 'lhs', 'again.txt', 'GHIJKL', subdir='sub'
-                      , mod_time=BEFORE )
-        self._makeFile( 'rhs', 'test.txt', 'ABCDEF\nWXYZ' )
-        self._makeDirectory( 'rhs', subdir='sub' )
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
 
-        cd = self._makeOne( lhs, rhs, missing_as_empty=True )
+        self._makeFile('lhs', 'test.txt', 'ABCDEF\nWXYZ',
+                       subdir='skipme', mod_time=BEFORE)
+        self._makeFile('lhs', 'again.txt', 'GHIJKL', subdir='sub')
+        self._makeFile('rhs', 'test.txt', 'ABCDEF\nQRST',
+                       subdir='skipme', mod_time=AFTER)
+        self._makeFile('rhs', 'again.txt', 'GHIJKL', subdir='sub')
+
+        cd = self._makeOne(lhs, rhs, skip=['skipme'])
+
+        diffs = cd.compare()
+
+        self.assertEqual(diffs, '')
+
+    def test_compare_changed_file_implicit_skip(self):
+
+        BEFORE = DateTime('2004-01-01T00:00:00Z')
+        AFTER = DateTime('2004-02-29T23:59:59Z')
+
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
+
+        self._makeFile('lhs', 'test.txt', 'ABCDEF\nWXYZ',
+                       subdir='CVS', mod_time=BEFORE)
+        self._makeFile('lhs', 'again.txt', 'GHIJKL',
+                       subdir='.svn', mod_time=BEFORE)
+
+        self._makeFile('rhs', 'test.txt', 'ABCDEF\nQRST',
+                       subdir='CVS', mod_time=AFTER)
+        self._makeFile('rhs', 'again.txt', 'MNOPQR',
+                       subdir='.svn', mod_time=AFTER)
+
+        cd = self._makeOne(lhs, rhs)
+
+        diffs = cd.compare()
+
+        self.assertEqual(diffs, '')
+
+    def test_compare_added_file_no_missing_as_empty(self):
+
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
+
+        self._makeFile('lhs', 'test.txt', 'ABCDEF\nWXYZ')
+        self._makeDirectory('lhs', subdir='sub')
+        self._makeFile('rhs', 'test.txt', 'ABCDEF\nWXYZ')
+        self._makeFile('rhs', 'again.txt', 'GHIJKL', subdir='sub')
+
+        cd = self._makeOne(lhs, rhs)
+
+        diffs = cd.compare()
+
+        self.assertEqual(diffs, ADDED_FILE_DIFFS_NO_MAE)
+
+    def test_compare_added_file_missing_as_empty(self):
+
+        AFTER = DateTime('2004-02-29T23:59:59Z')
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
+
+        self._makeFile('lhs', 'test.txt', 'ABCDEF\nWXYZ')
+        self._makeDirectory('lhs', subdir='sub')
+        self._makeFile('rhs', 'test.txt', 'ABCDEF\nWXYZ')
+        self._makeFile('rhs', 'again.txt', 'GHIJKL',
+                       subdir='sub', mod_time=AFTER)
+
+        cd = self._makeOne(lhs, rhs, missing_as_empty=True)
 
         diffs = cd.compare()
 
         if PYTHON27:
-            self.assertEqual( diffs, REMOVED_FILE_DIFFS_MAE_27 % BEFORE )
+            self.assertEqual(diffs, ADDED_FILE_DIFFS_MAE_27 % AFTER)
         else:
-            self.assertEqual( diffs, REMOVED_FILE_DIFFS_MAE % BEFORE )
+            self.assertEqual(diffs, ADDED_FILE_DIFFS_MAE % AFTER)
+
+    def test_compare_removed_file_no_missing_as_empty(self):
+
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
+
+        self._makeFile('lhs', 'test.txt', 'ABCDEF\nWXYZ')
+        self._makeFile('lhs', 'again.txt', 'GHIJKL', subdir='sub')
+        self._makeFile('rhs', 'test.txt', 'ABCDEF\nWXYZ')
+        self._makeDirectory('rhs', subdir='sub')
+
+        cd = self._makeOne(lhs, rhs)
+
+        diffs = cd.compare()
+
+        self.assertEqual(diffs, REMOVED_FILE_DIFFS_NO_MAE)
+
+    def test_compare_removed_file_missing_as_empty(self):
+
+        BEFORE = DateTime('2004-01-01T00:00:00Z')
+        lhs = self._makeContext('lhs')
+        rhs = self._makeContext('rhs')
+
+        self._makeFile('lhs', 'test.txt', 'ABCDEF\nWXYZ')
+        self._makeFile('lhs', 'again.txt', 'GHIJKL',
+                       subdir='sub', mod_time=BEFORE)
+        self._makeFile('rhs', 'test.txt', 'ABCDEF\nWXYZ')
+        self._makeDirectory('rhs', subdir='sub')
+
+        cd = self._makeOne(lhs, rhs, missing_as_empty=True)
+
+        diffs = cd.compare()
+
+        if PYTHON27:
+            self.assertEqual(diffs, REMOVED_FILE_DIFFS_MAE_27 % BEFORE)
+        else:
+            self.assertEqual(diffs, REMOVED_FILE_DIFFS_MAE % BEFORE)
 
 
 TEST_TXT_DIFFS = """\
@@ -455,4 +447,4 @@ def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(Test_unidiff),
         unittest.makeSuite(ConfigDiffTests),
-        ))
+    ))

--- a/Products/GenericSetup/tests/test_events.py
+++ b/Products/GenericSetup/tests/test_events.py
@@ -5,13 +5,15 @@ from Products.GenericSetup.interfaces import IBeforeProfileImportEvent
 from Products.GenericSetup.events import ProfileImportedEvent
 from Products.GenericSetup.interfaces import IProfileImportedEvent
 
+
 class BaseEventTests:
+
     def testInterface(self):
-        event=self.klass("tool", "profile_id", "steps", "full_import")
+        event = self.klass("tool", "profile_id", "steps", "full_import")
         verifyObject(self.iface, event)
 
     def testNormalConstruction(self):
-        event=self.klass("tool", "profile_id", "steps", "full_import")
+        event = self.klass("tool", "profile_id", "steps", "full_import")
         self.assertEqual(event.tool, "tool")
         self.assertEqual(event.profile_id, "profile_id")
         self.assertEqual(event.steps, "steps")
@@ -41,4 +43,3 @@ def test_suite():
     suite.addTest(unittest.makeSuite(BeforeProfileImportEventTests))
     suite.addTest(unittest.makeSuite(ProfileImportedEventTests))
     return suite
-

--- a/Products/GenericSetup/tests/test_profile_metadata.py
+++ b/Products/GenericSetup/tests/test_profile_metadata.py
@@ -40,7 +40,7 @@ _METADATA_MAP = {
     'description': desc,
     'version': version,
     'dependencies': (dep1, dep2),
-    }
+}
 
 _METADATA_EMPTY_DEPENDENCIES_XML = """<?xml version="1.0"?>
 <metadata>
@@ -54,15 +54,16 @@ _METADATA_MAP_EMPTY_DEPENDENCIES = {
     'description': desc,
     'version': version,
     'dependencies': (),
-    }
+}
 
-class ProfileMetadataTests( ZopeTestCase ):
+
+class ProfileMetadataTests(ZopeTestCase):
 
     installProduct('GenericSetup')
 
     def test_parseXML(self):
-        metadata = ProfileMetadata( '' )
-        parsed = metadata.parseXML( _METADATA_XML )
+        metadata = ProfileMetadata('')
+        parsed = metadata.parseXML(_METADATA_XML)
         self.assertEqual(parsed, _METADATA_MAP)
 
     def test_relativePath(self):
@@ -78,11 +79,12 @@ class ProfileMetadataTests( ZopeTestCase ):
 
     def test_parseXML_empty_dependencies(self):
         # https://bugs.launchpad.net/bugs/255301
-        metadata = ProfileMetadata( '')
+        metadata = ProfileMetadata('')
         parsed = metadata.parseXML(_METADATA_EMPTY_DEPENDENCIES_XML)
         self.assertEqual(parsed, _METADATA_MAP_EMPTY_DEPENDENCIES)
 
+
 def test_suite():
     return unittest.TestSuite((
-        unittest.makeSuite( ProfileMetadataTests ),
-        ))
+        unittest.makeSuite(ProfileMetadataTests),
+    ))

--- a/Products/GenericSetup/tests/test_registry.py
+++ b/Products/GenericSetup/tests/test_registry.py
@@ -31,497 +31,372 @@ from conformance import ConformsToIProfileRegistry
 #==============================================================================
 #   Dummy handlers
 #==============================================================================
-def ONE_FUNC( context ): pass
-def TWO_FUNC( context ): pass
-def THREE_FUNC( context ): pass
-def FOUR_FUNC( context ): pass
-def DOC_FUNC( site ):
+def ONE_FUNC(context): pass
+
+
+def TWO_FUNC(context): pass
+
+
+def THREE_FUNC(context): pass
+
+
+def FOUR_FUNC(context): pass
+
+
+def DOC_FUNC(site):
     """This is the first line.
 
     This is the second line.
     """
 
-ONE_FUNC_NAME = '%s.%s' % ( __name__, ONE_FUNC.__name__ )
-TWO_FUNC_NAME = '%s.%s' % ( __name__, TWO_FUNC.__name__ )
-THREE_FUNC_NAME = '%s.%s' % ( __name__, THREE_FUNC.__name__ )
-FOUR_FUNC_NAME = '%s.%s' % ( __name__, FOUR_FUNC.__name__ )
-DOC_FUNC_NAME = '%s.%s' % ( __name__, DOC_FUNC.__name__ )
+ONE_FUNC_NAME = '%s.%s' % (__name__, ONE_FUNC.__name__)
+TWO_FUNC_NAME = '%s.%s' % (__name__, TWO_FUNC.__name__)
+THREE_FUNC_NAME = '%s.%s' % (__name__, THREE_FUNC.__name__)
+FOUR_FUNC_NAME = '%s.%s' % (__name__, FOUR_FUNC.__name__)
+DOC_FUNC_NAME = '%s.%s' % (__name__, DOC_FUNC.__name__)
 
 #==============================================================================
 #   SSR tests
 #==============================================================================
-class ImportStepRegistryTests( BaseRegistryTests
-                             , ConformsToIStepRegistry
-                             , ConformsToIImportStepRegistry
-                             ):
+
+
+class ImportStepRegistryTests(BaseRegistryTests, ConformsToIStepRegistry, ConformsToIImportStepRegistry
+                              ):
 
     layer = ExportImportZCMLLayer
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.registry import ImportStepRegistry
         return ImportStepRegistry
 
-    def test_empty( self ):
+    def test_empty(self):
 
         registry = self._makeOne()
 
-        self.assertEqual( len( registry.listSteps() ), 0 )
-        self.assertEqual( len( registry.listStepMetadata() ), 0 )
-        self.assertEqual( len( registry.sortSteps() ), 0 )
+        self.assertEqual(len(registry.listSteps()), 0)
+        self.assertEqual(len(registry.listStepMetadata()), 0)
+        self.assertEqual(len(registry.sortSteps()), 0)
 
-    def test_getStep_nonesuch( self ):
+    def test_getStep_nonesuch(self):
 
         registry = self._makeOne()
 
-        self.assertEqual( registry.getStep( 'nonesuch' ), None )
-        self.assertEqual( registry.getStep( 'nonesuch' ), None )
+        self.assertEqual(registry.getStep('nonesuch'), None)
+        self.assertEqual(registry.getStep('nonesuch'), None)
         default = object()
-        self.failUnless( registry.getStepMetadata( 'nonesuch'
-                                                 , default ) is default )
-        self.failUnless( registry.getStep( 'nonesuch', default ) is default )
-        self.failUnless( registry.getStepMetadata( 'nonesuch'
-                                                 , default ) is default )
+        self.failUnless(registry.getStepMetadata(
+            'nonesuch', default) is default)
+        self.failUnless(registry.getStep('nonesuch', default) is default)
+        self.failUnless(registry.getStepMetadata(
+            'nonesuch', default) is default)
 
-    def test_getStep_defaulted( self ):
+    def test_getStep_defaulted(self):
 
         registry = self._makeOne()
         default = object()
 
-        self.failUnless( registry.getStep( 'nonesuch', default ) is default )
-        self.assertEqual( registry.getStepMetadata( 'nonesuch', {} ), {} )
+        self.failUnless(registry.getStep('nonesuch', default) is default)
+        self.assertEqual(registry.getStepMetadata('nonesuch', {}), {})
 
-    def test_registerStep_docstring( self ):
-
-        registry = self._makeOne()
-
-        registry.registerStep( id='docstring'
-                             , version='1'
-                             , handler=DOC_FUNC
-                             , dependencies=()
-                             )
-
-        info = registry.getStepMetadata( 'docstring' )
-        self.assertEqual( info[ 'id' ], 'docstring' )
-        self.assertEqual( info[ 'handler' ], DOC_FUNC_NAME )
-        self.assertEqual( info[ 'dependencies' ], () )
-        self.assertEqual( info[ 'title' ], 'This is the first line.' )
-        self.assertEqual( info[ 'description' ] , 'This is the second line.' )
-
-    def test_registerStep_docstring_override( self ):
+    def test_registerStep_docstring(self):
 
         registry = self._makeOne()
 
-        registry.registerStep( id='docstring'
-                             , version='1'
-                             , handler=DOC_FUNC
-                             , dependencies=()
-                             , title='Title'
-                             )
+        registry.registerStep(id='docstring', version='1', handler=DOC_FUNC, dependencies=()
+                              )
 
-        info = registry.getStepMetadata( 'docstring' )
-        self.assertEqual( info[ 'id' ], 'docstring' )
-        self.assertEqual( info[ 'handler' ], DOC_FUNC_NAME )
-        self.assertEqual( info[ 'dependencies' ], () )
-        self.assertEqual( info[ 'title' ], 'Title' )
-        self.assertEqual( info[ 'description' ] , 'This is the second line.' )
+        info = registry.getStepMetadata('docstring')
+        self.assertEqual(info['id'], 'docstring')
+        self.assertEqual(info['handler'], DOC_FUNC_NAME)
+        self.assertEqual(info['dependencies'], ())
+        self.assertEqual(info['title'], 'This is the first line.')
+        self.assertEqual(info['description'], 'This is the second line.')
 
-    def test_registerStep_single( self ):
+    def test_registerStep_docstring_override(self):
 
         registry = self._makeOne()
 
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'two', 'three' )
-                             , title='One Step'
-                             , description='One small step'
-                             )
+        registry.registerStep(id='docstring', version='1', handler=DOC_FUNC, dependencies=(), title='Title'
+                              )
+
+        info = registry.getStepMetadata('docstring')
+        self.assertEqual(info['id'], 'docstring')
+        self.assertEqual(info['handler'], DOC_FUNC_NAME)
+        self.assertEqual(info['dependencies'], ())
+        self.assertEqual(info['title'], 'Title')
+        self.assertEqual(info['description'], 'This is the second line.')
+
+    def test_registerStep_single(self):
+
+        registry = self._makeOne()
+
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('two', 'three'), title='One Step', description='One small step'
+                              )
 
         steps = registry.listSteps()
-        self.assertEqual( len( steps ), 1 )
-        self.failUnless( 'one' in steps )
-        self.assertEqual( registry.getStep( 'one' ), ONE_FUNC )
+        self.assertEqual(len(steps), 1)
+        self.failUnless('one' in steps)
+        self.assertEqual(registry.getStep('one'), ONE_FUNC)
 
-        info = registry.getStepMetadata( 'one' )
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'version' ], '1' )
-        self.assertEqual( info[ 'handler' ], ONE_FUNC_NAME )
-        self.assertEqual( info[ 'dependencies' ], ( 'two', 'three' ) )
-        self.assertEqual( info[ 'title' ], 'One Step' )
-        self.assertEqual( info[ 'description' ], 'One small step' )
-
-        info_list = registry.listStepMetadata()
-        self.assertEqual( len( info_list ), 1 )
-        self.assertEqual( info, info_list[ 0 ] )
-
-    def test_registerStep_conflict( self ):
-
-        registry = self._makeOne()
-
-        registry.registerStep( id='one', version='1', handler=ONE_FUNC_NAME )
-
-        self.assertRaises( KeyError
-                         , registry.registerStep
-                         , id='one'
-                         , version='0'
-                         , handler=ONE_FUNC
-                         )
-
-        registry.registerStep( id='one', version='1', handler=ONE_FUNC_NAME )
+        info = registry.getStepMetadata('one')
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['version'], '1')
+        self.assertEqual(info['handler'], ONE_FUNC_NAME)
+        self.assertEqual(info['dependencies'], ('two', 'three'))
+        self.assertEqual(info['title'], 'One Step')
+        self.assertEqual(info['description'], 'One small step')
 
         info_list = registry.listStepMetadata()
-        self.assertEqual( len( info_list ), 1 )
+        self.assertEqual(len(info_list), 1)
+        self.assertEqual(info, info_list[0])
 
-    def test_registerStep_replacement( self ):
-
-        registry = self._makeOne()
-
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'two', 'three' )
-                             , title='One Step'
-                             , description='One small step'
-                             )
-
-        registry.registerStep( id='one'
-                             , version='1.1'
-                             , handler=ONE_FUNC
-                             , dependencies=()
-                             , title='Leads to Another'
-                             , description='Another small step'
-                             )
-
-        info = registry.getStepMetadata( 'one' )
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'version' ], '1.1' )
-        self.assertEqual( info[ 'dependencies' ], () )
-        self.assertEqual( info[ 'title' ], 'Leads to Another' )
-        self.assertEqual( info[ 'description' ], 'Another small step' )
-
-    def test_registerStep_multiple( self ):
+    def test_registerStep_conflict(self):
 
         registry = self._makeOne()
 
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=()
-                             )
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC_NAME)
 
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=()
-                             )
+        self.assertRaises(KeyError, registry.registerStep, id='one', version='0', handler=ONE_FUNC
+                          )
 
-        registry.registerStep( id='three'
-                             , version='3'
-                             , handler=THREE_FUNC
-                             , dependencies=()
-                             )
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC_NAME)
+
+        info_list = registry.listStepMetadata()
+        self.assertEqual(len(info_list), 1)
+
+    def test_registerStep_replacement(self):
+
+        registry = self._makeOne()
+
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('two', 'three'), title='One Step', description='One small step'
+                              )
+
+        registry.registerStep(id='one', version='1.1', handler=ONE_FUNC, dependencies=(), title='Leads to Another', description='Another small step'
+                              )
+
+        info = registry.getStepMetadata('one')
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['version'], '1.1')
+        self.assertEqual(info['dependencies'], ())
+        self.assertEqual(info['title'], 'Leads to Another')
+        self.assertEqual(info['description'], 'Another small step')
+
+    def test_registerStep_multiple(self):
+
+        registry = self._makeOne()
+
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=()
+                              )
+
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=()
+                              )
+
+        registry.registerStep(id='three', version='3', handler=THREE_FUNC, dependencies=()
+                              )
 
         steps = registry.listSteps()
-        self.assertEqual( len( steps ), 3 )
-        self.failUnless( 'one' in steps )
-        self.failUnless( 'two' in steps )
-        self.failUnless( 'three' in steps )
+        self.assertEqual(len(steps), 3)
+        self.failUnless('one' in steps)
+        self.failUnless('two' in steps)
+        self.failUnless('three' in steps)
 
-    def test_sortStep_simple( self ):
+    def test_sortStep_simple(self):
 
         registry = self._makeOne()
 
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'two', )
-                             )
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('two', )
+                              )
 
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=()
-                             )
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=()
+                              )
 
         steps = registry.sortSteps()
-        self.assertEqual( len( steps ), 2 )
-        one = steps.index( 'one' )
-        two = steps.index( 'two' )
+        self.assertEqual(len(steps), 2)
+        one = steps.index('one')
+        two = steps.index('two')
 
-        self.failUnless( 0 <= two < one )
+        self.failUnless(0 <= two < one)
 
-    def test_sortStep_chained( self ):
-
-        registry = self._makeOne()
-
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'three', )
-                             , title='One small step'
-                             )
-
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=( 'one', )
-                             , title='Texas two step'
-                             )
-
-        registry.registerStep( id='three'
-                             , version='3'
-                             , handler=THREE_FUNC
-                             , dependencies=()
-                             , title='Gimme three steps'
-                             )
-       
-        steps = registry.sortSteps()
-        self.assertEqual( len( steps ), 3 )
-        one = steps.index( 'one' )
-        two = steps.index( 'two' )
-        three = steps.index( 'three' )
-
-        self.failUnless( 0 <= three < one < two )
-
-
-    def test_sortStep_complex( self ):
+    def test_sortStep_chained(self):
 
         registry = self._makeOne()
 
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'two', )
-                             , title='One small step'
-                             )
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('three', ), title='One small step'
+                              )
 
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=( 'four', )
-                             , title='Texas two step'
-                             )
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=('one', ), title='Texas two step'
+                              )
 
-        registry.registerStep( id='three'
-                             , version='3'
-                             , handler=THREE_FUNC
-                             , dependencies=( 'four', )
-                             , title='Gimme three steps'
-                             )
-
-        registry.registerStep( id='four'
-                             , version='4'
-                             , handler=FOUR_FUNC
-                             , dependencies=()
-                             , title='Four step program'
-                             )
+        registry.registerStep(id='three', version='3', handler=THREE_FUNC, dependencies=(), title='Gimme three steps'
+                              )
 
         steps = registry.sortSteps()
-        self.assertEqual( len( steps ), 4 )
-        one = steps.index( 'one' )
-        two = steps.index( 'two' )
-        three = steps.index( 'three' )
-        four = steps.index( 'four' )
+        self.assertEqual(len(steps), 3)
+        one = steps.index('one')
+        two = steps.index('two')
+        three = steps.index('three')
 
-        self.failUnless( 0 <= four < two < one )
-        self.failUnless( 0 <= four < three )
+        self.failUnless(0 <= three < one < two)
 
-    def test_sortStep_equivalence( self ):
+    def test_sortStep_complex(self):
 
         registry = self._makeOne()
 
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'two', 'three' )
-                             , title='One small step'
-                             )
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('two', ), title='One small step'
+                              )
 
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=( 'four', )
-                             , title='Texas two step'
-                             )
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=('four', ), title='Texas two step'
+                              )
 
-        registry.registerStep( id='three'
-                             , version='3'
-                             , handler=THREE_FUNC
-                             , dependencies=( 'four', )
-                             , title='Gimme three steps'
-                             )
+        registry.registerStep(id='three', version='3', handler=THREE_FUNC, dependencies=('four', ), title='Gimme three steps'
+                              )
 
-        registry.registerStep( id='four'
-                             , version='4'
-                             , handler=FOUR_FUNC
-                             , dependencies=()
-                             , title='Four step program'
-                             )
+        registry.registerStep(id='four', version='4', handler=FOUR_FUNC, dependencies=(), title='Four step program'
+                              )
 
         steps = registry.sortSteps()
-        self.assertEqual( len( steps ), 4 )
-        one = steps.index( 'one' )
-        two = steps.index( 'two' )
-        three = steps.index( 'three' )
-        four = steps.index( 'four' )
+        self.assertEqual(len(steps), 4)
+        one = steps.index('one')
+        two = steps.index('two')
+        three = steps.index('three')
+        four = steps.index('four')
 
-        self.failUnless( 0 <= four < two < one )
-        self.failUnless( 0 <= four < three < one )
+        self.failUnless(0 <= four < two < one)
+        self.failUnless(0 <= four < three)
 
-    def test_checkComplete_simple( self ):
-
-        registry = self._makeOne()
-
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'two', )
-                             )
-
-        incomplete = registry.checkComplete()
-        self.assertEqual( len( incomplete ), 1 )
-        self.failUnless( ( 'one', 'two' ) in incomplete )
-
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=()
-                             )
-
-        self.assertEqual( len( registry.checkComplete() ), 0 )
-
-    def test_checkComplete_double( self ):
+    def test_sortStep_equivalence(self):
 
         registry = self._makeOne()
 
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'two', 'three' )
-                             )
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('two', 'three'), title='One small step'
+                              )
+
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=('four', ), title='Texas two step'
+                              )
+
+        registry.registerStep(id='three', version='3', handler=THREE_FUNC, dependencies=('four', ), title='Gimme three steps'
+                              )
+
+        registry.registerStep(id='four', version='4', handler=FOUR_FUNC, dependencies=(), title='Four step program'
+                              )
+
+        steps = registry.sortSteps()
+        self.assertEqual(len(steps), 4)
+        one = steps.index('one')
+        two = steps.index('two')
+        three = steps.index('three')
+        four = steps.index('four')
+
+        self.failUnless(0 <= four < two < one)
+        self.failUnless(0 <= four < three < one)
+
+    def test_checkComplete_simple(self):
+
+        registry = self._makeOne()
+
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('two', )
+                              )
 
         incomplete = registry.checkComplete()
-        self.assertEqual( len( incomplete ), 2 )
-        self.failUnless( ( 'one', 'two' ) in incomplete )
-        self.failUnless( ( 'one', 'three' ) in incomplete )
+        self.assertEqual(len(incomplete), 1)
+        self.failUnless(('one', 'two') in incomplete)
 
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=()
-                             )
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=()
+                              )
 
-        incomplete = registry.checkComplete()
-        self.assertEqual( len( incomplete ), 1 )
-        self.failUnless( ( 'one', 'three' ) in incomplete )
+        self.assertEqual(len(registry.checkComplete()), 0)
 
-        registry.registerStep( id='three'
-                             , version='3'
-                             , handler=THREE_FUNC
-                             , dependencies=()
-                             )
+    def test_checkComplete_double(self):
 
-        self.assertEqual( len( registry.checkComplete() ), 0 )
+        registry = self._makeOne()
 
-        registry.registerStep( id='two'
-                             , version='2.1'
-                             , handler=TWO_FUNC
-                             , dependencies=( 'four', )
-                             )
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('two', 'three')
+                              )
 
         incomplete = registry.checkComplete()
-        self.assertEqual( len( incomplete ), 1 )
-        self.failUnless( ( 'two', 'four' ) in incomplete )
+        self.assertEqual(len(incomplete), 2)
+        self.failUnless(('one', 'two') in incomplete)
+        self.failUnless(('one', 'three') in incomplete)
 
-    def test_generateXML_empty( self ):
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=()
+                              )
 
-        registry = self._makeOne().__of__(self.app)
+        incomplete = registry.checkComplete()
+        self.assertEqual(len(incomplete), 1)
+        self.failUnless(('one', 'three') in incomplete)
 
-        self._compareDOM( registry.generateXML(), _EMPTY_IMPORT_XML , debug=True)
+        registry.registerStep(id='three', version='3', handler=THREE_FUNC, dependencies=()
+                              )
 
-    def test_generateXML_single( self ):
+        self.assertEqual(len(registry.checkComplete()), 0)
 
-        registry = self._makeOne().__of__(self.app)
+        registry.registerStep(id='two', version='2.1', handler=TWO_FUNC, dependencies=('four', )
+                              )
 
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=()
-                             , title='One Step'
-                             , description='One small step'
-                             )
+        incomplete = registry.checkComplete()
+        self.assertEqual(len(incomplete), 1)
+        self.failUnless(('two', 'four') in incomplete)
 
-        self._compareDOM( registry.generateXML(), _SINGLE_IMPORT_XML )
-
-    def test_generateXML_ordered( self ):
-
-        registry = self._makeOne().__of__(self.app)
-
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=( 'two', )
-                             , title='One Step'
-                             , description='One small step'
-                             )
-
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=( 'three', )
-                             , title='Two Steps'
-                             , description='Texas two step'
-                             )
-
-        registry.registerStep( id='three'
-                             , version='3'
-                             , handler=THREE_FUNC
-                             , dependencies=()
-                             , title='Three Steps'
-                             , description='Gimme three steps'
-                             )
-
-        self._compareDOM( registry.generateXML(), _ORDERED_IMPORT_XML )
-
-    def test_parseXML_empty( self ):
+    def test_generateXML_empty(self):
 
         registry = self._makeOne().__of__(self.app)
 
-        registry.registerStep( id='one'
-                             , version='1'
-                             , handler=ONE_FUNC
-                             , dependencies=()
-                             , description='One small step'
-                             )
+        self._compareDOM(registry.generateXML(), _EMPTY_IMPORT_XML, debug=True)
 
-        info_list = registry.parseXML( _EMPTY_IMPORT_XML )
-
-        self.assertEqual( len( info_list ), 0 )
-
-    def test_parseXML_single( self ):
+    def test_generateXML_single(self):
 
         registry = self._makeOne().__of__(self.app)
 
-        registry.registerStep( id='two'
-                             , version='2'
-                             , handler=TWO_FUNC
-                             , dependencies=()
-                             , title='Two Steps'
-                             , description='Texas two step'
-                             )
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=(), title='One Step', description='One small step'
+                              )
 
-        info_list = registry.parseXML( _SINGLE_IMPORT_XML )
+        self._compareDOM(registry.generateXML(), _SINGLE_IMPORT_XML)
 
-        self.assertEqual( len( info_list ), 1 )
+    def test_generateXML_ordered(self):
 
-        info = info_list[ 0 ]
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'version' ], '1' )
-        self.assertEqual( info[ 'handler' ], ONE_FUNC_NAME )
-        self.assertEqual( info[ 'dependencies' ], () )
-        self.assertEqual( info[ 'title' ], 'One Step' )
-        self.failUnless( 'One small step' in info[ 'description' ] )
+        registry = self._makeOne().__of__(self.app)
+
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=('two', ), title='One Step', description='One small step'
+                              )
+
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=('three', ), title='Two Steps', description='Texas two step'
+                              )
+
+        registry.registerStep(id='three', version='3', handler=THREE_FUNC, dependencies=(), title='Three Steps', description='Gimme three steps'
+                              )
+
+        self._compareDOM(registry.generateXML(), _ORDERED_IMPORT_XML)
+
+    def test_parseXML_empty(self):
+
+        registry = self._makeOne().__of__(self.app)
+
+        registry.registerStep(id='one', version='1', handler=ONE_FUNC, dependencies=(), description='One small step'
+                              )
+
+        info_list = registry.parseXML(_EMPTY_IMPORT_XML)
+
+        self.assertEqual(len(info_list), 0)
+
+    def test_parseXML_single(self):
+
+        registry = self._makeOne().__of__(self.app)
+
+        registry.registerStep(id='two', version='2', handler=TWO_FUNC, dependencies=(), title='Two Steps', description='Texas two step'
+                              )
+
+        info_list = registry.parseXML(_SINGLE_IMPORT_XML)
+
+        self.assertEqual(len(info_list), 1)
+
+        info = info_list[0]
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['version'], '1')
+        self.assertEqual(info['handler'], ONE_FUNC_NAME)
+        self.assertEqual(info['dependencies'], ())
+        self.assertEqual(info['title'], 'One Step')
+        self.failUnless('One small step' in info['description'])
 
 
 _EMPTY_IMPORT_XML = """\
@@ -571,189 +446,168 @@ _ORDERED_IMPORT_XML = """\
 #==============================================================================
 #   ESR tests
 #==============================================================================
-class ExportStepRegistryTests( BaseRegistryTests
-                             , ConformsToIStepRegistry
-                             , ConformsToIExportStepRegistry
-                             ):
+
+
+class ExportStepRegistryTests(BaseRegistryTests, ConformsToIStepRegistry, ConformsToIExportStepRegistry
+                              ):
 
     layer = ExportImportZCMLLayer
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.registry import ExportStepRegistry
         return ExportStepRegistry
 
-    def _makeOne( self, *args, **kw ):
+    def _makeOne(self, *args, **kw):
 
-        return self._getTargetClass()( *args, **kw )
+        return self._getTargetClass()(*args, **kw)
 
-    def test_empty( self ):
-
-        registry = self._makeOne()
-        self.assertEqual( len( registry.listSteps() ), 0 )
-        self.assertEqual( len( registry.listStepMetadata() ), 0 )
-
-    def test_getStep_nonesuch( self ):
+    def test_empty(self):
 
         registry = self._makeOne()
-        self.assertEqual( registry.getStep( 'nonesuch' ), None )
+        self.assertEqual(len(registry.listSteps()), 0)
+        self.assertEqual(len(registry.listStepMetadata()), 0)
 
-    def test_getStep_defaulted( self ):
+    def test_getStep_nonesuch(self):
+
+        registry = self._makeOne()
+        self.assertEqual(registry.getStep('nonesuch'), None)
+
+    def test_getStep_defaulted(self):
 
         registry = self._makeOne()
         default = lambda x: False
-        self.assertEqual( registry.getStep( 'nonesuch', default ), default )
+        self.assertEqual(registry.getStep('nonesuch', default), default)
 
-    def test_getStepMetadata_nonesuch( self ):
-
-        registry = self._makeOne()
-        self.assertEqual( registry.getStepMetadata( 'nonesuch' ), None )
-
-    def test_getStepMetadata_defaulted( self ):
+    def test_getStepMetadata_nonesuch(self):
 
         registry = self._makeOne()
-        self.assertEqual( registry.getStepMetadata( 'nonesuch', {} ), {} )
+        self.assertEqual(registry.getStepMetadata('nonesuch'), None)
 
-    def test_registerStep_simple( self ):
-
-        registry = self._makeOne()
-        registry.registerStep( 'one', ONE_FUNC_NAME )
-        info = registry.getStepMetadata( 'one', {} )
-
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'handler' ], ONE_FUNC_NAME )
-        self.assertEqual( info[ 'title' ], 'one' )
-        self.assertEqual( info[ 'description' ], '' )
-
-    def test_registerStep_docstring( self ):
+    def test_getStepMetadata_defaulted(self):
 
         registry = self._makeOne()
-        registry.registerStep( 'one', DOC_FUNC )
-        info = registry.getStepMetadata( 'one', {} )
+        self.assertEqual(registry.getStepMetadata('nonesuch', {}), {})
 
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'handler' ], DOC_FUNC_NAME )
-        self.assertEqual( info[ 'title' ], 'This is the first line.' )
-        self.assertEqual( info[ 'description' ] , 'This is the second line.' )
-
-    def test_registerStep_docstring_with_override( self ):
+    def test_registerStep_simple(self):
 
         registry = self._makeOne()
-        registry.registerStep( 'one', DOC_FUNC
-                               , description='Description' )
-        info = registry.getStepMetadata( 'one', {} )
+        registry.registerStep('one', ONE_FUNC_NAME)
+        info = registry.getStepMetadata('one', {})
 
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'handler' ], DOC_FUNC_NAME )
-        self.assertEqual( info[ 'title' ], 'This is the first line.' )
-        self.assertEqual( info[ 'description' ], 'Description' )
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['handler'], ONE_FUNC_NAME)
+        self.assertEqual(info['title'], 'one')
+        self.assertEqual(info['description'], '')
 
-    def test_registerStep_collision( self ):
+    def test_registerStep_docstring(self):
 
         registry = self._makeOne()
-        registry.registerStep( 'one', ONE_FUNC )
-        registry.registerStep( 'one', TWO_FUNC )
-        info = registry.getStepMetadata( 'one', {} )
+        registry.registerStep('one', DOC_FUNC)
+        info = registry.getStepMetadata('one', {})
 
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'handler' ], TWO_FUNC_NAME )
-        self.assertEqual( info[ 'title' ], 'one' )
-        self.assertEqual( info[ 'description' ], '' )
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['handler'], DOC_FUNC_NAME)
+        self.assertEqual(info['title'], 'This is the first line.')
+        self.assertEqual(info['description'], 'This is the second line.')
 
-    def test_generateXML_empty( self ):
+    def test_registerStep_docstring_with_override(self):
+
+        registry = self._makeOne()
+        registry.registerStep('one', DOC_FUNC, description='Description')
+        info = registry.getStepMetadata('one', {})
+
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['handler'], DOC_FUNC_NAME)
+        self.assertEqual(info['title'], 'This is the first line.')
+        self.assertEqual(info['description'], 'Description')
+
+    def test_registerStep_collision(self):
+
+        registry = self._makeOne()
+        registry.registerStep('one', ONE_FUNC)
+        registry.registerStep('one', TWO_FUNC)
+        info = registry.getStepMetadata('one', {})
+
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['handler'], TWO_FUNC_NAME)
+        self.assertEqual(info['title'], 'one')
+        self.assertEqual(info['description'], '')
+
+    def test_generateXML_empty(self):
 
         registry = self._makeOne().__of__(self.app)
 
-        self._compareDOM( registry.generateXML(), _EMPTY_EXPORT_XML )
+        self._compareDOM(registry.generateXML(), _EMPTY_EXPORT_XML)
 
-    def test_generateXML_single( self ):
-
-        registry = self._makeOne().__of__(self.app)
-
-        registry.registerStep( id='one'
-                             , handler=ONE_FUNC
-                             , title='One Step'
-                             , description='One small step'
-                             )
-
-        self._compareDOM( registry.generateXML(), _SINGLE_EXPORT_XML )
-
-    def test_generateXML_ordered( self ):
+    def test_generateXML_single(self):
 
         registry = self._makeOne().__of__(self.app)
 
-        registry.registerStep( id='one'
-                             , handler=ONE_FUNC
-                             , title='One Step'
-                             , description='One small step'
-                             )
+        registry.registerStep(id='one', handler=ONE_FUNC, title='One Step', description='One small step'
+                              )
 
-        registry.registerStep( id='two'
-                             , handler=TWO_FUNC
-                             , title='Two Steps'
-                             , description='Texas two step'
-                             )
+        self._compareDOM(registry.generateXML(), _SINGLE_EXPORT_XML)
 
-        registry.registerStep( id='three'
-                             , handler=THREE_FUNC
-                             , title='Three Steps'
-                             , description='Gimme three steps'
-                             )
-
-        self._compareDOM( registry.generateXML(), _ORDERED_EXPORT_XML )
-
-    def test_parseXML_empty( self ):
+    def test_generateXML_ordered(self):
 
         registry = self._makeOne().__of__(self.app)
 
-        registry.registerStep( id='one'
-                             , handler=ONE_FUNC
-                             , description='One small step'
-                             )
+        registry.registerStep(id='one', handler=ONE_FUNC, title='One Step', description='One small step'
+                              )
 
-        info_list = registry.parseXML( _EMPTY_EXPORT_XML )
+        registry.registerStep(id='two', handler=TWO_FUNC, title='Two Steps', description='Texas two step'
+                              )
 
-        self.assertEqual( len( info_list ), 0 )
+        registry.registerStep(id='three', handler=THREE_FUNC, title='Three Steps', description='Gimme three steps'
+                              )
 
-    def test_parseXML_single( self ):
+        self._compareDOM(registry.generateXML(), _ORDERED_EXPORT_XML)
 
-        registry = self._makeOne().__of__(self.app)
-
-        registry.registerStep( id='two'
-                             , handler=TWO_FUNC
-                             , title='Two Steps'
-                             , description='Texas two step'
-                             )
-
-        info_list = registry.parseXML( _SINGLE_EXPORT_XML )
-
-        self.assertEqual( len( info_list ), 1 )
-
-        info = info_list[ 0 ]
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'handler' ], ONE_FUNC_NAME )
-        self.assertEqual( info[ 'title' ], 'One Step' )
-        self.failUnless( 'One small step' in info[ 'description' ] )
-
-    def test_parseXML_single_as_ascii( self ):
+    def test_parseXML_empty(self):
 
         registry = self._makeOne().__of__(self.app)
 
-        registry.registerStep( id='two'
-                             , handler=TWO_FUNC
-                             , title='Two Steps'
-                             , description='Texas two step'
-                             )
+        registry.registerStep(id='one', handler=ONE_FUNC, description='One small step'
+                              )
 
-        info_list = registry.parseXML( _SINGLE_EXPORT_XML, encoding='ascii' )
+        info_list = registry.parseXML(_EMPTY_EXPORT_XML)
 
-        self.assertEqual( len( info_list ), 1 )
+        self.assertEqual(len(info_list), 0)
 
-        info = info_list[ 0 ]
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'handler' ], ONE_FUNC_NAME )
-        self.assertEqual( info[ 'title' ], 'One Step' )
-        self.failUnless( 'One small step' in info[ 'description' ] )
+    def test_parseXML_single(self):
+
+        registry = self._makeOne().__of__(self.app)
+
+        registry.registerStep(id='two', handler=TWO_FUNC, title='Two Steps', description='Texas two step'
+                              )
+
+        info_list = registry.parseXML(_SINGLE_EXPORT_XML)
+
+        self.assertEqual(len(info_list), 1)
+
+        info = info_list[0]
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['handler'], ONE_FUNC_NAME)
+        self.assertEqual(info['title'], 'One Step')
+        self.failUnless('One small step' in info['description'])
+
+    def test_parseXML_single_as_ascii(self):
+
+        registry = self._makeOne().__of__(self.app)
+
+        registry.registerStep(id='two', handler=TWO_FUNC, title='Two Steps', description='Texas two step'
+                              )
+
+        info_list = registry.parseXML(_SINGLE_EXPORT_XML, encoding='ascii')
+
+        self.assertEqual(len(info_list), 1)
+
+        info = info_list[0]
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['handler'], ONE_FUNC_NAME)
+        self.assertEqual(info['title'], 'One Step')
+        self.failUnless('One small step' in info['description'])
 
 
 _EMPTY_EXPORT_XML = """\
@@ -797,179 +651,174 @@ _ORDERED_EXPORT_XML = """\
 #==============================================================================
 #   ToolsetRegistry tests
 #==============================================================================
-class ToolsetRegistryTests( BaseRegistryTests
-                          , ConformsToIToolsetRegistry
-                          ):
+
+
+class ToolsetRegistryTests(BaseRegistryTests, ConformsToIToolsetRegistry
+                           ):
 
     layer = ExportImportZCMLLayer
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.registry import ToolsetRegistry
         return ToolsetRegistry
 
-    def _initSite( self ):
+    def _initSite(self):
 
         self.app.site = Folder(id='site')
         site = self.app.site
 
         return site
 
-    def test_empty( self ):
+    def test_empty(self):
 
         site = self._initSite()
-        configurator = self._makeOne().__of__( site )
+        configurator = self._makeOne().__of__(site)
 
-        self.assertEqual( len( configurator.listForbiddenTools() ), 0 )
-        self.assertEqual( len( configurator.listRequiredTools() ), 0 )
-        self.assertEqual( len( configurator.listRequiredToolInfo() ), 0 )
+        self.assertEqual(len(configurator.listForbiddenTools()), 0)
+        self.assertEqual(len(configurator.listRequiredTools()), 0)
+        self.assertEqual(len(configurator.listRequiredToolInfo()), 0)
 
-        self.assertRaises( KeyError
-                         , configurator.getRequiredToolInfo, 'nonesuch' )
+        self.assertRaises(
+            KeyError, configurator.getRequiredToolInfo, 'nonesuch')
 
-    def test_addForbiddenTool_multiple( self ):
+    def test_addForbiddenTool_multiple(self):
 
-        VERBOTTEN = ( 'foo', 'bar', 'bam' )
+        VERBOTTEN = ('foo', 'bar', 'bam')
 
         site = self._initSite()
-        configurator = self._makeOne().__of__( site )
+        configurator = self._makeOne().__of__(site)
 
         for verbotten in VERBOTTEN:
-            configurator.addForbiddenTool( verbotten )
+            configurator.addForbiddenTool(verbotten)
 
-        self.assertEqual( len( configurator.listForbiddenTools() )
-                        , len( VERBOTTEN ) )
+        self.assertEqual(
+            len(configurator.listForbiddenTools()), len(VERBOTTEN))
 
         for verbotten in configurator.listForbiddenTools():
-            self.failUnless( verbotten in VERBOTTEN )
+            self.failUnless(verbotten in VERBOTTEN)
 
-    def test_addForbiddenTool_duplicate( self ):
-
-        site = self._initSite()
-        configurator = self._makeOne().__of__( site )
-
-        configurator.addForbiddenTool( 'once' )
-        configurator.addForbiddenTool( 'once' )
-
-        self.assertEqual( len( configurator.listForbiddenTools() ), 1 )
-
-    def test_addForbiddenTool_but_required( self ):
+    def test_addForbiddenTool_duplicate(self):
 
         site = self._initSite()
-        configurator = self._makeOne().__of__( site )
+        configurator = self._makeOne().__of__(site)
 
-        configurator.addRequiredTool( 'required', 'some.dotted.name' )
+        configurator.addForbiddenTool('once')
+        configurator.addForbiddenTool('once')
 
-        self.assertRaises( ValueError
-                         , configurator.addForbiddenTool, 'required' )
+        self.assertEqual(len(configurator.listForbiddenTools()), 1)
 
-    def test_addRequiredTool_multiple( self ):
-
-        REQUIRED = ( ( 'one', 'path.to.one' )
-                   , ( 'two', 'path.to.two' )
-                   , ( 'three', 'path.to.three' )
-                   )
+    def test_addForbiddenTool_but_required(self):
 
         site = self._initSite()
-        configurator = self._makeOne().__of__( site )
+        configurator = self._makeOne().__of__(site)
+
+        configurator.addRequiredTool('required', 'some.dotted.name')
+
+        self.assertRaises(
+            ValueError, configurator.addForbiddenTool, 'required')
+
+    def test_addRequiredTool_multiple(self):
+
+        REQUIRED = (('one', 'path.to.one'), ('two', 'path.to.two'), ('three', 'path.to.three')
+                    )
+
+        site = self._initSite()
+        configurator = self._makeOne().__of__(site)
 
         for tool_id, dotted_name in REQUIRED:
-            configurator.addRequiredTool( tool_id, dotted_name )
+            configurator.addRequiredTool(tool_id, dotted_name)
 
-        self.assertEqual( len( configurator.listRequiredTools() )
-                        , len( REQUIRED ) )
+        self.assertEqual(len(configurator.listRequiredTools()), len(REQUIRED))
 
-        for id in [ x[0] for x in REQUIRED ]:
-            self.failUnless( id in configurator.listRequiredTools() )
+        for id in [x[0] for x in REQUIRED]:
+            self.failUnless(id in configurator.listRequiredTools())
 
-        self.assertEqual( len( configurator.listRequiredToolInfo() )
-                        , len( REQUIRED ) )
+        self.assertEqual(
+            len(configurator.listRequiredToolInfo()), len(REQUIRED))
 
         for tool_id, dotted_name in REQUIRED:
-            info = configurator.getRequiredToolInfo( tool_id )
-            self.assertEqual( info[ 'id' ], tool_id )
-            self.assertEqual( info[ 'class' ], dotted_name )
+            info = configurator.getRequiredToolInfo(tool_id)
+            self.assertEqual(info['id'], tool_id)
+            self.assertEqual(info['class'], dotted_name)
 
-    def test_addRequiredTool_duplicate( self ):
-
-        site = self._initSite()
-        configurator = self._makeOne().__of__( site )
-
-        configurator.addRequiredTool( 'required', 'some.dotted.name' )
-        configurator.addRequiredTool( 'required', 'another.name' )
-
-        info = configurator.getRequiredToolInfo( 'required' )
-        self.assertEqual( info[ 'id' ], 'required' )
-        self.assertEqual( info[ 'class' ], 'another.name' )
-
-    def test_addRequiredTool_but_forbidden( self ):
+    def test_addRequiredTool_duplicate(self):
 
         site = self._initSite()
-        configurator = self._makeOne().__of__( site )
+        configurator = self._makeOne().__of__(site)
 
-        configurator.addForbiddenTool( 'forbidden' )
+        configurator.addRequiredTool('required', 'some.dotted.name')
+        configurator.addRequiredTool('required', 'another.name')
 
-        self.assertRaises( ValueError
-                         , configurator.addRequiredTool
-                         , 'forbidden'
-                         , 'a.name'
-                         )
+        info = configurator.getRequiredToolInfo('required')
+        self.assertEqual(info['id'], 'required')
+        self.assertEqual(info['class'], 'another.name')
 
-    def test_generateXML_empty( self ):
-
-        site = self._initSite()
-        configurator = self._makeOne().__of__( site )
-
-        self._compareDOM( configurator.generateXML(), _EMPTY_TOOLSET_XML )
-
-    def test_generateXML_normal( self ):
+    def test_addRequiredTool_but_forbidden(self):
 
         site = self._initSite()
-        configurator = self._makeOne().__of__( site )
+        configurator = self._makeOne().__of__(site)
 
-        configurator.addForbiddenTool( 'doomed' )
-        configurator.addRequiredTool( 'mandatory', 'path.to.one' )
-        configurator.addRequiredTool( 'obligatory', 'path.to.another' )
+        configurator.addForbiddenTool('forbidden')
 
-        configurator.parseXML( _NORMAL_TOOLSET_XML )
+        self.assertRaises(ValueError, configurator.addRequiredTool, 'forbidden', 'a.name'
+                          )
 
-    def test_parseXML_empty( self ):
-
-        site = self._initSite()
-        configurator = self._makeOne().__of__( site )
-
-        configurator.parseXML( _EMPTY_TOOLSET_XML )
-
-        self.assertEqual( len( configurator.listForbiddenTools() ), 0 )
-        self.assertEqual( len( configurator.listRequiredTools() ), 0 )
-
-    def test_parseXML_normal( self ):
+    def test_generateXML_empty(self):
 
         site = self._initSite()
-        configurator = self._makeOne().__of__( site )
+        configurator = self._makeOne().__of__(site)
 
-        configurator.parseXML( _NORMAL_TOOLSET_XML )
+        self._compareDOM(configurator.generateXML(), _EMPTY_TOOLSET_XML)
 
-        self.assertEqual( len( configurator.listForbiddenTools() ), 1 )
-        self.failUnless( 'doomed' in configurator.listForbiddenTools() )
-
-        self.assertEqual( len( configurator.listRequiredTools() ), 2 )
-
-        self.failUnless( 'mandatory' in configurator.listRequiredTools() )
-        info = configurator.getRequiredToolInfo( 'mandatory' )
-        self.assertEqual( info[ 'class' ], 'path.to.one' )
-
-        self.failUnless( 'obligatory' in configurator.listRequiredTools() )
-        info = configurator.getRequiredToolInfo( 'obligatory' )
-        self.assertEqual( info[ 'class' ], 'path.to.another' )
-
-    def test_parseXML_confused( self ):
+    def test_generateXML_normal(self):
 
         site = self._initSite()
-        configurator = self._makeOne().__of__( site )
+        configurator = self._makeOne().__of__(site)
 
-        self.assertRaises( ValueError
-                         , configurator.parseXML, _CONFUSED_TOOLSET_XML )
+        configurator.addForbiddenTool('doomed')
+        configurator.addRequiredTool('mandatory', 'path.to.one')
+        configurator.addRequiredTool('obligatory', 'path.to.another')
+
+        configurator.parseXML(_NORMAL_TOOLSET_XML)
+
+    def test_parseXML_empty(self):
+
+        site = self._initSite()
+        configurator = self._makeOne().__of__(site)
+
+        configurator.parseXML(_EMPTY_TOOLSET_XML)
+
+        self.assertEqual(len(configurator.listForbiddenTools()), 0)
+        self.assertEqual(len(configurator.listRequiredTools()), 0)
+
+    def test_parseXML_normal(self):
+
+        site = self._initSite()
+        configurator = self._makeOne().__of__(site)
+
+        configurator.parseXML(_NORMAL_TOOLSET_XML)
+
+        self.assertEqual(len(configurator.listForbiddenTools()), 1)
+        self.failUnless('doomed' in configurator.listForbiddenTools())
+
+        self.assertEqual(len(configurator.listRequiredTools()), 2)
+
+        self.failUnless('mandatory' in configurator.listRequiredTools())
+        info = configurator.getRequiredToolInfo('mandatory')
+        self.assertEqual(info['class'], 'path.to.one')
+
+        self.failUnless('obligatory' in configurator.listRequiredTools())
+        info = configurator.getRequiredToolInfo('obligatory')
+        self.assertEqual(info['class'], 'path.to.another')
+
+    def test_parseXML_confused(self):
+
+        site = self._initSite()
+        configurator = self._makeOne().__of__(site)
+
+        self.assertRaises(ValueError, configurator.parseXML,
+                          _CONFUSED_TOOLSET_XML)
 
 
 _EMPTY_TOOLSET_XML = """\
@@ -995,36 +844,36 @@ _CONFUSED_TOOLSET_XML = """\
 </tool-setup>
 """
 
+
 class ISite(Interface):
     pass
 
+
 class IDerivedSite(ISite):
     pass
+
 
 class IAnotherSite(Interface):
     pass
 
 
-class ProfileRegistryTests( BaseRegistryTests
-                          , ConformsToIProfileRegistry
-                          ):
+class ProfileRegistryTests(BaseRegistryTests, ConformsToIProfileRegistry
+                           ):
 
-
-
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.registry import ProfileRegistry
         return ProfileRegistry
 
-    def test_empty( self ):
+    def test_empty(self):
 
         registry = self._makeOne()
 
-        self.assertEqual( len( registry.listProfiles() ), 0 )
-        self.assertEqual( len( registry.listProfiles() ), 0 )
-        self.assertRaises( KeyError, registry.getProfileInfo, 'nonesuch' )
+        self.assertEqual(len(registry.listProfiles()), 0)
+        self.assertEqual(len(registry.listProfiles()), 0)
+        self.assertRaises(KeyError, registry.getProfileInfo, 'nonesuch')
 
-    def test_registerProfile_normal( self ):
+    def test_registerProfile_normal(self):
 
         NAME = 'one'
         TITLE = 'One'
@@ -1035,35 +884,30 @@ class ProfileRegistryTests( BaseRegistryTests
         PROFILE_ID = 'TestProduct:one'
 
         registry = self._makeOne()
-        registry.registerProfile( NAME
-                                , TITLE
-                                , DESCRIPTION
-                                , PATH
-                                , PRODUCT
-                                , PROFILE_TYPE
-                                )
-        
-        self.assertEqual( len( registry.listProfiles() ), 1 )
-        self.assertEqual( len( registry.listProfileInfo() ), 1 )
+        registry.registerProfile(NAME, TITLE, DESCRIPTION, PATH, PRODUCT, PROFILE_TYPE
+                                 )
 
-        info = registry.getProfileInfo( PROFILE_ID )
+        self.assertEqual(len(registry.listProfiles()), 1)
+        self.assertEqual(len(registry.listProfileInfo()), 1)
 
-        self.assertEqual( info[ 'id' ], PROFILE_ID )
-        self.assertEqual( info[ 'title' ], TITLE )
-        self.assertEqual( info[ 'description' ], DESCRIPTION )
-        self.assertEqual( info[ 'path' ], PATH )
-        self.assertEqual( info[ 'product' ], PRODUCT )
-        self.assertEqual( info[ 'type' ], PROFILE_TYPE )
-        self.assertEqual( info[ 'for' ], None )
+        info = registry.getProfileInfo(PROFILE_ID)
+
+        self.assertEqual(info['id'], PROFILE_ID)
+        self.assertEqual(info['title'], TITLE)
+        self.assertEqual(info['description'], DESCRIPTION)
+        self.assertEqual(info['path'], PATH)
+        self.assertEqual(info['product'], PRODUCT)
+        self.assertEqual(info['type'], PROFILE_TYPE)
+        self.assertEqual(info['for'], None)
 
         # We strip off any 'profile-' or 'snapshot-' at the beginning
         # of the profile id.
-        info2 = registry.getProfileInfo( 'profile-' + PROFILE_ID )
+        info2 = registry.getProfileInfo('profile-' + PROFILE_ID)
         self.assertEqual(info, info2)
-        info3 = registry.getProfileInfo( 'snapshot-' + PROFILE_ID )
+        info3 = registry.getProfileInfo('snapshot-' + PROFILE_ID)
         self.assertEqual(info, info3)
 
-    def test_registerProfile_duplicate( self ):
+    def test_registerProfile_duplicate(self):
 
         NAME = 'one'
         TITLE = 'One'
@@ -1071,13 +915,11 @@ class ProfileRegistryTests( BaseRegistryTests
         PATH = '/path/to/one'
 
         registry = self._makeOne()
-        registry.registerProfile( NAME, TITLE, DESCRIPTION, PATH )
-        self.assertRaises( KeyError
-                         , registry.registerProfile
-                         , NAME, TITLE, DESCRIPTION, PATH )
+        registry.registerProfile(NAME, TITLE, DESCRIPTION, PATH)
+        self.assertRaises(KeyError, registry.registerProfile,
+                          NAME, TITLE, DESCRIPTION, PATH)
 
-
-    def test_registerProfile_site_type( self ):
+    def test_registerProfile_site_type(self):
 
         NAME = 'one'
         TITLE = 'One'
@@ -1091,60 +933,46 @@ class ProfileRegistryTests( BaseRegistryTests
         DERIVED_FOR = IDerivedSite
 
         registry = self._makeOne()
-        registry.registerProfile( NAME
-                                , TITLE
-                                , DESCRIPTION
-                                , PATH
-                                , PRODUCT
-                                , PROFILE_TYPE
-                                , for_=FOR
-                                )
+        registry.registerProfile(NAME, TITLE, DESCRIPTION, PATH, PRODUCT, PROFILE_TYPE, for_=FOR
+                                 )
 
+        self.assertEqual(len(registry.listProfiles()), 1)
+        self.assertEqual(len(registry.listProfiles(for_=FOR)), 1)
+        self.assertEqual(len(registry.listProfiles(for_=DERIVED_FOR)), 1)
+        self.assertEqual(len(registry.listProfiles(for_=NOT_FOR)), 0)
 
-        self.assertEqual( len( registry.listProfiles() ), 1 )
-        self.assertEqual( len( registry.listProfiles( for_=FOR ) ), 1 )
-        self.assertEqual( len( registry.listProfiles( for_=DERIVED_FOR ) )
-                        , 1 )
-        self.assertEqual( len( registry.listProfiles( for_=NOT_FOR ) )
-                        , 0 )
-
-        self.assertEqual( len( registry.listProfileInfo() ), 1 )
-        self.assertEqual( len( registry.listProfileInfo( for_=FOR ) ), 1 )
-        self.assertEqual( len( registry.listProfileInfo( for_=DERIVED_FOR ) )
-                        , 1 )
-        self.assertEqual( len( registry.listProfileInfo( for_=NOT_FOR ) )
-                        , 0 )
+        self.assertEqual(len(registry.listProfileInfo()), 1)
+        self.assertEqual(len(registry.listProfileInfo(for_=FOR)), 1)
+        self.assertEqual(len(registry.listProfileInfo(for_=DERIVED_FOR)), 1)
+        self.assertEqual(len(registry.listProfileInfo(for_=NOT_FOR)), 0)
 
         # Verify that these lookups succeed...
-        info1 = registry.getProfileInfo( PROFILE_ID )
-        info2 = registry.getProfileInfo( PROFILE_ID, for_=FOR )
-        info3 = registry.getProfileInfo( PROFILE_ID, for_=DERIVED_FOR )
+        info1 = registry.getProfileInfo(PROFILE_ID)
+        info2 = registry.getProfileInfo(PROFILE_ID, for_=FOR)
+        info3 = registry.getProfileInfo(PROFILE_ID, for_=DERIVED_FOR)
 
         self.assertEqual(info1, info2)
         self.assertEqual(info1, info3)
 
         # ...and that this one fails.
-        self.assertRaises( KeyError
-                         , registry.getProfileInfo
-                         , PROFILE_ID
-                         , for_=NOT_FOR
-                         )
+        self.assertRaises(KeyError, registry.getProfileInfo, PROFILE_ID, for_=NOT_FOR
+                          )
 
-        info = registry.getProfileInfo( PROFILE_ID , for_=FOR )
+        info = registry.getProfileInfo(PROFILE_ID, for_=FOR)
 
-        self.assertEqual( info[ 'id' ], PROFILE_ID )
-        self.assertEqual( info[ 'title' ], TITLE )
-        self.assertEqual( info[ 'description' ], DESCRIPTION )
-        self.assertEqual( info[ 'path' ], PATH )
-        self.assertEqual( info[ 'product' ], PRODUCT )
-        self.assertEqual( info[ 'type' ], PROFILE_TYPE )
-        self.assertEqual( info[ 'for' ], FOR )
+        self.assertEqual(info['id'], PROFILE_ID)
+        self.assertEqual(info['title'], TITLE)
+        self.assertEqual(info['description'], DESCRIPTION)
+        self.assertEqual(info['path'], PATH)
+        self.assertEqual(info['product'], PRODUCT)
+        self.assertEqual(info['type'], PROFILE_TYPE)
+        self.assertEqual(info['for'], FOR)
 
 
 def test_suite():
     return unittest.TestSuite((
-        unittest.makeSuite( ImportStepRegistryTests ),
-        unittest.makeSuite( ExportStepRegistryTests ),
-        unittest.makeSuite( ToolsetRegistryTests ),
-        unittest.makeSuite( ProfileRegistryTests ),
-        ))
+        unittest.makeSuite(ImportStepRegistryTests),
+        unittest.makeSuite(ExportStepRegistryTests),
+        unittest.makeSuite(ToolsetRegistryTests),
+        unittest.makeSuite(ProfileRegistryTests),
+    ))

--- a/Products/GenericSetup/tests/test_rolemap.py
+++ b/Products/GenericSetup/tests/test_rolemap.py
@@ -27,247 +27,246 @@ class RolemapExportConfiguratorTests(BaseRegistryTests):
 
     layer = ExportImportZCMLLayer
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.rolemap import RolemapExportConfigurator
         return RolemapExportConfigurator
 
-    def test_listRoles_normal( self ):
+    def test_listRoles_normal(self):
 
-        EXPECTED = [ 'Anonymous', 'Authenticated', 'Manager', 'Owner' ]
+        EXPECTED = ['Anonymous', 'Authenticated', 'Manager', 'Owner']
         self.app.site = Folder(id='site')
         site = self.app.site
-        configurator = self._makeOne( site )
+        configurator = self._makeOne(site)
 
-        roles = list( configurator.listRoles() )
-        self.assertEqual( len( roles ), len( EXPECTED ) )
+        roles = list(configurator.listRoles())
+        self.assertEqual(len(roles), len(EXPECTED))
 
         roles.sort()
 
-        for found, expected in zip( roles, EXPECTED ):
-            self.assertEqual( found, expected )
+        for found, expected in zip(roles, EXPECTED):
+            self.assertEqual(found, expected)
 
-    def test_listRoles_added( self ):
+    def test_listRoles_added(self):
 
-        EXPECTED = [ 'Anonymous', 'Authenticated', 'Manager', 'Owner', 'ZZZ' ]
+        EXPECTED = ['Anonymous', 'Authenticated', 'Manager', 'Owner', 'ZZZ']
         self.app.site = Folder(id='site')
         site = self.app.site
-        existing_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
-        existing_roles.append( 'ZZZ' )
+        existing_roles = list(getattr(site, '__ac_roles__', []))[:]
+        existing_roles.append('ZZZ')
         site.__ac_roles__ = existing_roles
 
-        configurator = self._makeOne( site )
+        configurator = self._makeOne(site)
 
-        roles = list( configurator.listRoles() )
-        self.assertEqual( len( roles ), len( EXPECTED ) )
+        roles = list(configurator.listRoles())
+        self.assertEqual(len(roles), len(EXPECTED))
 
         roles.sort()
 
-        for found, expected in zip( roles, EXPECTED ):
-            self.assertEqual( found, expected )
+        for found, expected in zip(roles, EXPECTED):
+            self.assertEqual(found, expected)
 
-    def test_listPermissions_nooverrides( self ):
+    def test_listPermissions_nooverrides(self):
 
         site = Folder(id='site').__of__(self.app)
-        configurator = self._makeOne( site )
+        configurator = self._makeOne(site)
 
-        self.assertEqual( len( configurator.listPermissions() ), 0 )
+        self.assertEqual(len(configurator.listPermissions()), 0)
 
-    def test_listPermissions_acquire( self ):
+    def test_listPermissions_acquire(self):
 
         ACI = 'Access contents information'
-        ROLES = [ 'Manager', 'Owner' ]
+        ROLES = ['Manager', 'Owner']
 
         site = Folder(id='site').__of__(self.app)
-        site.manage_permission( ACI, ROLES, acquire=1 )
-        configurator = self._makeOne( site )
+        site.manage_permission(ACI, ROLES, acquire=1)
+        configurator = self._makeOne(site)
 
-        self.assertEqual( len( configurator.listPermissions() ), 1 )
-        info = configurator.listPermissions()[ 0 ]
-        self.assertEqual( info[ 'name' ], ACI )
-        self.assertEqual( info[ 'roles' ], ROLES )
-        self.failUnless( info[ 'acquire' ] )
+        self.assertEqual(len(configurator.listPermissions()), 1)
+        info = configurator.listPermissions()[0]
+        self.assertEqual(info['name'], ACI)
+        self.assertEqual(info['roles'], ROLES)
+        self.failUnless(info['acquire'])
 
-    def test_listPermissions_no_acquire( self ):
+    def test_listPermissions_no_acquire(self):
 
         ACI = 'Access contents information'
-        ROLES = [ 'Manager', 'Owner' ]
+        ROLES = ['Manager', 'Owner']
 
         site = Folder(id='site').__of__(self.app)
-        site.manage_permission( ACI, ROLES )
-        configurator = self._makeOne( site )
+        site.manage_permission(ACI, ROLES)
+        configurator = self._makeOne(site)
 
-        self.assertEqual( len( configurator.listPermissions() ), 1 )
-        info = configurator.listPermissions()[ 0 ]
-        self.assertEqual( info[ 'name' ], ACI )
-        self.assertEqual( info[ 'roles' ], ROLES )
-        self.failIf( info[ 'acquire' ] )
+        self.assertEqual(len(configurator.listPermissions()), 1)
+        info = configurator.listPermissions()[0]
+        self.assertEqual(info['name'], ACI)
+        self.assertEqual(info['roles'], ROLES)
+        self.failIf(info['acquire'])
 
-    def test_generateXML_empty( self ):
+    def test_generateXML_empty(self):
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        configurator = self._makeOne( site ).__of__( site )
+        configurator = self._makeOne(site).__of__(site)
 
-        self._compareDOM( configurator.generateXML(), _EMPTY_EXPORT )
+        self._compareDOM(configurator.generateXML(), _EMPTY_EXPORT)
 
-    def test_generateXML_added_role( self ):
+    def test_generateXML_added_role(self):
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        existing_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
-        existing_roles.append( 'ZZZ' )
+        existing_roles = list(getattr(site, '__ac_roles__', []))[:]
+        existing_roles.append('ZZZ')
         site.__ac_roles__ = existing_roles
-        configurator = self._makeOne( site ).__of__( site )
+        configurator = self._makeOne(site).__of__(site)
 
-        self._compareDOM( configurator.generateXML(), _ADDED_ROLE_EXPORT )
+        self._compareDOM(configurator.generateXML(), _ADDED_ROLE_EXPORT)
 
-    def test_generateEXML_acquired_perm( self ):
-
-        ACI = 'Access contents information'
-        ROLES = [ 'Manager', 'Owner' ]
-
-        site = Folder(id='site').__of__(self.app)
-        site.manage_permission( ACI, ROLES, acquire=1 )
-        configurator = self._makeOne( site ).__of__( site )
-
-        self._compareDOM( configurator.generateXML(), _ACQUIRED_EXPORT )
-
-    def test_generateEXML_unacquired_perm( self ):
+    def test_generateEXML_acquired_perm(self):
 
         ACI = 'Access contents information'
-        ROLES = [ 'Manager', 'Owner', 'ZZZ' ]
+        ROLES = ['Manager', 'Owner']
 
         site = Folder(id='site').__of__(self.app)
-        existing_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
-        existing_roles.append( 'ZZZ' )
+        site.manage_permission(ACI, ROLES, acquire=1)
+        configurator = self._makeOne(site).__of__(site)
+
+        self._compareDOM(configurator.generateXML(), _ACQUIRED_EXPORT)
+
+    def test_generateEXML_unacquired_perm(self):
+
+        ACI = 'Access contents information'
+        ROLES = ['Manager', 'Owner', 'ZZZ']
+
+        site = Folder(id='site').__of__(self.app)
+        existing_roles = list(getattr(site, '__ac_roles__', []))[:]
+        existing_roles.append('ZZZ')
         site.__ac_roles__ = existing_roles
-        site.manage_permission( ACI, ROLES )
-        configurator = self._makeOne( site ).__of__( site )
+        site.manage_permission(ACI, ROLES)
+        configurator = self._makeOne(site).__of__(site)
 
-        self._compareDOM( configurator.generateXML(), _COMBINED_EXPORT )
+        self._compareDOM(configurator.generateXML(), _COMBINED_EXPORT)
 
-    def test_generateEXML_unacquired_perm_added_role( self ):
+    def test_generateEXML_unacquired_perm_added_role(self):
 
         ACI = 'Access contents information'
-        ROLES = [ 'Manager', 'Owner' ]
+        ROLES = ['Manager', 'Owner']
 
         site = Folder(id='site').__of__(self.app)
-        site.manage_permission( ACI, ROLES )
-        configurator = self._makeOne( site ).__of__( site )
+        site.manage_permission(ACI, ROLES)
+        configurator = self._makeOne(site).__of__(site)
 
-        self._compareDOM( configurator.generateXML(), _UNACQUIRED_EXPORT )
+        self._compareDOM(configurator.generateXML(), _UNACQUIRED_EXPORT)
 
 
 class RolemapImportConfiguratorTests(BaseRegistryTests):
 
     layer = ExportImportZCMLLayer
 
-    def _getTargetClass( self ):
+    def _getTargetClass(self):
 
         from Products.GenericSetup.rolemap import RolemapImportConfigurator
         return RolemapImportConfigurator
 
-    def test_parseXML_empty( self ):
+    def test_parseXML_empty(self):
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        existing_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
-        configurator = self._makeOne( site )
+        existing_roles = list(getattr(site, '__ac_roles__', []))[:]
+        configurator = self._makeOne(site)
 
-        rolemap_info = configurator.parseXML( _EMPTY_EXPORT )
+        rolemap_info = configurator.parseXML(_EMPTY_EXPORT)
 
-        self.assertEqual( len( rolemap_info[ 'roles' ] ), len(existing_roles) )
-        self.assertEqual( len( rolemap_info[ 'permissions' ] ), 0 )
+        self.assertEqual(len(rolemap_info['roles']), len(existing_roles))
+        self.assertEqual(len(rolemap_info['permissions']), 0)
 
-    def test_parseXML_added_role( self ):
+    def test_parseXML_added_role(self):
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        configurator = self._makeOne( site )
+        configurator = self._makeOne(site)
 
-        rolemap_info = configurator.parseXML( _ADDED_ROLE_EXPORT )
-        roles = rolemap_info[ 'roles' ]
+        rolemap_info = configurator.parseXML(_ADDED_ROLE_EXPORT)
+        roles = rolemap_info['roles']
 
-        self.assertEqual( len( roles ), 5 )
-        self.failUnless( 'Anonymous' in roles )
-        self.failUnless( 'Authenticated' in roles )
-        self.failUnless( 'Manager' in roles )
-        self.failUnless( 'Owner' in roles )
-        self.failUnless( 'ZZZ' in roles )
+        self.assertEqual(len(roles), 5)
+        self.failUnless('Anonymous' in roles)
+        self.failUnless('Authenticated' in roles)
+        self.failUnless('Manager' in roles)
+        self.failUnless('Owner' in roles)
+        self.failUnless('ZZZ' in roles)
 
-    def test_parseXML_acquired_permission( self ):
+    def test_parseXML_acquired_permission(self):
 
         ACI = 'Access contents information'
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        configurator = self._makeOne( site )
+        configurator = self._makeOne(site)
 
-        rolemap_info = configurator.parseXML( _ACQUIRED_EXPORT )
+        rolemap_info = configurator.parseXML(_ACQUIRED_EXPORT)
 
-        self.assertEqual( len( rolemap_info[ 'permissions' ] ), 1 )
-        permission = rolemap_info[ 'permissions' ][ 0 ]
+        self.assertEqual(len(rolemap_info['permissions']), 1)
+        permission = rolemap_info['permissions'][0]
 
-        self.assertEqual( permission[ 'name' ], ACI )
-        self.failUnless( permission[ 'acquire' ] )
+        self.assertEqual(permission['name'], ACI)
+        self.failUnless(permission['acquire'])
 
-        p_roles = permission[ 'roles' ]
-        self.assertEqual( len( p_roles ), 2 )
-        self.failUnless( 'Manager' in p_roles )
-        self.failUnless( 'Owner' in p_roles )
+        p_roles = permission['roles']
+        self.assertEqual(len(p_roles), 2)
+        self.failUnless('Manager' in p_roles)
+        self.failUnless('Owner' in p_roles)
 
-    def test_parseXML_unacquired_permission( self ):
-
-        ACI = 'Access contents information'
-
-        self.app.site = Folder(id='site')
-        site = self.app.site
-        configurator = self._makeOne( site )
-
-        rolemap_info = configurator.parseXML( _UNACQUIRED_EXPORT )
-
-        self.assertEqual( len( rolemap_info[ 'permissions' ] ), 1 )
-        permission = rolemap_info[ 'permissions' ][ 0 ]
-
-        self.assertEqual( permission[ 'name' ], ACI )
-        self.failIf( permission[ 'acquire' ] )
-
-        p_roles = permission[ 'roles' ]
-        self.assertEqual( len( p_roles ), 2 )
-        self.failUnless( 'Manager' in p_roles )
-        self.failUnless( 'Owner' in p_roles )
-
-    def test_parseXML_unacquired_permission_added_role( self ):
+    def test_parseXML_unacquired_permission(self):
 
         ACI = 'Access contents information'
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        configurator = self._makeOne( site )
+        configurator = self._makeOne(site)
 
-        rolemap_info = configurator.parseXML( _COMBINED_EXPORT )
-        roles = rolemap_info[ 'roles' ]
+        rolemap_info = configurator.parseXML(_UNACQUIRED_EXPORT)
 
-        self.assertEqual( len( roles ), 5 )
-        self.failUnless( 'Anonymous' in roles )
-        self.failUnless( 'Authenticated' in roles )
-        self.failUnless( 'Manager' in roles )
-        self.failUnless( 'Owner' in roles )
-        self.failUnless( 'ZZZ' in roles )
+        self.assertEqual(len(rolemap_info['permissions']), 1)
+        permission = rolemap_info['permissions'][0]
 
-        self.assertEqual( len( rolemap_info[ 'permissions' ] ), 1 )
-        permission = rolemap_info[ 'permissions' ][ 0 ]
+        self.assertEqual(permission['name'], ACI)
+        self.failIf(permission['acquire'])
 
-        self.assertEqual( permission[ 'name' ], ACI )
-        self.failIf( permission[ 'acquire' ] )
+        p_roles = permission['roles']
+        self.assertEqual(len(p_roles), 2)
+        self.failUnless('Manager' in p_roles)
+        self.failUnless('Owner' in p_roles)
 
-        p_roles = permission[ 'roles' ]
-        self.assertEqual( len( p_roles ), 3 )
-        self.failUnless( 'Manager' in p_roles )
-        self.failUnless( 'Owner' in p_roles )
-        self.failUnless( 'ZZZ' in p_roles )
+    def test_parseXML_unacquired_permission_added_role(self):
 
+        ACI = 'Access contents information'
+
+        self.app.site = Folder(id='site')
+        site = self.app.site
+        configurator = self._makeOne(site)
+
+        rolemap_info = configurator.parseXML(_COMBINED_EXPORT)
+        roles = rolemap_info['roles']
+
+        self.assertEqual(len(roles), 5)
+        self.failUnless('Anonymous' in roles)
+        self.failUnless('Authenticated' in roles)
+        self.failUnless('Manager' in roles)
+        self.failUnless('Owner' in roles)
+        self.failUnless('ZZZ' in roles)
+
+        self.assertEqual(len(rolemap_info['permissions']), 1)
+        permission = rolemap_info['permissions'][0]
+
+        self.assertEqual(permission['name'], ACI)
+        self.failIf(permission['acquire'])
+
+        p_roles = permission['roles']
+        self.assertEqual(len(p_roles), 3)
+        self.failUnless('Manager' in p_roles)
+        self.failUnless('Owner' in p_roles)
+        self.failUnless('ZZZ' in p_roles)
 
 
 _EMPTY_EXPORT = """\
@@ -358,111 +357,111 @@ _COMBINED_EXPORT = """\
 </rolemap>
 """
 
-class Test_exportRolemap( BaseRegistryTests ):
+
+class Test_exportRolemap(BaseRegistryTests):
 
     layer = ExportImportZCMLLayer
 
-    def test_unchanged( self ):
+    def test_unchanged(self):
 
         self.app.site = Folder('site')
         site = self.app.site
 
-        context = DummyExportContext( site )
+        context = DummyExportContext(site)
 
         from Products.GenericSetup.rolemap import exportRolemap
-        exportRolemap( context )
+        exportRolemap(context)
 
-        self.assertEqual( len( context._wrote ), 1 )
-        filename, text, content_type = context._wrote[ 0 ]
-        self.assertEqual( filename, 'rolemap.xml' )
-        self._compareDOM( text, _EMPTY_EXPORT )
-        self.assertEqual( content_type, 'text/xml' )
+        self.assertEqual(len(context._wrote), 1)
+        filename, text, content_type = context._wrote[0]
+        self.assertEqual(filename, 'rolemap.xml')
+        self._compareDOM(text, _EMPTY_EXPORT)
+        self.assertEqual(content_type, 'text/xml')
 
-    def test_added_role( self ):
+    def test_added_role(self):
 
         self.app.site = Folder('site')
         site = self.app.site
-        existing_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
-        existing_roles.append( 'ZZZ' )
+        existing_roles = list(getattr(site, '__ac_roles__', []))[:]
+        existing_roles.append('ZZZ')
         site.__ac_roles__ = existing_roles
 
-        context = DummyExportContext( site )
+        context = DummyExportContext(site)
 
         from Products.GenericSetup.rolemap import exportRolemap
-        exportRolemap( context )
+        exportRolemap(context)
 
-        self.assertEqual( len( context._wrote ), 1 )
-        filename, text, content_type = context._wrote[ 0 ]
-        self.assertEqual( filename, 'rolemap.xml' )
-        self._compareDOM( text, _ADDED_ROLE_EXPORT )
-        self.assertEqual( content_type, 'text/xml' )
+        self.assertEqual(len(context._wrote), 1)
+        filename, text, content_type = context._wrote[0]
+        self.assertEqual(filename, 'rolemap.xml')
+        self._compareDOM(text, _ADDED_ROLE_EXPORT)
+        self.assertEqual(content_type, 'text/xml')
 
-
-    def test_acquired_perm( self ):
+    def test_acquired_perm(self):
 
         ACI = 'Access contents information'
-        ROLES = [ 'Manager', 'Owner' ]
+        ROLES = ['Manager', 'Owner']
 
         self.app.site = Folder('site')
         site = self.app.site
-        site.manage_permission( ACI, ROLES, acquire=1 )
+        site.manage_permission(ACI, ROLES, acquire=1)
 
-        context = DummyExportContext( site )
+        context = DummyExportContext(site)
 
         from Products.GenericSetup.rolemap import exportRolemap
-        exportRolemap( context )
+        exportRolemap(context)
 
-        self.assertEqual( len( context._wrote ), 1 )
-        filename, text, content_type = context._wrote[ 0 ]
-        self.assertEqual( filename, 'rolemap.xml' )
-        self._compareDOM( text, _ACQUIRED_EXPORT )
-        self.assertEqual( content_type, 'text/xml' )
+        self.assertEqual(len(context._wrote), 1)
+        filename, text, content_type = context._wrote[0]
+        self.assertEqual(filename, 'rolemap.xml')
+        self._compareDOM(text, _ACQUIRED_EXPORT)
+        self.assertEqual(content_type, 'text/xml')
 
-    def test_unacquired_perm( self ):
+    def test_unacquired_perm(self):
 
         ACI = 'Access contents information'
-        ROLES = [ 'Manager', 'Owner', 'ZZZ' ]
+        ROLES = ['Manager', 'Owner', 'ZZZ']
 
         self.app.site = Folder('site')
         site = self.app.site
-        existing_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
-        existing_roles.append( 'ZZZ' )
+        existing_roles = list(getattr(site, '__ac_roles__', []))[:]
+        existing_roles.append('ZZZ')
         site.__ac_roles__ = existing_roles
-        site.manage_permission( ACI, ROLES )
+        site.manage_permission(ACI, ROLES)
 
-        context = DummyExportContext( site )
+        context = DummyExportContext(site)
 
         from Products.GenericSetup.rolemap import exportRolemap
-        exportRolemap( context )
+        exportRolemap(context)
 
-        self.assertEqual( len( context._wrote ), 1 )
-        filename, text, content_type = context._wrote[ 0 ]
-        self.assertEqual( filename, 'rolemap.xml' )
-        self._compareDOM( text, _COMBINED_EXPORT )
-        self.assertEqual( content_type, 'text/xml' )
+        self.assertEqual(len(context._wrote), 1)
+        filename, text, content_type = context._wrote[0]
+        self.assertEqual(filename, 'rolemap.xml')
+        self._compareDOM(text, _COMBINED_EXPORT)
+        self.assertEqual(content_type, 'text/xml')
 
-    def test_unacquired_perm_added_role( self ):
+    def test_unacquired_perm_added_role(self):
 
         ACI = 'Access contents information'
-        ROLES = [ 'Manager', 'Owner' ]
+        ROLES = ['Manager', 'Owner']
 
         self.app.site = Folder('site')
         site = self.app.site
-        site.manage_permission( ACI, ROLES )
+        site.manage_permission(ACI, ROLES)
 
-        context = DummyExportContext( site )
+        context = DummyExportContext(site)
 
         from Products.GenericSetup.rolemap import exportRolemap
-        exportRolemap( context )
+        exportRolemap(context)
 
-        self.assertEqual( len( context._wrote ), 1 )
-        filename, text, content_type = context._wrote[ 0 ]
-        self.assertEqual( filename, 'rolemap.xml' )
-        self._compareDOM( text, _UNACQUIRED_EXPORT )
-        self.assertEqual( content_type, 'text/xml' )
+        self.assertEqual(len(context._wrote), 1)
+        filename, text, content_type = context._wrote[0]
+        self.assertEqual(filename, 'rolemap.xml')
+        self._compareDOM(text, _UNACQUIRED_EXPORT)
+        self.assertEqual(content_type, 'text/xml')
 
 
-class Test_importRolemap( BaseRegistryTests ):
+class Test_importRolemap(BaseRegistryTests):
 
     layer = ExportImportZCMLLayer
 
@@ -472,7 +471,7 @@ class Test_importRolemap( BaseRegistryTests ):
         VIEW = 'View'
 
         self.app.site = Folder(id='site')
-        site = self.app.site # wrap
+        site = self.app.site  # wrap
         original_roles = list(getattr(site, '__ac_roles__', []))[:]
         modified_roles = original_roles[:]
         modified_roles.append('ZZZ')
@@ -482,12 +481,12 @@ class Test_importRolemap( BaseRegistryTests ):
         site.manage_permission(ACI, ('Manager', 'ZZZ'))
 
         existing_allowed = [x['name'] for x in site.rolesOfPermission(ACI)
-                                if x['selected']]
+                            if x['selected']]
 
         self.assertEqual(existing_allowed, ['Manager', 'ZZZ'])
 
         context = DummyImportContext(site, True)
-        #context._files[ 'rolemap.xml' ] = _EMPTY_EXPORT # no file!
+        # context._files[ 'rolemap.xml' ] = _EMPTY_EXPORT # no file!
 
         from Products.GenericSetup.rolemap import importRolemap
         importRolemap(context)
@@ -500,321 +499,321 @@ class Test_importRolemap( BaseRegistryTests ):
         self.assertEqual(modified_roles, new_roles)
 
         new_allowed = [x['name'] for x in site.rolesOfPermission(ACI)
-                                if x['selected']]
+                       if x['selected']]
 
         self.assertEqual(new_allowed, existing_allowed)
 
-    def test_empty_default_purge( self ):
+    def test_empty_default_purge(self):
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        original_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
+        original_roles = list(getattr(site, '__ac_roles__', []))[:]
         modified_roles = original_roles[:]
-        modified_roles.append( 'ZZZ' )
+        modified_roles.append('ZZZ')
         site.__ac_roles__ = modified_roles
 
-        context = DummyImportContext( site )
-        context._files[ 'rolemap.xml' ] = _EMPTY_EXPORT
+        context = DummyImportContext(site)
+        context._files['rolemap.xml'] = _EMPTY_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        new_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
+        new_roles = list(getattr(site, '__ac_roles__', []))[:]
 
         original_roles.sort()
         new_roles.sort()
 
-        self.assertEqual( original_roles, new_roles )
+        self.assertEqual(original_roles, new_roles)
 
-    def test_empty_explicit_purge( self ):
+    def test_empty_explicit_purge(self):
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        original_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
+        original_roles = list(getattr(site, '__ac_roles__', []))[:]
         modified_roles = original_roles[:]
-        modified_roles.append( 'ZZZ' )
+        modified_roles.append('ZZZ')
         site.__ac_roles__ = modified_roles
 
-        context = DummyImportContext( site, True )
-        context._files[ 'rolemap.xml' ] = _EMPTY_EXPORT
+        context = DummyImportContext(site, True)
+        context._files['rolemap.xml'] = _EMPTY_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        new_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
+        new_roles = list(getattr(site, '__ac_roles__', []))[:]
 
         original_roles.sort()
         new_roles.sort()
 
-        self.assertEqual( original_roles, new_roles )
+        self.assertEqual(original_roles, new_roles)
 
-    def test_empty_skip_purge( self ):
+    def test_empty_skip_purge(self):
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        original_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
+        original_roles = list(getattr(site, '__ac_roles__', []))[:]
         modified_roles = original_roles[:]
-        modified_roles.append( 'ZZZ' )
+        modified_roles.append('ZZZ')
         site.__ac_roles__ = modified_roles
 
-        context = DummyImportContext( site, False )
-        context._files[ 'rolemap.xml' ] = _EMPTY_EXPORT
+        context = DummyImportContext(site, False)
+        context._files['rolemap.xml'] = _EMPTY_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        new_roles = list( getattr( site, '__ac_roles__', [] ) )[:]
+        new_roles = list(getattr(site, '__ac_roles__', []))[:]
 
         modified_roles.sort()
         new_roles.sort()
 
-        self.assertEqual( modified_roles, new_roles )
+        self.assertEqual(modified_roles, new_roles)
 
-    def test_acquired_permission_explicit_purge( self ):
+    def test_acquired_permission_explicit_purge(self):
 
         ACI = 'Access contents information'
         VIEW = 'View'
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        site.manage_permission( ACI, () )
-        site.manage_permission( VIEW, () )
+        site.manage_permission(ACI, ())
+        site.manage_permission(VIEW, ())
 
-        existing_allowed = [ x[ 'name' ]
-                                for x in site.rolesOfPermission( ACI )
-                                if x[ 'selected' ] ]
+        existing_allowed = [x['name']
+                            for x in site.rolesOfPermission(ACI)
+                            if x['selected']]
 
-        self.assertEqual( existing_allowed, [] )
+        self.assertEqual(existing_allowed, [])
 
-        self.failIf( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failIf(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
 
-        context = DummyImportContext( site, True )
-        context._files[ 'rolemap.xml' ] = _ACQUIRED_EXPORT
+        context = DummyImportContext(site, True)
+        context._files['rolemap.xml'] = _ACQUIRED_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        new_allowed = [ x[ 'name' ]
-                           for x in site.rolesOfPermission( ACI )
-                           if x[ 'selected' ] ]
+        new_allowed = [x['name']
+                       for x in site.rolesOfPermission(ACI)
+                       if x['selected']]
 
-        self.assertEqual( new_allowed, [ 'Manager', 'Owner' ] )
+        self.assertEqual(new_allowed, ['Manager', 'Owner'])
 
         # ACI is overwritten by XML, but VIEW was purged
-        self.failUnless( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failUnless( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failUnless(site.acquiredRolesAreUsedBy(ACI))
+        self.failUnless(site.acquiredRolesAreUsedBy(VIEW))
 
-    def test_acquired_permission_no_purge( self ):
+    def test_acquired_permission_no_purge(self):
 
         ACI = 'Access contents information'
         VIEW = 'View'
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        site.manage_permission( ACI, () )
-        site.manage_permission( VIEW, () )
+        site.manage_permission(ACI, ())
+        site.manage_permission(VIEW, ())
 
-        existing_allowed = [ x[ 'name' ]
-                                for x in site.rolesOfPermission( ACI )
-                                if x[ 'selected' ] ]
+        existing_allowed = [x['name']
+                            for x in site.rolesOfPermission(ACI)
+                            if x['selected']]
 
-        self.assertEqual( existing_allowed, [] )
+        self.assertEqual(existing_allowed, [])
 
-        self.failIf( site.acquiredRolesAreUsedBy( ACI ) )
+        self.failIf(site.acquiredRolesAreUsedBy(ACI))
 
-        context = DummyImportContext( site, False )
-        context._files[ 'rolemap.xml' ] = _ACQUIRED_EXPORT
+        context = DummyImportContext(site, False)
+        context._files['rolemap.xml'] = _ACQUIRED_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        new_allowed = [ x[ 'name' ]
-                           for x in site.rolesOfPermission( ACI )
-                           if x[ 'selected' ] ]
+        new_allowed = [x['name']
+                       for x in site.rolesOfPermission(ACI)
+                       if x['selected']]
 
-        self.assertEqual( new_allowed, [ 'Manager', 'Owner' ] )
+        self.assertEqual(new_allowed, ['Manager', 'Owner'])
 
         # ACI is overwritten by XML, but VIEW is not
-        self.failUnless( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failUnless(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
 
-    def test_unacquired_permission_explicit_purge( self ):
-
-        ACI = 'Access contents information'
-        VIEW = 'View'
-
-        self.app.site = Folder(id='site')
-        site = self.app.site
-        site.manage_permission( VIEW, () )
-
-        existing_allowed = [ x[ 'name' ]
-                                for x in site.rolesOfPermission( ACI )
-                                if x[ 'selected' ] ]
-
-        self.assertEqual( existing_allowed, [ 'Manager' ] )
-
-        self.failUnless( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
-
-        context = DummyImportContext( site, True )
-        context._files[ 'rolemap.xml' ] = _UNACQUIRED_EXPORT
-
-        from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
-
-        new_allowed = [ x[ 'name' ]
-                           for x in site.rolesOfPermission( ACI )
-                           if x[ 'selected' ] ]
-
-        self.assertEqual( new_allowed, [ 'Manager', 'Owner' ] )
-
-        self.failIf( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failUnless( site.acquiredRolesAreUsedBy( VIEW ) )
-
-    def test_unacquired_permission_skip_purge( self ):
+    def test_unacquired_permission_explicit_purge(self):
 
         ACI = 'Access contents information'
         VIEW = 'View'
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        site.manage_permission( VIEW, () )
+        site.manage_permission(VIEW, ())
 
-        existing_allowed = [ x[ 'name' ]
-                                for x in site.rolesOfPermission( ACI )
-                                if x[ 'selected' ] ]
+        existing_allowed = [x['name']
+                            for x in site.rolesOfPermission(ACI)
+                            if x['selected']]
 
-        self.assertEqual( existing_allowed, [ 'Manager' ] )
+        self.assertEqual(existing_allowed, ['Manager'])
 
-        self.failUnless( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failUnless(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
 
-        context = DummyImportContext( site, False )
-        context._files[ 'rolemap.xml' ] = _UNACQUIRED_EXPORT
+        context = DummyImportContext(site, True)
+        context._files['rolemap.xml'] = _UNACQUIRED_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        new_allowed = [ x[ 'name' ]
-                           for x in site.rolesOfPermission( ACI )
-                           if x[ 'selected' ] ]
+        new_allowed = [x['name']
+                       for x in site.rolesOfPermission(ACI)
+                       if x['selected']]
 
-        self.assertEqual( new_allowed, [ 'Manager', 'Owner' ] )
+        self.assertEqual(new_allowed, ['Manager', 'Owner'])
 
-        self.failIf( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failIf(site.acquiredRolesAreUsedBy(ACI))
+        self.failUnless(site.acquiredRolesAreUsedBy(VIEW))
 
-    def test_unacquired_permission_added_role_explicit_purge( self ):
+    def test_unacquired_permission_skip_purge(self):
 
         ACI = 'Access contents information'
         VIEW = 'View'
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        site.manage_permission( VIEW, () )
+        site.manage_permission(VIEW, ())
 
-        existing_allowed = [ x[ 'name' ]
-                                for x in site.rolesOfPermission( ACI )
-                                if x[ 'selected' ] ]
+        existing_allowed = [x['name']
+                            for x in site.rolesOfPermission(ACI)
+                            if x['selected']]
 
-        self.assertEqual( existing_allowed, [ 'Manager' ] )
+        self.assertEqual(existing_allowed, ['Manager'])
 
-        self.failUnless( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failUnless(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
 
-        self.failIf( site._has_user_defined_role( 'ZZZ' ) )
-
-        context = DummyImportContext( site, True )
-        context._files[ 'rolemap.xml' ] = _COMBINED_EXPORT
+        context = DummyImportContext(site, False)
+        context._files['rolemap.xml'] = _UNACQUIRED_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        self.failUnless( site._has_user_defined_role( 'ZZZ' ) )
+        new_allowed = [x['name']
+                       for x in site.rolesOfPermission(ACI)
+                       if x['selected']]
 
-        new_allowed = [ x[ 'name' ]
-                           for x in site.rolesOfPermission( ACI )
-                           if x[ 'selected' ] ]
+        self.assertEqual(new_allowed, ['Manager', 'Owner'])
 
-        self.assertEqual( new_allowed, [ 'Manager', 'Owner', 'ZZZ' ] )
+        self.failIf(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
 
-        self.failIf( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failUnless( site.acquiredRolesAreUsedBy( VIEW ) )
-
-    def test_unacquired_permission_added_role_skip_purge( self ):
+    def test_unacquired_permission_added_role_explicit_purge(self):
 
         ACI = 'Access contents information'
         VIEW = 'View'
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        site.manage_permission( VIEW, () )
+        site.manage_permission(VIEW, ())
 
-        existing_allowed = [ x[ 'name' ]
-                                for x in site.rolesOfPermission( ACI )
-                                if x[ 'selected' ] ]
+        existing_allowed = [x['name']
+                            for x in site.rolesOfPermission(ACI)
+                            if x['selected']]
 
-        self.assertEqual( existing_allowed, [ 'Manager' ] )
+        self.assertEqual(existing_allowed, ['Manager'])
 
-        self.failUnless( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failUnless(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
 
-        self.failIf( site._has_user_defined_role( 'ZZZ' ) )
+        self.failIf(site._has_user_defined_role('ZZZ'))
 
-        context = DummyImportContext( site, False )
-        context._files[ 'rolemap.xml' ] = _COMBINED_EXPORT
+        context = DummyImportContext(site, True)
+        context._files['rolemap.xml'] = _COMBINED_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        self.failUnless( site._has_user_defined_role( 'ZZZ' ) )
+        self.failUnless(site._has_user_defined_role('ZZZ'))
 
-        new_allowed = [ x[ 'name' ]
-                           for x in site.rolesOfPermission( ACI )
-                           if x[ 'selected' ] ]
+        new_allowed = [x['name']
+                       for x in site.rolesOfPermission(ACI)
+                       if x['selected']]
 
-        self.assertEqual( new_allowed, [ 'Manager', 'Owner', 'ZZZ' ] )
+        self.assertEqual(new_allowed, ['Manager', 'Owner', 'ZZZ'])
 
-        self.failIf( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failIf(site.acquiredRolesAreUsedBy(ACI))
+        self.failUnless(site.acquiredRolesAreUsedBy(VIEW))
 
-    def test_unacquired_permission_added_role_skip_purge_encode_ascii( self ):
+    def test_unacquired_permission_added_role_skip_purge(self):
 
         ACI = 'Access contents information'
         VIEW = 'View'
 
         self.app.site = Folder(id='site')
         site = self.app.site
-        site.manage_permission( VIEW, () )
+        site.manage_permission(VIEW, ())
 
-        existing_allowed = [ x[ 'name' ]
-                                for x in site.rolesOfPermission( ACI )
-                                if x[ 'selected' ] ]
+        existing_allowed = [x['name']
+                            for x in site.rolesOfPermission(ACI)
+                            if x['selected']]
 
-        self.assertEqual( existing_allowed, [ 'Manager' ] )
+        self.assertEqual(existing_allowed, ['Manager'])
 
-        self.failUnless( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failUnless(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
 
-        self.failIf( site._has_user_defined_role( 'ZZZ' ) )
+        self.failIf(site._has_user_defined_role('ZZZ'))
 
-        context = DummyImportContext( site, False, encoding='ascii' )
-        context._files[ 'rolemap.xml' ] = _COMBINED_EXPORT
+        context = DummyImportContext(site, False)
+        context._files['rolemap.xml'] = _COMBINED_EXPORT
 
         from Products.GenericSetup.rolemap import importRolemap
-        importRolemap( context )
+        importRolemap(context)
 
-        self.failUnless( site._has_user_defined_role( 'ZZZ' ) )
+        self.failUnless(site._has_user_defined_role('ZZZ'))
 
-        new_allowed = [ x[ 'name' ]
-                           for x in site.rolesOfPermission( ACI )
-                           if x[ 'selected' ] ]
+        new_allowed = [x['name']
+                       for x in site.rolesOfPermission(ACI)
+                       if x['selected']]
 
-        self.assertEqual( new_allowed, [ 'Manager', 'Owner', 'ZZZ' ] )
+        self.assertEqual(new_allowed, ['Manager', 'Owner', 'ZZZ'])
 
-        self.failIf( site.acquiredRolesAreUsedBy( ACI ) )
-        self.failIf( site.acquiredRolesAreUsedBy( VIEW ) )
+        self.failIf(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
+
+    def test_unacquired_permission_added_role_skip_purge_encode_ascii(self):
+
+        ACI = 'Access contents information'
+        VIEW = 'View'
+
+        self.app.site = Folder(id='site')
+        site = self.app.site
+        site.manage_permission(VIEW, ())
+
+        existing_allowed = [x['name']
+                            for x in site.rolesOfPermission(ACI)
+                            if x['selected']]
+
+        self.assertEqual(existing_allowed, ['Manager'])
+
+        self.failUnless(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
+
+        self.failIf(site._has_user_defined_role('ZZZ'))
+
+        context = DummyImportContext(site, False, encoding='ascii')
+        context._files['rolemap.xml'] = _COMBINED_EXPORT
+
+        from Products.GenericSetup.rolemap import importRolemap
+        importRolemap(context)
+
+        self.failUnless(site._has_user_defined_role('ZZZ'))
+
+        new_allowed = [x['name']
+                       for x in site.rolesOfPermission(ACI)
+                       if x['selected']]
+
+        self.assertEqual(new_allowed, ['Manager', 'Owner', 'ZZZ'])
+
+        self.failIf(site.acquiredRolesAreUsedBy(ACI))
+        self.failIf(site.acquiredRolesAreUsedBy(VIEW))
 
 
 def test_suite():
@@ -823,4 +822,4 @@ def test_suite():
         unittest.makeSuite(RolemapImportConfiguratorTests),
         unittest.makeSuite(Test_exportRolemap),
         unittest.makeSuite(Test_importRolemap),
-        ))
+    ))

--- a/Products/GenericSetup/tests/test_stepzcml.py
+++ b/Products/GenericSetup/tests/test_stepzcml.py
@@ -41,6 +41,7 @@ ONE_STEP_ZCML = '''\
     />
 </configure>'''
 
+
 class ImportStepTests(unittest.TestCase):
 
     def setUp(self):
@@ -56,20 +57,20 @@ class ImportStepTests(unittest.TestCase):
     def testOneStepImport(self):
         zcml.load_string(ONE_STEP_ZCML)
         self.assertEqual(_import_step_registry.listSteps(),
-            [ u'Products.GenericSetup.teststep'  ])
+                         [u'Products.GenericSetup.teststep'])
         info = _import_step_registry.getStepMetadata(
             u'Products.GenericSetup.teststep')
-        self.assertEqual( info['description'],
-                u'step description' )
-        self.assertEqual( info['title'],
-                u'step title' )
-        self.assertEqual( info['handler'],
-                'Products.GenericSetup.initialize')
-        self.assertEqual( info['id'],
-                u'Products.GenericSetup.teststep' )
+        self.assertEqual(info['description'],
+                         u'step description')
+        self.assertEqual(info['title'],
+                         u'step title')
+        self.assertEqual(info['handler'],
+                         'Products.GenericSetup.initialize')
+        self.assertEqual(info['id'],
+                         u'Products.GenericSetup.teststep')
 
 
 def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(ImportStepTests),
-        ))
+    ))

--- a/Products/GenericSetup/tests/test_tool.py
+++ b/Products/GenericSetup/tests/test_tool.py
@@ -51,11 +51,15 @@ from Products.GenericSetup.upgrade import listUpgradeSteps
 from Products.GenericSetup.upgrade import UpgradeStep
 
 _before_import_events = []
+
+
 @adapter(IBeforeProfileImportEvent)
 def handleBeforeProfileImportEvent(event):
     _before_import_events.append(event)
 
 _after_import_events = []
+
+
 @adapter(IProfileImportedEvent)
 def handleProfileImportedEvent(event):
     _after_import_events.append(event)
@@ -116,33 +120,33 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
 
         return SetupTool
 
-    def _makeSite( self, title="Don't care" ):
+    def _makeSite(self, title="Don't care"):
 
         site = Folder()
-        site._setId( 'site' )
+        site._setId('site')
         site.title = title
 
-        self.app._setObject( 'site', site )
-        return self.app._getOb( 'site' )
+        self.app._setObject('site', site)
+        return self.app._getOb('site')
 
-    def test_empty( self ):
+    def test_empty(self):
 
         tool = self._makeOne('setup_tool')
 
-        self.assertEqual( tool.getBaselineContextID(), '' )
+        self.assertEqual(tool.getBaselineContextID(), '')
 
         import_registry = tool.getImportStepRegistry()
-        self.assertEqual( len( import_registry.listSteps() ), 0 )
+        self.assertEqual(len(import_registry.listSteps()), 0)
 
         export_registry = tool.getExportStepRegistry()
         export_steps = export_registry.listSteps()
         self.assertEqual(len(export_steps), 0)
 
         toolset_registry = tool.getToolsetRegistry()
-        self.assertEqual( len( toolset_registry.listForbiddenTools() ), 0 )
-        self.assertEqual( len( toolset_registry.listRequiredTools() ), 0 )
+        self.assertEqual(len(toolset_registry.listForbiddenTools()), 0)
+        self.assertEqual(len(toolset_registry.listRequiredTools()), 0)
 
-    def test_getBaselineContextID( self ):
+    def test_getBaselineContextID(self):
         from Products.GenericSetup.tool import EXPORT_STEPS_XML
         from Products.GenericSetup.tool import IMPORT_STEPS_XML
         from Products.GenericSetup.tool import TOOLSET_XML
@@ -156,27 +160,23 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         profile_registry.registerProfile('foo', 'Foo', '', self._PROFILE_PATH)
         tool.setBaselineContext('profile-other:foo')
 
-        self.assertEqual( tool.getBaselineContextID(), 'profile-other:foo' )
+        self.assertEqual(tool.getBaselineContextID(), 'profile-other:foo')
 
-    def test_setBaselineContext_invalid( self ):
-
-        tool = self._makeOne('setup_tool')
-
-        self.assertRaises( KeyError
-                         , tool.setBaselineContext
-                         , 'profile-foo'
-                         )
-
-    def test_setBaselineContext_empty_string( self ):
+    def test_setBaselineContext_invalid(self):
 
         tool = self._makeOne('setup_tool')
 
-        self.assertRaises( KeyError
-                         , tool.setBaselineContext
-                         , ''
-                         )
+        self.assertRaises(KeyError, tool.setBaselineContext, 'profile-foo'
+                          )
 
-    def test_setBaselineContext( self ):
+    def test_setBaselineContext_empty_string(self):
+
+        tool = self._makeOne('setup_tool')
+
+        self.assertRaises(KeyError, tool.setBaselineContext, ''
+                          )
+
+    def test_setBaselineContext(self):
         from Products.GenericSetup.tool import EXPORT_STEPS_XML
         from Products.GenericSetup.tool import IMPORT_STEPS_XML
         from Products.GenericSetup.tool import TOOLSET_XML
@@ -191,70 +191,69 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         profile_registry.registerProfile('foo', 'Foo', '', self._PROFILE_PATH)
         tool.setBaselineContext('profile-other:foo')
 
-        self.assertEqual( tool.getBaselineContextID(), 'profile-other:foo' )
+        self.assertEqual(tool.getBaselineContextID(), 'profile-other:foo')
 
         import_registry = tool.getImportStepRegistry()
-        self.assertEqual( len( import_registry.listSteps() ), 1 )
-        self.failUnless( 'one' in import_registry.listSteps() )
-        info = import_registry.getStepMetadata( 'one' )
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'title' ], 'One Step' )
-        self.assertEqual( info[ 'version' ], '1' )
-        self.failUnless( 'One small step' in info[ 'description' ] )
-        self.assertEqual( info[ 'handler' ]
-                        , 'Products.GenericSetup.tests.test_registry.ONE_FUNC')
+        self.assertEqual(len(import_registry.listSteps()), 1)
+        self.failUnless('one' in import_registry.listSteps())
+        info = import_registry.getStepMetadata('one')
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['title'], 'One Step')
+        self.assertEqual(info['version'], '1')
+        self.failUnless('One small step' in info['description'])
+        self.assertEqual(
+            info['handler'], 'Products.GenericSetup.tests.test_registry.ONE_FUNC')
 
-        self.assertEqual( import_registry.getStep( 'one' ), ONE_FUNC )
+        self.assertEqual(import_registry.getStep('one'), ONE_FUNC)
 
         export_registry = tool.getExportStepRegistry()
-        self.assertEqual( len( export_registry.listSteps() ), 1 )
-        self.failUnless( 'one' in import_registry.listSteps() )
-        info = export_registry.getStepMetadata( 'one' )
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'title' ], 'One Step' )
-        self.failUnless( 'One small step' in info[ 'description' ] )
-        self.assertEqual( info[ 'handler' ]
-                        , 'Products.GenericSetup.tests.test_registry.ONE_FUNC')
+        self.assertEqual(len(export_registry.listSteps()), 1)
+        self.failUnless('one' in import_registry.listSteps())
+        info = export_registry.getStepMetadata('one')
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['title'], 'One Step')
+        self.failUnless('One small step' in info['description'])
+        self.assertEqual(
+            info['handler'], 'Products.GenericSetup.tests.test_registry.ONE_FUNC')
 
-        self.assertEqual( export_registry.getStep( 'one' ), ONE_FUNC )
+        self.assertEqual(export_registry.getStep('one'), ONE_FUNC)
 
     def test_runImportStepFromProfile_nonesuch(self):
 
         site = self._makeSite()
 
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
-        self.assertRaises( KeyError, tool.runImportStepFromProfile,
-                           '', 'nonesuch' )
+        self.assertRaises(KeyError, tool.runImportStepFromProfile,
+                          '', 'nonesuch')
 
     def test_runImportStepFromProfile_simple(self):
 
         TITLE = 'original title'
-        site = self._makeSite( TITLE )
+        site = self._makeSite(TITLE)
 
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'simple', '1', _uppercaseSiteTitle )
+        registry.registerStep('simple', '1', _uppercaseSiteTitle)
 
-        result = tool.runImportStepFromProfile( 'snapshot-dummy', 'simple' )
+        result = tool.runImportStepFromProfile('snapshot-dummy', 'simple')
 
-        self.assertEqual( len( result[ 'steps' ] ), 1 )
+        self.assertEqual(len(result['steps']), 1)
 
-        self.assertEqual( result[ 'steps' ][ 0 ], 'simple' )
-        self.assertEqual( result[ 'messages' ][ 'simple' ]
-                        , 'Uppercased title' )
+        self.assertEqual(result['steps'][0], 'simple')
+        self.assertEqual(result['messages']['simple'], 'Uppercased title')
 
-        self.assertEqual( site.title, TITLE.upper() )
+        self.assertEqual(site.title, TITLE.upper())
 
         global _before_import_events
-        self.assertEqual( len(_before_import_events), 1)
+        self.assertEqual(len(_before_import_events), 1)
         self.assertEqual(_before_import_events[0].profile_id, 'snapshot-dummy')
         self.assertEqual(_before_import_events[0].steps, ['simple'])
         self.assertEqual(_before_import_events[0].full_import, False)
 
         global _after_import_events
-        self.assertEqual( len(_after_import_events), 1)
+        self.assertEqual(len(_after_import_events), 1)
         self.assertEqual(_after_import_events[0].profile_id, 'snapshot-dummy')
         self.assertEqual(_after_import_events[0].steps, ['simple'])
         self.assertEqual(_after_import_events[0].full_import, False)
@@ -262,37 +261,35 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
     def test_runImportStepFromProfile_dependencies(self):
 
         TITLE = 'original title'
-        site = self._makeSite( TITLE )
+        site = self._makeSite(TITLE)
 
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'dependable', '1', _underscoreSiteTitle )
-        registry.registerStep( 'dependent', '1'
-                             , _uppercaseSiteTitle, ( 'dependable', ) )
+        registry.registerStep('dependable', '1', _underscoreSiteTitle)
+        registry.registerStep(
+            'dependent', '1', _uppercaseSiteTitle, ('dependable', ))
 
-        result = tool.runImportStepFromProfile( 'snapshot-dummy', 'dependent' )
+        result = tool.runImportStepFromProfile('snapshot-dummy', 'dependent')
 
-        self.assertEqual( len( result[ 'steps' ] ), 2 )
+        self.assertEqual(len(result['steps']), 2)
 
-        self.assertEqual( result[ 'steps' ][ 0 ], 'dependable' )
-        self.assertEqual( result[ 'messages' ][ 'dependable' ]
-                        , 'Underscored title' )
+        self.assertEqual(result['steps'][0], 'dependable')
+        self.assertEqual(result['messages']['dependable'], 'Underscored title')
 
-        self.assertEqual( result[ 'steps' ][ 1 ], 'dependent' )
-        self.assertEqual( result[ 'messages' ][ 'dependent' ]
-                        , 'Uppercased title' )
-        self.assertEqual( site.title, TITLE.replace( ' ', '_' ).upper() )
+        self.assertEqual(result['steps'][1], 'dependent')
+        self.assertEqual(result['messages']['dependent'], 'Uppercased title')
+        self.assertEqual(site.title, TITLE.replace(' ', '_').upper())
 
         global _before_import_events
-        self.assertEqual( len(_before_import_events), 1)
+        self.assertEqual(len(_before_import_events), 1)
         self.assertEqual(_before_import_events[0].profile_id, 'snapshot-dummy')
         self.assertEqual(_before_import_events[0].steps,
                          ['dependable', 'dependent'])
         self.assertEqual(_before_import_events[0].full_import, False)
 
         global _after_import_events
-        self.assertEqual( len(_after_import_events), 1)
+        self.assertEqual(len(_after_import_events), 1)
         self.assertEqual(_after_import_events[0].profile_id, 'snapshot-dummy')
         self.assertEqual(_after_import_events[0].steps,
                          ['dependable', 'dependent'])
@@ -301,34 +298,33 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
     def test_runImportStepFromProfile_skip_dependencies(self):
 
         TITLE = 'original title'
-        site = self._makeSite( TITLE )
+        site = self._makeSite(TITLE)
 
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'dependable', '1', _underscoreSiteTitle )
-        registry.registerStep( 'dependent', '1'
-                             , _uppercaseSiteTitle, ( 'dependable', ) )
+        registry.registerStep('dependable', '1', _underscoreSiteTitle)
+        registry.registerStep(
+            'dependent', '1', _uppercaseSiteTitle, ('dependable', ))
 
-        result = tool.runImportStepFromProfile( 'snapshot-dummy', 'dependent',
-                                                run_dependencies=False )
+        result = tool.runImportStepFromProfile('snapshot-dummy', 'dependent',
+                                               run_dependencies=False)
 
-        self.assertEqual( len( result[ 'steps' ] ), 1 )
+        self.assertEqual(len(result['steps']), 1)
 
-        self.assertEqual( result[ 'steps' ][ 0 ], 'dependent' )
-        self.assertEqual( result[ 'messages' ][ 'dependent' ]
-                        , 'Uppercased title' )
+        self.assertEqual(result['steps'][0], 'dependent')
+        self.assertEqual(result['messages']['dependent'], 'Uppercased title')
 
-        self.assertEqual( site.title, TITLE.upper() )
+        self.assertEqual(site.title, TITLE.upper())
 
         global _before_import_events
-        self.assertEqual( len(_before_import_events), 1)
+        self.assertEqual(len(_before_import_events), 1)
         self.assertEqual(_before_import_events[0].profile_id, 'snapshot-dummy')
         self.assertEqual(_before_import_events[0].steps, ['dependent'])
         self.assertEqual(_before_import_events[0].full_import, False)
 
         global _after_import_events
-        self.assertEqual( len(_after_import_events), 1)
+        self.assertEqual(len(_after_import_events), 1)
         self.assertEqual(_after_import_events[0].profile_id, 'snapshot-dummy')
         self.assertEqual(_after_import_events[0].steps, ['dependent'])
         self.assertEqual(_after_import_events[0].full_import, False)
@@ -337,72 +333,72 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
 
         site = self._makeSite()
 
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'purging', '1', _purgeIfRequired )
+        registry.registerStep('purging', '1', _purgeIfRequired)
 
-        result = tool.runImportStepFromProfile( 'snapshot-dummy', 'purging' )
+        result = tool.runImportStepFromProfile('snapshot-dummy', 'purging')
 
-        self.assertEqual( len( result[ 'steps' ] ), 1 )
-        self.assertEqual( result[ 'steps' ][ 0 ], 'purging' )
-        self.assertEqual( result[ 'messages' ][ 'purging' ], 'Purged' )
-        self.failUnless( site.purged )
+        self.assertEqual(len(result['steps']), 1)
+        self.assertEqual(result['steps'][0], 'purging')
+        self.assertEqual(result['messages']['purging'], 'Purged')
+        self.failUnless(site.purged)
 
     def test_runImportStepFromProfile_explicit_purge(self):
 
         site = self._makeSite()
 
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'purging', '1', _purgeIfRequired )
+        registry.registerStep('purging', '1', _purgeIfRequired)
 
-        result = tool.runImportStepFromProfile( 'snapshot-dummy', 'purging',
-                                                purge_old=True )
+        result = tool.runImportStepFromProfile('snapshot-dummy', 'purging',
+                                               purge_old=True)
 
-        self.assertEqual( len( result[ 'steps' ] ), 1 )
-        self.assertEqual( result[ 'steps' ][ 0 ], 'purging' )
-        self.assertEqual( result[ 'messages' ][ 'purging' ], 'Purged' )
-        self.failUnless( site.purged )
+        self.assertEqual(len(result['steps']), 1)
+        self.assertEqual(result['steps'][0], 'purging')
+        self.assertEqual(result['messages']['purging'], 'Purged')
+        self.failUnless(site.purged)
 
     def test_runImportStepFromProfile_skip_purge(self):
 
         site = self._makeSite()
 
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'purging', '1', _purgeIfRequired )
+        registry.registerStep('purging', '1', _purgeIfRequired)
 
-        result = tool.runImportStepFromProfile( 'snapshot-dummy', 'purging',
-                                                purge_old=False )
+        result = tool.runImportStepFromProfile('snapshot-dummy', 'purging',
+                                               purge_old=False)
 
-        self.assertEqual( len( result[ 'steps' ] ), 1 )
-        self.assertEqual( result[ 'steps' ][ 0 ], 'purging' )
-        self.assertEqual( result[ 'messages' ][ 'purging' ], 'Unpurged' )
-        self.failIf( site.purged )
+        self.assertEqual(len(result['steps']), 1)
+        self.assertEqual(result['steps'][0], 'purging')
+        self.assertEqual(result['messages']['purging'], 'Unpurged')
+        self.failIf(site.purged)
 
     def test_runImportStepFromProfile_consistent_context(self):
 
         site = self._makeSite()
 
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'purging', '1', _purgeIfRequired )
-        registry.registerStep( 'dependent', '1'
-                             , _uppercaseSiteTitle, ( 'purging', ) )
+        registry.registerStep('purging', '1', _purgeIfRequired)
+        registry.registerStep(
+            'dependent', '1', _uppercaseSiteTitle, ('purging', ))
 
         tool.runImportStepFromProfile('snapshot-dummy', 'dependent',
                                       purge_old=False)
-        self.failIf( site.purged )
+        self.failIf(site.purged)
 
     def test_runAllImportStepsFromProfile_empty(self):
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         result = tool.runAllImportStepsFromProfile('snapshot-dummy')
 
-        self.assertEqual( len(result['steps']), 3 )
+        self.assertEqual(len(result['steps']), 3)
 
     def test_runAllImportStepsFromProfile_inquicksuccession(self):
         """
@@ -412,7 +408,7 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         """
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         tool.runAllImportStepsFromProfile('snapshot-dummy')
         tool.runAllImportStepsFromProfile('snapshot-dummy')
@@ -425,36 +421,32 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
 
         TITLE = 'original title'
         PROFILE_ID = 'snapshot-testing'
-        site = self._makeSite( TITLE )
-        tool = self._makeOne('setup_tool').__of__( site )
+        site = self._makeSite(TITLE)
+        tool = self._makeOne('setup_tool').__of__(site)
         tool._exclude_global_steps = True
 
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'dependable', '1'
-                             , _underscoreSiteTitle, ( 'purging', ) )
-        registry.registerStep( 'dependent', '1'
-                             , _uppercaseSiteTitle, ( 'dependable', ) )
-        registry.registerStep( 'purging', '1'
-                             , _purgeIfRequired )
+        registry.registerStep(
+            'dependable', '1', _underscoreSiteTitle, ('purging', ))
+        registry.registerStep(
+            'dependent', '1', _uppercaseSiteTitle, ('dependable', ))
+        registry.registerStep('purging', '1', _purgeIfRequired)
 
         result = tool.runAllImportStepsFromProfile(PROFILE_ID)
 
-        self.assertEqual( len(result['steps']), 3 )
+        self.assertEqual(len(result['steps']), 3)
 
-        self.assertEqual( result['steps'][0], 'purging' )
-        self.assertEqual( result[ 'messages' ][ 'purging' ]
-                        , 'Purged' )
+        self.assertEqual(result['steps'][0], 'purging')
+        self.assertEqual(result['messages']['purging'], 'Purged')
 
-        self.assertEqual( result['steps'][1], 'dependable' )
-        self.assertEqual( result[ 'messages' ][ 'dependable' ]
-                        , 'Underscored title' )
+        self.assertEqual(result['steps'][1], 'dependable')
+        self.assertEqual(result['messages']['dependable'], 'Underscored title')
 
-        self.assertEqual( result['steps'][2], 'dependent' )
-        self.assertEqual( result[ 'messages' ][ 'dependent' ]
-                        , 'Uppercased title' )
+        self.assertEqual(result['steps'][2], 'dependent')
+        self.assertEqual(result['messages']['dependent'], 'Uppercased title')
 
-        self.assertEqual( site.title, TITLE.replace( ' ', '_' ).upper() )
-        self.failUnless( site.purged )
+        self.assertEqual(site.title, TITLE.replace(' ', '_').upper())
+        self.failUnless(site.purged)
 
         prefix = 'import-all-%s' % PROFILE_ID
         logged = [x for x in tool.objectIds('File') if x.startswith(prefix)]
@@ -464,16 +456,15 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
 
         TITLE = 'original title'
         PROFILE_ID = u'snapshot-testing'
-        site = self._makeSite( TITLE )
-        tool = self._makeOne('setup_tool').__of__( site )
+        site = self._makeSite(TITLE)
+        tool = self._makeOne('setup_tool').__of__(site)
 
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'dependable', '1'
-                             , _underscoreSiteTitle, ( 'purging', ) )
-        registry.registerStep( 'dependent', '1'
-                             , _uppercaseSiteTitle, ( 'dependable', ) )
-        registry.registerStep( 'purging', '1'
-                             , _purgeIfRequired )
+        registry.registerStep(
+            'dependable', '1', _underscoreSiteTitle, ('purging', ))
+        registry.registerStep(
+            'dependent', '1', _uppercaseSiteTitle, ('dependable', ))
+        registry.registerStep('purging', '1', _purgeIfRequired)
 
         tool.runAllImportStepsFromProfile(PROFILE_ID)
 
@@ -484,56 +475,52 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
     def test_runAllImportStepsFromProfile_sorted_explicit_purge(self):
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
         tool._exclude_global_steps = True
 
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'dependable', '1'
-                             , _underscoreSiteTitle, ( 'purging', ) )
-        registry.registerStep( 'dependent', '1'
-                             , _uppercaseSiteTitle, ( 'dependable', ) )
-        registry.registerStep( 'purging', '1'
-                             , _purgeIfRequired )
+        registry.registerStep(
+            'dependable', '1', _underscoreSiteTitle, ('purging', ))
+        registry.registerStep(
+            'dependent', '1', _uppercaseSiteTitle, ('dependable', ))
+        registry.registerStep('purging', '1', _purgeIfRequired)
 
         result = tool.runAllImportStepsFromProfile('snapshot-dummy',
-                                                   purge_old=True )
+                                                   purge_old=True)
 
-        self.assertEqual( len(result['steps']), 3 )
+        self.assertEqual(len(result['steps']), 3)
 
-        self.assertEqual( result['steps'][0], 'purging' )
-        self.assertEqual( result[ 'messages' ][ 'purging' ]
-                        , 'Purged' )
+        self.assertEqual(result['steps'][0], 'purging')
+        self.assertEqual(result['messages']['purging'], 'Purged')
 
-        self.assertEqual( result['steps'][1], 'dependable' )
-        self.assertEqual( result['steps'][2], 'dependent' )
-        self.failUnless( site.purged )
+        self.assertEqual(result['steps'][1], 'dependable')
+        self.assertEqual(result['steps'][2], 'dependent')
+        self.failUnless(site.purged)
 
     def test_runAllImportStepsFromProfile_sorted_skip_purge(self):
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
         tool._exclude_global_steps = True
 
         registry = tool.getImportStepRegistry()
-        registry.registerStep( 'dependable', '1'
-                             , _underscoreSiteTitle, ( 'purging', ) )
-        registry.registerStep( 'dependent', '1'
-                             , _uppercaseSiteTitle, ( 'dependable', ) )
-        registry.registerStep( 'purging', '1'
-                             , _purgeIfRequired )
+        registry.registerStep(
+            'dependable', '1', _underscoreSiteTitle, ('purging', ))
+        registry.registerStep(
+            'dependent', '1', _uppercaseSiteTitle, ('dependable', ))
+        registry.registerStep('purging', '1', _purgeIfRequired)
 
         result = tool.runAllImportStepsFromProfile('snapshot-dummy',
-                                                   purge_old=False )
+                                                   purge_old=False)
 
-        self.assertEqual( len(result['steps']), 3 )
+        self.assertEqual(len(result['steps']), 3)
 
-        self.assertEqual( result['steps'][0], 'purging' )
-        self.assertEqual( result[ 'messages' ][ 'purging' ]
-                        , 'Unpurged' )
+        self.assertEqual(result['steps'][0], 'purging')
+        self.assertEqual(result['messages']['purging'], 'Unpurged')
 
-        self.assertEqual( result['steps'][1], 'dependable' )
-        self.assertEqual( result['steps'][2], 'dependent' )
-        self.failIf( site.purged )
+        self.assertEqual(result['steps'][1], 'dependable')
+        self.assertEqual(result['steps'][2], 'dependent')
+        self.failIf(site.purged)
 
     def test_runAllImportStepsFromProfile_without_depends(self):
         from Products.GenericSetup.metadata import METADATA_XML
@@ -541,15 +528,16 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self._makeFile(METADATA_XML, _METADATA_XML)
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         profile_registry.registerProfile('foo', 'Foo', '', self._PROFILE_PATH)
 
         _imported = []
+
         def applyContext(context):
             _imported.append(context._profile_path)
 
-        tool.applyContext=applyContext
+        tool.applyContext = applyContext
         tool.runAllImportStepsFromProfile('profile-other:foo',
                                           ignore_dependencies=True)
         self.assertEqual(_imported, [self._PROFILE_PATH])
@@ -560,16 +548,17 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self._makeFile(METADATA_XML, _METADATA_XML)
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         profile_registry.registerProfile('foo', 'Foo', '', self._PROFILE_PATH)
         profile_registry.registerProfile('bar', 'Bar', '', self._PROFILE_PATH2)
 
         _imported = []
+
         def applyContext(context):
             _imported.append(context._profile_path)
 
-        tool.applyContext=applyContext
+        tool.applyContext = applyContext
         tool.runAllImportStepsFromProfile('profile-other:foo',
                                           ignore_dependencies=False)
         self.assertEqual(_imported, [self._PROFILE_PATH2, self._PROFILE_PATH])
@@ -705,7 +694,7 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self._makeFile(METADATA_XML, _METADATA_XML)
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         profile_registry.registerProfile('foo', 'Foo', '', self._PROFILE_PATH)
 
@@ -741,7 +730,7 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self._makeFile('import_steps.xml', _IMPORT_STEPS_XML)
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         profile_registry.registerProfile('foo', 'Foo', '', self._PROFILE_PATH)
         profile_registry.registerProfile('bar', 'Bar', '', self._PROFILE_PATH2)
@@ -755,33 +744,32 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
     def test_runAllImportStepsFromProfile_skipStep(self):
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
         result = tool.runAllImportStepsFromProfile(
             'snapshot-dummy',
             blacklisted_steps=['toolset']
         )
 
-        self.assertEqual( (result['messages']['toolset']), 'step skipped' )
+        self.assertEqual((result['messages']['toolset']), 'step skipped')
 
-    def test_runExportStep_nonesuch( self ):
+    def test_runExportStep_nonesuch(self):
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
-        self.assertRaises( ValueError, tool.runExportStep, 'nonesuch' )
+        self.assertRaises(ValueError, tool.runExportStep, 'nonesuch')
 
     def test_runExportStep_step_registry_empty(self):
         site = self._makeSite()
         site.setup_tool = self._makeOne('setup_tool')
         tool = site.setup_tool
 
-        result = tool.runExportStep( 'step_registries' )
+        result = tool.runExportStep('step_registries')
 
-        self.assertEqual( len( result[ 'steps' ] ), 1 )
-        self.assertEqual( result[ 'steps' ][ 0 ], 'step_registries' )
-        self.assertEqual( result[ 'messages' ][ 'step_registries' ]
-                        , None
-                        )
+        self.assertEqual(len(result['steps']), 1)
+        self.assertEqual(result['steps'][0], 'step_registries')
+        self.assertEqual(result['messages']['step_registries'], None
+                         )
 
     def test_runExportStep_step_registry_default(self):
         site = self._makeSite()
@@ -789,25 +777,23 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         tool = site.setup_tool
         tool._import_registry.registerStep('foo', handler='foo.bar')
         tool._export_registry.registerStep('step_registries',
-                'Products.GenericSetup.tool.exportStepRegistries',
-                'Export import / export steps.')
+                                           'Products.GenericSetup.tool.exportStepRegistries',
+                                           'Export import / export steps.')
 
-        result = tool.runExportStep( 'step_registries' )
+        result = tool.runExportStep('step_registries')
 
-        self.assertEqual( len( result[ 'steps' ] ), 1 )
-        self.assertEqual( result[ 'steps' ][ 0 ], 'step_registries' )
-        self.assertEqual( result[ 'messages' ][ 'step_registries' ]
-                        , None
-                        )
-        fileish = StringIO( result[ 'tarball' ] )
+        self.assertEqual(len(result['steps']), 1)
+        self.assertEqual(result['steps'][0], 'step_registries')
+        self.assertEqual(result['messages']['step_registries'], None
+                         )
+        fileish = StringIO(result['tarball'])
 
-        self._verifyTarballContents( fileish, [ 'import_steps.xml'
-                                              , 'export_steps.xml'
-                                              ] )
-        self._verifyTarballEntryXML( fileish, 'import_steps.xml'
-                                   , _DEFAULT_STEP_REGISTRIES_IMPORT_XML )
-        self._verifyTarballEntryXML( fileish, 'export_steps.xml'
-                                   , _DEFAULT_STEP_REGISTRIES_EXPORT_XML )
+        self._verifyTarballContents(fileish, ['import_steps.xml', 'export_steps.xml'
+                                              ])
+        self._verifyTarballEntryXML(
+            fileish, 'import_steps.xml', _DEFAULT_STEP_REGISTRIES_IMPORT_XML)
+        self._verifyTarballEntryXML(
+            fileish, 'export_steps.xml', _DEFAULT_STEP_REGISTRIES_EXPORT_XML)
 
     def test_runAllExportSteps_empty(self):
         site = self._makeSite()
@@ -816,11 +802,10 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
 
         result = tool.runAllExportSteps()
 
-        self.assertEqual( len(result['steps'] ), 4 )
-        self.assertEqual( result['steps'][1], 'step_registries' )
-        self.assertEqual( result[ 'messages' ][ 'step_registries' ]
-                        , None
-                        )
+        self.assertEqual(len(result['steps']), 4)
+        self.assertEqual(result['steps'][1], 'step_registries')
+        self.assertEqual(result['messages']['step_registries'], None
+                         )
 
     def test_runAllExportSteps_default(self):
         site = self._makeSite()
@@ -828,78 +813,66 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         tool = site.setup_tool
         tool._import_registry.registerStep('foo', handler='foo.bar')
         tool._export_registry.registerStep('step_registries',
-                'Products.GenericSetup.tool.exportStepRegistries',
-                'Export import / export steps.')
+                                           'Products.GenericSetup.tool.exportStepRegistries',
+                                           'Export import / export steps.')
 
         result = tool.runAllExportSteps()
 
-        self.assertEqual( len(result['steps']), 4 )
-        self.assertEqual( result['steps'][1], 'step_registries' )
-        self.assertEqual( result[ 'messages' ][ 'step_registries' ]
-                        , None
-                        )
-        fileish = StringIO( result[ 'tarball' ] )
+        self.assertEqual(len(result['steps']), 4)
+        self.assertEqual(result['steps'][1], 'step_registries')
+        self.assertEqual(result['messages']['step_registries'], None
+                         )
+        fileish = StringIO(result['tarball'])
 
-        self._verifyTarballContents( fileish, [ 'import_steps.xml'
-                                              , 'export_steps.xml'
-                                              , 'rolemap.xml'
-                                              , 'toolset.xml'
-                                              ] )
-        self._verifyTarballEntryXML( fileish, 'import_steps.xml'
-                                   , _DEFAULT_STEP_REGISTRIES_IMPORT_XML )
-        self._verifyTarballEntryXML( fileish, 'export_steps.xml'
-                                   , _DEFAULT_STEP_REGISTRIES_EXPORT_XML )
+        self._verifyTarballContents(fileish, ['import_steps.xml', 'export_steps.xml', 'rolemap.xml', 'toolset.xml'
+                                              ])
+        self._verifyTarballEntryXML(
+            fileish, 'import_steps.xml', _DEFAULT_STEP_REGISTRIES_IMPORT_XML)
+        self._verifyTarballEntryXML(
+            fileish, 'export_steps.xml', _DEFAULT_STEP_REGISTRIES_EXPORT_XML)
 
-    def test_runAllExportSteps_extras( self ):
+    def test_runAllExportSteps_extras(self):
         site = self._makeSite()
         site.setup_tool = self._makeOne('setup_tool')
         tool = site.setup_tool
         tool._export_registry.registerStep('step_registries',
-                'Products.GenericSetup.tool.exportStepRegistries',
-                'Export import / export steps.')
+                                           'Products.GenericSetup.tool.exportStepRegistries',
+                                           'Export import / export steps.')
 
         import_reg = tool.getImportStepRegistry()
-        import_reg.registerStep( 'dependable', '1'
-                               , _underscoreSiteTitle, ( 'purging', ) )
-        import_reg.registerStep( 'dependent', '1'
-                               , _uppercaseSiteTitle, ( 'dependable', ) )
-        import_reg.registerStep( 'purging', '1'
-                               , _purgeIfRequired )
+        import_reg.registerStep(
+            'dependable', '1', _underscoreSiteTitle, ('purging', ))
+        import_reg.registerStep(
+            'dependent', '1', _uppercaseSiteTitle, ('dependable', ))
+        import_reg.registerStep('purging', '1', _purgeIfRequired)
 
         export_reg = tool.getExportStepRegistry()
-        export_reg.registerStep( 'properties'
-                               , _exportPropertiesINI )
+        export_reg.registerStep('properties', _exportPropertiesINI)
 
         result = tool.runAllExportSteps()
 
-        self.assertEqual( len(result['steps']), 5 )
+        self.assertEqual(len(result['steps']), 5)
 
-        self.failUnless( 'properties' in result[ 'steps' ] )
-        self.assertEqual( result[ 'messages' ][ 'properties' ]
-                        , 'Exported properties'
-                        )
+        self.failUnless('properties' in result['steps'])
+        self.assertEqual(result['messages']['properties'], 'Exported properties'
+                         )
 
-        self.failUnless( 'step_registries' in result[ 'steps' ] )
-        self.assertEqual( result[ 'messages' ][ 'step_registries' ]
-                        , None
-                        )
+        self.failUnless('step_registries' in result['steps'])
+        self.assertEqual(result['messages']['step_registries'], None
+                         )
 
-        fileish = StringIO( result[ 'tarball' ] )
+        fileish = StringIO(result['tarball'])
 
-        self._verifyTarballContents( fileish, [ 'import_steps.xml'
-                                              , 'export_steps.xml'
-                                              , 'properties.ini'
-                                              , 'rolemap.xml'
-                                              , 'toolset.xml'
-                                              ] )
-        self._verifyTarballEntryXML( fileish, 'import_steps.xml'
-                                   , _EXTRAS_STEP_REGISTRIES_IMPORT_XML )
-        self._verifyTarballEntryXML( fileish, 'export_steps.xml'
-                                   , _EXTRAS_STEP_REGISTRIES_EXPORT_XML )
-        self._verifyTarballEntry( fileish, 'properties.ini'
-                                , _PROPERTIES_INI % site.title  )
+        self._verifyTarballContents(fileish, ['import_steps.xml', 'export_steps.xml', 'properties.ini', 'rolemap.xml', 'toolset.xml'
+                                              ])
+        self._verifyTarballEntryXML(
+            fileish, 'import_steps.xml', _EXTRAS_STEP_REGISTRIES_IMPORT_XML)
+        self._verifyTarballEntryXML(
+            fileish, 'export_steps.xml', _EXTRAS_STEP_REGISTRIES_EXPORT_XML)
+        self._verifyTarballEntry(
+            fileish, 'properties.ini', _PROPERTIES_INI % site.title)
 
-    def test_createSnapshot_default( self ):
+    def test_createSnapshot_default(self):
         _EXPECTED = [('import_steps.xml', _DEFAULT_STEP_REGISTRIES_IMPORT_XML),
                      ('export_steps.xml', _DEFAULT_STEP_REGISTRIES_EXPORT_XML),
                      ('rolemap.xml', 'dummy'),
@@ -910,25 +883,24 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         tool = site.setup_tool
         tool._import_registry.registerStep('foo', handler='foo.bar')
         tool._export_registry.registerStep('step_registries',
-                'Products.GenericSetup.tool.exportStepRegistries',
-                'Export import / export steps.')
+                                           'Products.GenericSetup.tool.exportStepRegistries',
+                                           'Export import / export steps.')
 
-        self.assertEqual( len( tool.listSnapshotInfo() ), 0 )
+        self.assertEqual(len(tool.listSnapshotInfo()), 0)
 
-        result = tool.createSnapshot( 'default' )
+        result = tool.createSnapshot('default')
 
-        self.assertEqual( len(result['steps']), 4 )
-        self.assertEqual( result['steps'][1], 'step_registries' )
-        self.assertEqual( result[ 'messages' ][ 'step_registries' ]
-                        , None
-                        )
+        self.assertEqual(len(result['steps']), 4)
+        self.assertEqual(result['steps'][1], 'step_registries')
+        self.assertEqual(result['messages']['step_registries'], None
+                         )
 
-        snapshot = result[ 'snapshot' ]
+        snapshot = result['snapshot']
 
-        self.assertEqual( len( snapshot.objectIds() ), len( _EXPECTED ) )
+        self.assertEqual(len(snapshot.objectIds()), len(_EXPECTED))
 
-        for id in [ x[0] for x in _EXPECTED ]:
-            self.failUnless( id in snapshot.objectIds() )
+        for id in [x[0] for x in _EXPECTED]:
+            self.failUnless(id in snapshot.objectIds())
 
         def normalize_xml(xml):
             # using this might mask a real problem on windows, but so far the
@@ -937,20 +909,20 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
                            [line.strip() for line in xml.splitlines() if line])
             return ' '.join(lines)
 
-        fileobj = snapshot._getOb( 'import_steps.xml' )
-        self.assertEqual( normalize_xml( fileobj.read() ),
-                          normalize_xml(_DEFAULT_STEP_REGISTRIES_IMPORT_XML))
+        fileobj = snapshot._getOb('import_steps.xml')
+        self.assertEqual(normalize_xml(fileobj.read()),
+                         normalize_xml(_DEFAULT_STEP_REGISTRIES_IMPORT_XML))
 
-        fileobj = snapshot._getOb( 'export_steps.xml' )
-        self.assertEqual( normalize_xml( fileobj.read() ),
-                          normalize_xml(_DEFAULT_STEP_REGISTRIES_EXPORT_XML ))
+        fileobj = snapshot._getOb('export_steps.xml')
+        self.assertEqual(normalize_xml(fileobj.read()),
+                         normalize_xml(_DEFAULT_STEP_REGISTRIES_EXPORT_XML))
 
-        self.assertEqual( len( tool.listSnapshotInfo() ), 1 )
+        self.assertEqual(len(tool.listSnapshotInfo()), 1)
 
-        info = tool.listSnapshotInfo()[ 0 ]
+        info = tool.listSnapshotInfo()[0]
 
-        self.assertEqual( info[ 'id' ], 'default' )
-        self.assertEqual( info[ 'title' ], 'default' )
+        self.assertEqual(info['id'], 'default')
+        self.assertEqual(info['title'], 'default')
 
     def test_applyContext(self):
         from Products.GenericSetup.tool import EXPORT_STEPS_XML
@@ -963,38 +935,38 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         tool.getExportStepRegistry().clear()
         tool.getToolsetRegistry().clear()
 
-        context = DummyImportContext( site, tool=tool )
-        context._files[ IMPORT_STEPS_XML ] = _SINGLE_IMPORT_XML
-        context._files[ EXPORT_STEPS_XML ] = _SINGLE_EXPORT_XML
-        context._files[ TOOLSET_XML ] = _NORMAL_TOOLSET_XML
+        context = DummyImportContext(site, tool=tool)
+        context._files[IMPORT_STEPS_XML] = _SINGLE_IMPORT_XML
+        context._files[EXPORT_STEPS_XML] = _SINGLE_EXPORT_XML
+        context._files[TOOLSET_XML] = _NORMAL_TOOLSET_XML
 
         tool.applyContext(context)
 
         import_registry = tool.getImportStepRegistry()
-        self.assertEqual( len( import_registry.listSteps() ), 1 )
-        self.failUnless( 'one' in import_registry.listSteps() )
-        info = import_registry.getStepMetadata( 'one' )
+        self.assertEqual(len(import_registry.listSteps()), 1)
+        self.failUnless('one' in import_registry.listSteps())
+        info = import_registry.getStepMetadata('one')
 
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'title' ], 'One Step' )
-        self.assertEqual( info[ 'version' ], '1' )
-        self.failUnless( 'One small step' in info[ 'description' ] )
-        self.assertEqual(info[ 'handler' ],
-                         'Products.GenericSetup.tests.test_registry.ONE_FUNC' )
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['title'], 'One Step')
+        self.assertEqual(info['version'], '1')
+        self.failUnless('One small step' in info['description'])
+        self.assertEqual(info['handler'],
+                         'Products.GenericSetup.tests.test_registry.ONE_FUNC')
 
-        self.assertEqual( import_registry.getStep( 'one' ), ONE_FUNC )
+        self.assertEqual(import_registry.getStep('one'), ONE_FUNC)
 
         export_registry = tool.getExportStepRegistry()
-        self.assertEqual( len( export_registry.listSteps() ), 1 )
-        self.failUnless( 'one' in import_registry.listSteps() )
-        info = export_registry.getStepMetadata( 'one' )
-        self.assertEqual( info[ 'id' ], 'one' )
-        self.assertEqual( info[ 'title' ], 'One Step' )
-        self.failUnless( 'One small step' in info[ 'description' ] )
-        self.assertEqual(info[ 'handler' ],
-                         'Products.GenericSetup.tests.test_registry.ONE_FUNC' )
+        self.assertEqual(len(export_registry.listSteps()), 1)
+        self.failUnless('one' in import_registry.listSteps())
+        info = export_registry.getStepMetadata('one')
+        self.assertEqual(info['id'], 'one')
+        self.assertEqual(info['title'], 'One Step')
+        self.failUnless('One small step' in info['description'])
+        self.assertEqual(info['handler'],
+                         'Products.GenericSetup.tests.test_registry.ONE_FUNC')
 
-        self.assertEqual( export_registry.getStep( 'one' ), ONE_FUNC )
+        self.assertEqual(export_registry.getStep('one'), ONE_FUNC)
 
     def test_listContextInfos_empty(self):
         site = self._makeSite()
@@ -1135,13 +1107,16 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self.assertEqual(tool._profile_upgrade_versions, {})
         # Any 'profile-' is stripped off in these calls.
         self.assertEqual(tool.getLastVersionForProfile('foo'), 'unknown')
-        self.assertEqual(tool.getLastVersionForProfile('profile-foo'), 'unknown')
+        self.assertEqual(tool.getLastVersionForProfile(
+            'profile-foo'), 'unknown')
         tool.setLastVersionForProfile('foo', '1.0')
         self.assertEqual(tool.getLastVersionForProfile('foo'), ('1', '0'))
-        self.assertEqual(tool.getLastVersionForProfile('profile-foo'), ('1', '0'))
+        self.assertEqual(tool.getLastVersionForProfile(
+            'profile-foo'), ('1', '0'))
         tool.setLastVersionForProfile('profile-foo', '2.0')
         self.assertEqual(tool.getLastVersionForProfile('foo'), ('2', '0'))
-        self.assertEqual(tool.getLastVersionForProfile('profile-foo'), ('2', '0'))
+        self.assertEqual(tool.getLastVersionForProfile(
+            'profile-foo'), ('2', '0'))
 
     def test_manage_doUpgrades_no_profile_id_or_updates(self):
         site = self._makeSite()
@@ -1152,7 +1127,7 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
 
     def test_manage_doUpgrades_upgrade_w_no_target_version(self):
         step = UpgradeStep('TITLE', 'foo', '*', '*', 'DESC',
-                            lambda tool: None)
+                           lambda tool: None)
         _registerUpgradeStep(step)
         site = self._makeSite()
         site.setup_tool = self._makeOne('setup_tool')
@@ -1270,10 +1245,10 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self._makeFile(METADATA_XML, _METADATA_XML)
 
         site = self._makeSite()
-        tool = self._makeOne('setup_tool').__of__( site )
+        tool = self._makeOne('setup_tool').__of__(site)
 
         profile_registry.registerProfile('foo', 'Foo', '', self._PROFILE_PATH,
-                                        for_=ISite)
+                                         for_=ISite)
         # tool.listProfileInfo should call registry.listProfileInfo
         # with the for_ parameter
         self.assertEqual(len(tool.listProfileInfo()), 1)
@@ -1355,43 +1330,46 @@ Title=%s
 """
 
 
-def _underscoreSiteTitle( context ):
+def _underscoreSiteTitle(context):
 
     site = context.getSite()
-    site.title = site.title.replace( ' ', '_' )
+    site.title = site.title.replace(' ', '_')
     return 'Underscored title'
 
-def _uppercaseSiteTitle( context ):
+
+def _uppercaseSiteTitle(context):
 
     site = context.getSite()
     site.title = site.title.upper()
     return 'Uppercased title'
 
-def _purgeIfRequired( context ):
+
+def _purgeIfRequired(context):
 
     site = context.getSite()
     purged = site.purged = context.shouldPurge()
     return purged and 'Purged' or 'Unpurged'
 
-def _exportPropertiesINI( context ):
+
+def _exportPropertiesINI(context):
 
     site = context.getSite()
     text = _PROPERTIES_INI % site.title
 
-    context.writeDataFile( 'properties.ini', text, 'text/plain' )
+    context.writeDataFile('properties.ini', text, 'text/plain')
 
     return 'Exported properties'
 
 
 class _ToolsetSetup(BaseRegistryTests):
 
-    def _initSite( self ):
+    def _initSite(self):
         from Products.GenericSetup.tool import SetupTool
 
         site = Folder()
-        site._setId( 'site' )
-        self.app._setObject( 'site', site )
-        site = self.app._getOb( 'site' )
+        site._setId('site')
+        self.app._setObject('site', site)
+        site = self.app._getOb('site')
         site._setObject('setup_tool', SetupTool('setup_tool'))
         return site
 
@@ -1400,40 +1378,40 @@ class Test_exportToolset(_ToolsetSetup):
 
     layer = ExportImportZCMLLayer
 
-    def test_empty( self ):
+    def test_empty(self):
         from Products.GenericSetup.tool import exportToolset
         from Products.GenericSetup.tool import TOOLSET_XML
 
         site = self._initSite()
-        context = DummyExportContext( site, tool=site.setup_tool )
+        context = DummyExportContext(site, tool=site.setup_tool)
 
-        exportToolset( context )
+        exportToolset(context)
 
-        self.assertEqual( len( context._wrote ), 1 )
-        filename, text, content_type = context._wrote[ 0 ]
-        self.assertEqual( filename, TOOLSET_XML )
-        self._compareDOM( text, _EMPTY_TOOLSET_XML )
-        self.assertEqual( content_type, 'text/xml' )
+        self.assertEqual(len(context._wrote), 1)
+        filename, text, content_type = context._wrote[0]
+        self.assertEqual(filename, TOOLSET_XML)
+        self._compareDOM(text, _EMPTY_TOOLSET_XML)
+        self.assertEqual(content_type, 'text/xml')
 
-    def test_normal( self ):
+    def test_normal(self):
         from Products.GenericSetup.tool import exportToolset
         from Products.GenericSetup.tool import TOOLSET_XML
 
         site = self._initSite()
         toolset = site.setup_tool.getToolsetRegistry()
-        toolset.addForbiddenTool( 'doomed' )
-        toolset.addRequiredTool( 'mandatory', 'path.to.one' )
-        toolset.addRequiredTool( 'obligatory', 'path.to.another' )
+        toolset.addForbiddenTool('doomed')
+        toolset.addRequiredTool('mandatory', 'path.to.one')
+        toolset.addRequiredTool('obligatory', 'path.to.another')
 
-        context = DummyExportContext( site, tool=site.setup_tool )
+        context = DummyExportContext(site, tool=site.setup_tool)
 
-        exportToolset( context )
+        exportToolset(context)
 
-        self.assertEqual( len( context._wrote ), 1 )
-        filename, text, content_type = context._wrote[ 0 ]
-        self.assertEqual( filename, TOOLSET_XML )
-        self._compareDOM( text, _NORMAL_TOOLSET_XML )
-        self.assertEqual( content_type, 'text/xml' )
+        self.assertEqual(len(context._wrote), 1)
+        filename, text, content_type = context._wrote[0]
+        self.assertEqual(filename, TOOLSET_XML)
+        self._compareDOM(text, _NORMAL_TOOLSET_XML)
+        self.assertEqual(content_type, 'text/xml')
 
 
 class Test_importToolset(_ToolsetSetup):
@@ -1445,35 +1423,35 @@ class Test_importToolset(_ToolsetSetup):
         from Products.GenericSetup.tool import TOOLSET_XML
 
         site = self._initSite()
-        context = DummyImportContext( site, tool=site.setup_tool )
+        context = DummyImportContext(site, tool=site.setup_tool)
 
         # Import forbidden
-        context._files[ TOOLSET_XML ] = _FORBIDDEN_TOOLSET_XML
-        importToolset( context )
+        context._files[TOOLSET_XML] = _FORBIDDEN_TOOLSET_XML
+        importToolset(context)
 
         tool = context.getSetupTool()
         toolset = tool.getToolsetRegistry()
 
-        self.assertEqual( len( toolset.listForbiddenTools() ), 3 )
-        self.failUnless( 'doomed' in toolset.listForbiddenTools() )
-        self.failUnless( 'damned' in toolset.listForbiddenTools() )
-        self.failUnless( 'blasted' in toolset.listForbiddenTools() )
+        self.assertEqual(len(toolset.listForbiddenTools()), 3)
+        self.failUnless('doomed' in toolset.listForbiddenTools())
+        self.failUnless('damned' in toolset.listForbiddenTools())
+        self.failUnless('blasted' in toolset.listForbiddenTools())
 
         # Import required
-        context._files[ TOOLSET_XML ] = _REQUIRED_TOOLSET_XML
-        importToolset( context )
+        context._files[TOOLSET_XML] = _REQUIRED_TOOLSET_XML
+        importToolset(context)
 
-        self.assertEqual( len( toolset.listRequiredTools() ), 2 )
-        self.failUnless( 'mandatory' in toolset.listRequiredTools() )
-        info = toolset.getRequiredToolInfo( 'mandatory' )
-        self.assertEqual( info[ 'class' ],
-                          'Products.GenericSetup.tests.test_tool.DummyTool' )
-        self.failUnless( 'obligatory' in toolset.listRequiredTools() )
-        info = toolset.getRequiredToolInfo( 'obligatory' )
-        self.assertEqual( info[ 'class' ],
-                          'Products.GenericSetup.tests.test_tool.DummyTool' )
+        self.assertEqual(len(toolset.listRequiredTools()), 2)
+        self.failUnless('mandatory' in toolset.listRequiredTools())
+        info = toolset.getRequiredToolInfo('mandatory')
+        self.assertEqual(info['class'],
+                         'Products.GenericSetup.tests.test_tool.DummyTool')
+        self.failUnless('obligatory' in toolset.listRequiredTools())
+        info = toolset.getRequiredToolInfo('obligatory')
+        self.assertEqual(info['class'],
+                         'Products.GenericSetup.tests.test_tool.DummyTool')
 
-    def test_tool_ids( self ):
+    def test_tool_ids(self):
         # The tool import mechanism used to rely on the fact that all tools
         # have unique IDs set at the class level and that you can call their
         # constructor with no arguments. However, there might be tools
@@ -1482,14 +1460,14 @@ class Test_importToolset(_ToolsetSetup):
         from Products.GenericSetup.tool import TOOLSET_XML
 
         site = self._initSite()
-        context = DummyImportContext( site, tool=site.setup_tool )
-        context._files[ TOOLSET_XML ] = _REQUIRED_TOOLSET_XML
+        context = DummyImportContext(site, tool=site.setup_tool)
+        context._files[TOOLSET_XML] = _REQUIRED_TOOLSET_XML
 
-        importToolset( context )
+        importToolset(context)
 
-        for tool_id in ( 'mandatory', 'obligatory' ):
-            tool = getattr( site, tool_id )
-            self.assertEqual( tool.getId(), tool_id )
+        for tool_id in ('mandatory', 'obligatory'):
+            tool = getattr(site, tool_id)
+            self.assertEqual(tool.getId(), tool_id)
 
     def test_tool_id_required(self):
         # Tests that tool creation will still work when an id is required
@@ -1507,108 +1485,108 @@ class Test_importToolset(_ToolsetSetup):
             tool = getattr(site, tool_id)
             self.assertEqual(tool.getId(), tool_id)
 
-    def test_forbidden_tools( self ):
+    def test_forbidden_tools(self):
         from Products.GenericSetup.tool import importToolset
         from Products.GenericSetup.tool import TOOLSET_XML
 
-        TOOL_IDS = ( 'doomed', 'blasted', 'saved' )
+        TOOL_IDS = ('doomed', 'blasted', 'saved')
 
         site = self._initSite()
 
         for tool_id in TOOL_IDS:
             pseudo = Folder()
-            pseudo._setId( tool_id )
-            site._setObject( tool_id, pseudo )
+            pseudo._setId(tool_id)
+            site._setObject(tool_id, pseudo)
 
-        self.assertEqual( len( site.objectIds() ), len( TOOL_IDS ) + 1 )
+        self.assertEqual(len(site.objectIds()), len(TOOL_IDS) + 1)
 
         for tool_id in TOOL_IDS:
-            self.failUnless( tool_id in site.objectIds() )
+            self.failUnless(tool_id in site.objectIds())
 
-        context = DummyImportContext( site, tool=site.setup_tool )
-        context._files[ TOOLSET_XML ] = _FORBIDDEN_TOOLSET_XML
+        context = DummyImportContext(site, tool=site.setup_tool)
+        context._files[TOOLSET_XML] = _FORBIDDEN_TOOLSET_XML
 
-        importToolset( context )
+        importToolset(context)
 
-        self.assertEqual( len( site.objectIds() ), 2 )
-        self.failUnless( 'setup_tool' in site.objectIds() )
-        self.failUnless( 'saved' in site.objectIds() )
+        self.assertEqual(len(site.objectIds()), 2)
+        self.failUnless('setup_tool' in site.objectIds())
+        self.failUnless('saved' in site.objectIds())
 
-    def test_required_tools_missing( self ):
+    def test_required_tools_missing(self):
         from Products.GenericSetup.tool import importToolset
         from Products.GenericSetup.tool import TOOLSET_XML
 
         site = self._initSite()
-        self.assertEqual( len( site.objectIds() ), 1 )
+        self.assertEqual(len(site.objectIds()), 1)
 
-        context = DummyImportContext( site, tool=site.setup_tool )
-        context._files[ TOOLSET_XML ] = _REQUIRED_TOOLSET_XML
+        context = DummyImportContext(site, tool=site.setup_tool)
+        context._files[TOOLSET_XML] = _REQUIRED_TOOLSET_XML
 
-        importToolset( context )
+        importToolset(context)
 
-        self.assertEqual( len( site.objectIds() ), 3 )
-        self.failUnless( isinstance( aq_base( site._getOb( 'mandatory' ) )
-                                   , DummyTool ) )
-        self.failUnless( isinstance( aq_base( site._getOb( 'obligatory' ) )
-                                   , DummyTool ) )
+        self.assertEqual(len(site.objectIds()), 3)
+        self.failUnless(isinstance(
+            aq_base(site._getOb('mandatory')), DummyTool))
+        self.failUnless(isinstance(
+            aq_base(site._getOb('obligatory')), DummyTool))
 
-    def test_required_tools_no_replacement( self ):
+    def test_required_tools_no_replacement(self):
         from Products.GenericSetup.tool import importToolset
         from Products.GenericSetup.tool import TOOLSET_XML
 
         site = self._initSite()
 
         mandatory = DummyTool()
-        mandatory._setId( 'mandatory' )
-        site._setObject( 'mandatory', mandatory )
+        mandatory._setId('mandatory')
+        site._setObject('mandatory', mandatory)
 
         obligatory = DummyTool()
-        obligatory._setId( 'obligatory' )
-        site._setObject( 'obligatory', obligatory )
+        obligatory._setId('obligatory')
+        site._setObject('obligatory', obligatory)
 
-        self.assertEqual( len( site.objectIds() ), 3 )
+        self.assertEqual(len(site.objectIds()), 3)
 
-        context = DummyImportContext( site, tool=site.setup_tool )
-        context._files[ TOOLSET_XML ] = _REQUIRED_TOOLSET_XML
+        context = DummyImportContext(site, tool=site.setup_tool)
+        context._files[TOOLSET_XML] = _REQUIRED_TOOLSET_XML
 
-        importToolset( context )
+        importToolset(context)
 
-        self.assertEqual( len( site.objectIds() ), 3 )
-        self.failUnless( aq_base( site._getOb( 'mandatory' ) ) is mandatory )
-        self.failUnless( aq_base( site._getOb( 'obligatory' ) ) is obligatory )
+        self.assertEqual(len(site.objectIds()), 3)
+        self.failUnless(aq_base(site._getOb('mandatory')) is mandatory)
+        self.failUnless(aq_base(site._getOb('obligatory')) is obligatory)
 
-    def test_required_tools_with_replacement( self ):
+    def test_required_tools_with_replacement(self):
         from Products.GenericSetup.tool import importToolset
         from Products.GenericSetup.tool import TOOLSET_XML
 
         site = self._initSite()
 
         mandatory = AnotherDummyTool()
-        mandatory._setId( 'mandatory' )
-        site._setObject( 'mandatory', mandatory )
+        mandatory._setId('mandatory')
+        site._setObject('mandatory', mandatory)
 
         obligatory = SubclassedDummyTool()
-        obligatory._setId( 'obligatory' )
-        site._setObject( 'obligatory', obligatory )
+        obligatory._setId('obligatory')
+        site._setObject('obligatory', obligatory)
 
-        self.assertEqual( len( site.objectIds() ), 3 )
+        self.assertEqual(len(site.objectIds()), 3)
 
-        context = DummyImportContext( site, tool=site.setup_tool )
-        context._files[ TOOLSET_XML ] = _REQUIRED_TOOLSET_XML
+        context = DummyImportContext(site, tool=site.setup_tool)
+        context._files[TOOLSET_XML] = _REQUIRED_TOOLSET_XML
 
-        importToolset( context )
+        importToolset(context)
 
-        self.assertEqual( len( site.objectIds() ), 3 )
+        self.assertEqual(len(site.objectIds()), 3)
 
-        self.failIf( aq_base( site._getOb( 'mandatory' ) ) is mandatory )
-        self.failUnless( isinstance( aq_base( site._getOb( 'mandatory' ) )
-                                   , DummyTool ) )
+        self.failIf(aq_base(site._getOb('mandatory')) is mandatory)
+        self.failUnless(isinstance(
+            aq_base(site._getOb('mandatory')), DummyTool))
 
-        self.failIf( aq_base( site._getOb( 'obligatory' ) ) is obligatory )
-        self.failUnless( isinstance( aq_base( site._getOb( 'obligatory' ) )
-                                   , DummyTool ) )
+        self.failIf(aq_base(site._getOb('obligatory')) is obligatory)
+        self.failUnless(isinstance(
+            aq_base(site._getOb('obligatory')), DummyTool))
 
-    def test_required_tools_missing_acquired_nofail( self ):
+    def test_required_tools_missing_acquired_nofail(self):
         from Products.GenericSetup.tool import importToolset
         from Products.GenericSetup.tool import TOOLSET_XML
 
@@ -1616,12 +1594,12 @@ class Test_importToolset(_ToolsetSetup):
         parent_site = Folder()
 
         mandatory = AnotherDummyTool()
-        mandatory._setId( 'mandatory' )
-        parent_site._setObject( 'mandatory', mandatory )
+        mandatory._setId('mandatory')
+        parent_site._setObject('mandatory', mandatory)
 
         obligatory = AnotherDummyTool()
-        obligatory._setId( 'obligatory' )
-        parent_site._setObject( 'obligatory', obligatory )
+        obligatory._setId('obligatory')
+        parent_site._setObject('obligatory', obligatory)
 
         site = site.__of__(parent_site)
 
@@ -1629,37 +1607,37 @@ class Test_importToolset(_ToolsetSetup):
         # should not prevent new objects from being created if they
         # don't exist in the site
 
-        context = DummyImportContext( site, tool=site.setup_tool )
-        context._files[ TOOLSET_XML ] = _REQUIRED_TOOLSET_XML
+        context = DummyImportContext(site, tool=site.setup_tool)
+        context._files[TOOLSET_XML] = _REQUIRED_TOOLSET_XML
 
-        importToolset( context )
+        importToolset(context)
 
-        self.failIf( aq_base( site._getOb( 'mandatory' ) ) is mandatory )
-        self.failUnless( isinstance( aq_base( site._getOb( 'mandatory' ) )
-                                   , DummyTool ) )
+        self.failIf(aq_base(site._getOb('mandatory')) is mandatory)
+        self.failUnless(isinstance(
+            aq_base(site._getOb('mandatory')), DummyTool))
 
-        self.failIf( aq_base( site._getOb( 'obligatory' ) ) is obligatory )
-        self.failUnless( isinstance( aq_base( site._getOb( 'obligatory' ) )
-                                   , DummyTool ) )
+        self.failIf(aq_base(site._getOb('obligatory')) is obligatory)
+        self.failUnless(isinstance(
+            aq_base(site._getOb('obligatory')), DummyTool))
 
-    def test_required_tools_missing_class_with_replacement( self ):
+    def test_required_tools_missing_class_with_replacement(self):
         from Products.GenericSetup.tool import importToolset
         from Products.GenericSetup.tool import TOOLSET_XML
 
         site = self._initSite()
 
         obligatory = AnotherDummyTool()
-        obligatory._setId( 'obligatory' )
-        site._setObject( 'obligatory', obligatory )
+        obligatory._setId('obligatory')
+        site._setObject('obligatory', obligatory)
 
-        self.assertEqual( len( site.objectIds() ), 2 )
+        self.assertEqual(len(site.objectIds()), 2)
 
-        context = DummyImportContext( site, tool=site.setup_tool )
-        context._files[ TOOLSET_XML ] = _BAD_CLASS_TOOLSET_XML
+        context = DummyImportContext(site, tool=site.setup_tool)
+        context._files[TOOLSET_XML] = _BAD_CLASS_TOOLSET_XML
 
-        importToolset( context )
+        importToolset(context)
 
-        self.assertEqual( len( site.objectIds() ), 2 )
+        self.assertEqual(len(site.objectIds()), 2)
 
 
 class DummyTool(Folder):
@@ -1738,9 +1716,10 @@ _BAD_CLASS_TOOLSET_XML = """\
 </tool-setup>
 """
 
+
 def test_suite():
     return unittest.TestSuite((
-        unittest.makeSuite( SetupToolTests ),
-        unittest.makeSuite( Test_exportToolset ),
-        unittest.makeSuite( Test_importToolset ),
-        ))
+        unittest.makeSuite(SetupToolTests),
+        unittest.makeSuite(Test_exportToolset),
+        unittest.makeSuite(Test_importToolset),
+    ))

--- a/Products/GenericSetup/tests/test_utils.py
+++ b/Products/GenericSetup/tests/test_utils.py
@@ -229,14 +229,14 @@ def _getDocumentElement(text):
     return parseString(text).documentElement
 
 
-def _testFunc( *args, **kw ):
-
+def _testFunc(*args, **kw):
     """ This is a test.
 
     This is only a test.
     """
 
 _TEST_FUNC_NAME = 'Products.GenericSetup.tests.test_utils._testFunc'
+
 
 class Whatever:
     pass
@@ -248,42 +248,42 @@ whatever_inst.__name__ = 'whatever_inst'
 
 _WHATEVER_INST_NAME = 'Products.GenericSetup.tests.test_utils.whatever_inst'
 
-class UtilsTests( unittest.TestCase ):
 
-    def test__getDottedName_simple( self ):
+class UtilsTests(unittest.TestCase):
 
-        from Products.GenericSetup.utils import _getDottedName
-
-        self.assertEqual( _getDottedName( _testFunc ), _TEST_FUNC_NAME )
-
-    def test__getDottedName_string( self ):
+    def test__getDottedName_simple(self):
 
         from Products.GenericSetup.utils import _getDottedName
 
-        self.assertEqual( _getDottedName( _TEST_FUNC_NAME ), _TEST_FUNC_NAME )
+        self.assertEqual(_getDottedName(_testFunc), _TEST_FUNC_NAME)
 
-    def test__getDottedName_unicode( self ):
+    def test__getDottedName_string(self):
+
+        from Products.GenericSetup.utils import _getDottedName
+
+        self.assertEqual(_getDottedName(_TEST_FUNC_NAME), _TEST_FUNC_NAME)
+
+    def test__getDottedName_unicode(self):
 
         from Products.GenericSetup.utils import _getDottedName
 
         dotted = u'%s' % _TEST_FUNC_NAME
-        self.assertEqual( _getDottedName( dotted ), _TEST_FUNC_NAME )
-        self.assertEqual( type( _getDottedName( dotted ) ), str )
+        self.assertEqual(_getDottedName(dotted), _TEST_FUNC_NAME)
+        self.assertEqual(type(_getDottedName(dotted)), str)
 
-    def test__getDottedName_class( self ):
-
-        from Products.GenericSetup.utils import _getDottedName
-
-        self.assertEqual( _getDottedName( Whatever ), _WHATEVER_NAME )
-
-    def test__getDottedName_inst( self ):
+    def test__getDottedName_class(self):
 
         from Products.GenericSetup.utils import _getDottedName
 
-        self.assertEqual( _getDottedName( whatever_inst )
-                        , _WHATEVER_INST_NAME )
+        self.assertEqual(_getDottedName(Whatever), _WHATEVER_NAME)
 
-    def test__getDottedName_noname( self ):
+    def test__getDottedName_inst(self):
+
+        from Products.GenericSetup.utils import _getDottedName
+
+        self.assertEqual(_getDottedName(whatever_inst), _WHATEVER_INST_NAME)
+
+    def test__getDottedName_noname(self):
 
         from Products.GenericSetup.utils import _getDottedName
 
@@ -291,7 +291,7 @@ class UtilsTests( unittest.TestCase ):
             pass
 
         doh = Doh()
-        self.assertRaises( ValueError, _getDottedName, doh )
+        self.assertRaises(ValueError, _getDottedName, doh)
 
 
 class PropertyManagerHelpersTests(unittest.TestCase):
@@ -354,14 +354,14 @@ class PropertyManagerHelpersTests(unittest.TestCase):
         obj._updateProperty('foo_date', '2000/01/01 00:00:00 UTC')
         obj._updateProperty('foo_float', '1.1')
         obj._updateProperty('foo_int', '1')
-        obj._updateProperty('foo_lines', 
-                u'Foo\nLines\n\xfcbrigens'.encode('utf-8'))
+        obj._updateProperty('foo_lines',
+                            u'Foo\nLines\n\xfcbrigens'.encode('utf-8'))
         obj._updateProperty('foo_long', '1')
         obj._updateProperty('foo_string', 'Foo String')
         obj._updateProperty('foo_text', 'Foo\nText')
-        obj._updateProperty( 'foo_tokens', ('Foo', 'Tokens') )
+        obj._updateProperty('foo_tokens', ('Foo', 'Tokens'))
         obj._updateProperty('foo_selection', 'Foo')
-        obj._updateProperty( 'foo_mselection', ('Foo', 'Baz') )
+        obj._updateProperty('foo_mselection', ('Foo', 'Baz'))
         obj.foo_boolean0 = 0
         obj._updateProperty('foo_date_naive', '2000/01/01 00:00:00')
         obj._updateProperty('foo_ro', 'RO')
@@ -390,7 +390,7 @@ class PropertyManagerHelpersTests(unittest.TestCase):
 
         # The extraction process wants to decode text properties
         # to unicode using the default ZPublisher encoding, which
-        # defaults to iso-8859-15. We force UTF-8 here because we 
+        # defaults to iso-8859-15. We force UTF-8 here because we
         # forced our properties to be UTF-8 encoded.
         helpers._encoding = 'utf-8'
         node.appendChild(helpers._extractProperties())
@@ -475,12 +475,12 @@ class PropertyManagerHelpersTests(unittest.TestCase):
         helpers._initProperties(node)
 
         self.assertEqual(helpers.context.getProperty('i18n_domain'),
-                        'dummy_domain')
+                         'dummy_domain')
 
     def test__initProperties_nopurge_base(self):
         helpers = self._makeOne()
         node = _getDocumentElement(_NOPURGE_IMPORT)
-        helpers.environ._should_purge = True # base profile
+        helpers.environ._should_purge = True  # base profile
         obj = helpers.context
         obj._properties = ()
         obj.manage_addProperty('lines1', ('Foo', 'Gee'), 'lines')
@@ -495,7 +495,7 @@ class PropertyManagerHelpersTests(unittest.TestCase):
     def test__initProperties_nopurge_extension(self):
         helpers = self._makeOne()
         node = _getDocumentElement(_NOPURGE_IMPORT)
-        helpers.environ._should_purge = False # extension profile
+        helpers.environ._should_purge = False  # extension profile
         obj = helpers.context
         obj._properties = ()
         obj.manage_addProperty('lines1', ('Foo', 'Gee'), 'lines')
@@ -510,7 +510,7 @@ class PropertyManagerHelpersTests(unittest.TestCase):
     def test_initProperties_remove_elements(self):
         helpers = self._makeOne()
         node = _getDocumentElement(_REMOVE_ELEMENT_IMPORT)
-        helpers.environ._should_purge = False # extension profile
+        helpers.environ._should_purge = False  # extension profile
         obj = helpers.context
         obj._properties = ()
         obj.manage_addProperty('lines1', ('Foo', 'Gee'), 'lines')
@@ -522,7 +522,7 @@ class PropertyManagerHelpersTests(unittest.TestCase):
 
     def test_initProperties_remove_properties(self):
         helpers = self._makeOne()
-        helpers.environ._should_purge = False # extension profile
+        helpers.environ._should_purge = False  # extension profile
         obj = helpers.context
         obj._properties = ()
 
@@ -716,14 +716,14 @@ class ObjectManagerHelpersTests(ZopeTestCase):
         helpers._initObjects(node)
         self.failIf('history' in obj.objectIds())
         self.failUnless('future' in obj.objectIds())
-        
+
         # Removing it a second time should not throw an
         # AttributeError.
         node = _getDocumentElement(_REMOVE_IMPORT)
         helpers._initObjects(node)
         self.failIf('history' in obj.objectIds())
         self.failUnless('future' in obj.objectIds())
-        
+
 
 class PrettyDocumentTests(unittest.TestCase):
 
@@ -732,7 +732,7 @@ class PrettyDocumentTests(unittest.TestCase):
         original = 'baz &nbsp;<bar>&"\''
         expected = ('<?xml version="1.0"?>\n'
                     '<doc bar="" foo="baz '
-                        '&amp;nbsp;&lt;bar&gt;&amp;&quot;\'"/>\n')
+                    '&amp;nbsp;&lt;bar&gt;&amp;&quot;\'"/>\n')
 
         doc = PrettyDocument()
         node = doc.createElement('doc')
@@ -772,4 +772,4 @@ def test_suite():
         unittest.makeSuite(MarkerInterfaceHelpersTests),
         unittest.makeSuite(ObjectManagerHelpersTests),
         unittest.makeSuite(PrettyDocumentTests),
-        ))
+    ))

--- a/Products/GenericSetup/tests/test_zcml.py
+++ b/Products/GenericSetup/tests/test_zcml.py
@@ -31,17 +31,22 @@ except ImportError:
 def dummy_importstep(context):
     pass
 
+
 def dummy_exportstep(context):
     pass
+
 
 def dummy_upgrade(context):
     pass
 
+
 def b_dummy_upgrade(context):
     pass
 
+
 def c_dummy_upgrade(context):
     pass
+
 
 def test_simpleRegisterProfile():
     """
@@ -84,6 +89,7 @@ def test_simpleRegisterProfile():
 
       >>> cleanUp()
     """
+
 
 def test_registerProfile():
     """
@@ -129,6 +135,7 @@ def test_registerProfile():
 
       >>> cleanUp()
     """
+
 
 def test_registerUpgradeStep(self):
     """
@@ -190,6 +197,7 @@ def test_registerUpgradeStep(self):
       >>> cleanUp()
     """
 
+
 def test_registerUpgradeDepends(self):
     """
     Use the standalone genericsetup:upgradeDepends directive::
@@ -233,6 +241,7 @@ def test_registerUpgradeDepends(self):
 
       >>> cleanUp()
     """
+
 
 def test_registerUpgradeSteps(self):
     """
@@ -371,15 +380,14 @@ class ImportStepTests(unittest.TestCase):
              handler="Products.GenericSetup.tests.test_zcml.dummy_importstep">
          </genericsetup:importStep>
         </configure>""")
-        self.assertEqual( _import_step_registry.listSteps(), [u'name'])
-        data=_import_step_registry.getStepMetadata(u'name')
+        self.assertEqual(_import_step_registry.listSteps(), [u'name'])
+        data = _import_step_registry.getStepMetadata(u'name')
         self.assertEqual(data["handler"],
-                'Products.GenericSetup.tests.test_zcml.dummy_importstep')
+                         'Products.GenericSetup.tests.test_zcml.dummy_importstep')
         self.assertEqual(data["description"], u"description")
         self.assertEqual(data["title"], u"title")
         self.assertEqual(data["dependencies"], ())
         self.assertEqual(data["id"], u"name")
-
 
     def testWithDependency(self):
         zcml.load_string("""
@@ -393,9 +401,8 @@ class ImportStepTests(unittest.TestCase):
           <depends name="something.else"/>
          </genericsetup:importStep>
         </configure>""")
-        data=_import_step_registry.getStepMetadata(u'name')
+        data = _import_step_registry.getStepMetadata(u'name')
         self.assertEqual(data["dependencies"], (u"something.else",))
-
 
 
 class ExportStepTests(unittest.TestCase):
@@ -418,10 +425,10 @@ class ExportStepTests(unittest.TestCase):
             handler="Products.GenericSetup.tests.test_zcml.dummy_exportstep"
             />
         </configure>""")
-        self.assertEqual( _export_step_registry.listSteps(), [u'name'])
-        data=_export_step_registry.getStepMetadata(u'name')
+        self.assertEqual(_export_step_registry.listSteps(), [u'name'])
+        data = _export_step_registry.getStepMetadata(u'name')
         self.assertEqual(data["handler"],
-                'Products.GenericSetup.tests.test_zcml.dummy_exportstep')
+                         'Products.GenericSetup.tests.test_zcml.dummy_exportstep')
         self.assertEqual(data["description"], u"description")
         self.assertEqual(data["title"], u"title")
         self.assertEqual(data["id"], u"name")

--- a/Products/GenericSetup/tests/tests.py
+++ b/Products/GenericSetup/tests/tests.py
@@ -16,6 +16,7 @@
 import doctest
 import unittest
 
+
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest.DocFileSuite('upgrade.txt'))

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -68,6 +68,7 @@ DEFAULT_DEPENDENCY_STRATEGY = DEPENDENCY_STRATEGY_UPGRADE
 
 generic_logger = logging.getLogger(__name__)
 
+
 def exportStepRegistries(context):
     """ Built-in handler for exporting import / export step registries.
     """
@@ -89,6 +90,7 @@ def exportStepRegistries(context):
         logger.info('Local export steps exported.')
     else:
         logger.debug('No local export steps.')
+
 
 def importToolset(context):
     """ Import required / forbidden tools from XML file.
@@ -144,6 +146,7 @@ def importToolset(context):
                 site._setObject(tool_id, tool_class())
 
     logger.info('Toolset imported.')
+
 
 def exportToolset(context):
     """ Export required / forbidden tools to XML file.
@@ -290,7 +293,6 @@ class SetupTool(Folder):
         if not self._exclude_global_steps:
             steps.update(set(_import_step_registry.listSteps()))
         return tuple(steps)
-
 
     security.declareProtected(ManagePortal, 'getExportStepMetadata')
     def getExportStepMetadata(self, step, default=None):
@@ -1356,6 +1358,7 @@ Comparing configurations: '%s' and '%s'
 _TOOL_ID = 'setup_tool'
 
 addSetupToolForm = PageTemplateFile('toolAdd.zpt', _wwwdir)
+
 
 def addSetupTool(dispatcher, RESPONSE):
     """

--- a/Products/GenericSetup/upgrade.py
+++ b/Products/GenericSetup/upgrade.py
@@ -200,10 +200,12 @@ class UpgradeDepends(UpgradeEntity):
                                               purge_old=self.purge,
                                               ignore_dependencies=ign_deps)
 
+
 def _registerUpgradeStep(step):
     profile_id = step.profile
     profile_steps = _upgrade_registry.getUpgradeStepsForProfile(profile_id)
     profile_steps[step.id] = step
+
 
 def _registerNestedUpgradeStep(step, outer_id):
     profile_id = step.profile
@@ -211,6 +213,7 @@ def _registerNestedUpgradeStep(step, outer_id):
     nested_steps = profile_steps.get(outer_id, [])
     nested_steps.append((step.id, step))
     profile_steps[outer_id] = nested_steps
+
 
 def _extractStepInfo(tool, id, step, source):
     """Returns the info data structure for a given step.
@@ -230,8 +233,10 @@ def _extractStepInfo(tool, id, step, source):
         }
     return info
 
+
 def listProfilesWithUpgrades():
     return _upgrade_registry.keys()
+
 
 def listUpgradeSteps(tool, profile_id, source):
     """Lists upgrade steps available from a given version, for a given

--- a/Products/GenericSetup/utils.py
+++ b/Products/GenericSetup/utils.py
@@ -88,6 +88,7 @@ def _getDottedName(named):
 
     return short_dotted
 
+
 def _resolveDottedName(dotted):
     __traceback_info__ = dotted
 
@@ -124,6 +125,7 @@ def _resolveDottedName(dotted):
             return None
 
     return obj
+
 
 def _extractDocstring(func, default_title, default_description):
     try:
@@ -289,6 +291,7 @@ InitializeClass(ExportConfiguratorBase)
 
 #
 ##############################################################################
+
 
 class _LineWrapper:
 
@@ -829,6 +832,7 @@ def exportObjects(obj, parent_path, context):
         for sub in obj.objectValues():
             exportObjects(sub, path + '/', context)
 
+
 def importObjects(obj, parent_path, context):
     """ Import subobjects recursively.
     """
@@ -899,6 +903,7 @@ def _computeTopologicalSort(steps):
         unresolved = []
 
     return result
+
 
 def _getProductPath(product_name):
     """ Return the absolute path of the product's directory.

--- a/Products/GenericSetup/zcml.py
+++ b/Products/GenericSetup/zcml.py
@@ -24,7 +24,8 @@ from Products.GenericSetup.registry import _import_step_registry
 from Products.GenericSetup.registry import _export_step_registry
 from Products.GenericSetup.registry import _profile_registry
 
-#### genericsetup:registerProfile
+# genericsetup:registerProfile
+
 
 class IRegisterProfileDirective(Interface):
 
@@ -88,7 +89,7 @@ def registerProfile(_context, name=u'default', title=None, description=None,
         )
 
 
-#### genericsetup:exportStep
+# genericsetup:exportStep
 
 class IExportStepDirective(Interface):
     name = PythonIdentifier(
@@ -112,7 +113,6 @@ class IExportStepDirective(Interface):
         required=True)
 
 
-
 def exportStep(context, name, handler, title=None, description=None):
 
     context.action(
@@ -122,7 +122,7 @@ def exportStep(context, name, handler, title=None, description=None):
         )
 
 
-#### genericsetup:importStep
+# genericsetup:importStep
 
 class IImportStepDirective(Interface):
 
@@ -184,7 +184,7 @@ class importStep:
             )
 
 
-#### genericsetup:upgradeStep
+# genericsetup:upgradeStep
 
 import zope.schema
 import zope.configuration
@@ -192,6 +192,7 @@ from upgrade import UpgradeStep
 from upgrade import UpgradeDepends
 from upgrade import _registerUpgradeStep
 from upgrade import _registerNestedUpgradeStep
+
 
 class IUpgradeStepsDirective(Interface):
 
@@ -304,6 +305,7 @@ def upgradeStep(_context, title, profile, handler, description=None,
         callable=_registerUpgradeStep,
         args=(step,),
         )
+
 
 def upgradeDepends(_context, title, profile, description=None,
                    import_profile=None, import_steps=[], source='*',


### PR DESCRIPTION
This supersedes pull request #20 because not everyone wants such a big cleanup, as it diminishes the value of doing a 'git blame'.

This cleans up pep8 in the tests. The first commit is only white space. The second commit is more aggressive, but far, far smaller.

Plus in the rest of the code this fixes only pep8 issues in comments or in empty lines: removing or adding a line or removing white space on an otherwise blank line.