### PR TITLE
Improve ZMI for imports and upgrades

### DIFF
--- a/Products/GenericSetup/registry.py
+++ b/Products/GenericSetup/registry.py
@@ -644,6 +644,16 @@ class ProfileRegistry(Implicit):
     def getProfileInfo(self, profile_id, for_=None):
         """ See IProfileRegistry.
         """
+        if profile_id is None:
+            # tarball import
+            info = {'id': u'',
+                    'title': u'',
+                    'description': u'',
+                    'path': u'',
+                    'product': u'',
+                    'type': None,
+                    'for': None}
+            return info
         prefixes = ('profile-', 'snapshot-')
         for prefix in prefixes:
             if profile_id.startswith(prefix):

--- a/Products/GenericSetup/tests/test_registry.py
+++ b/Products/GenericSetup/tests/test_registry.py
@@ -968,6 +968,19 @@ class ProfileRegistryTests(BaseRegistryTests, ConformsToIProfileRegistry
         self.assertEqual(info['type'], PROFILE_TYPE)
         self.assertEqual(info['for'], FOR)
 
+    def test_getProfileInfo_tarball(self):
+        # When importing a tarball, some code calls getProfileInfo with id
+        # None.  This must not crash.
+        registry = self._makeOne()
+        self.assertEqual(registry.getProfileInfo(None),
+                         {'description': u'',
+                          'for': None,
+                          'id': u'',
+                          'path': u'',
+                          'product': u'',
+                          'title': u'',
+                         'type': None})
+
 
 def test_suite():
     return unittest.TestSuite((

--- a/Products/GenericSetup/tests/test_tool.py
+++ b/Products/GenericSetup/tests/test_tool.py
@@ -1186,6 +1186,176 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         tool.purgeProfileVersions()
         self.assertEqual(tool._profile_upgrade_versions, {})
 
+    def test_listProfilesWithUpgrades(self):
+        site = self._makeSite()
+        site.setup_tool = self._makeOne('setup_tool')
+        tool = site.setup_tool
+        self.assertEqual(tool.listProfilesWithUpgrades(), [])
+        self.assertEqual(tool.listProfilesWithPendingUpgrades(), [])
+        self.assertEqual(tool.listUptodateProfiles(), [])
+        self.assertEqual(tool.hasPendingUpgrades(), False)
+        profile_id = 'dummy_profile'
+        product_name = 'GenericSetup'
+        directory = os.path.split(__file__)[0]
+        path = os.path.join(directory, 'versioned_profile')
+
+        # register profile
+        profile_registry.registerProfile(profile_id,
+                                         'Dummy Profile',
+                                         'This is a dummy profile',
+                                         path,
+                                         product=product_name)
+        self.assertEqual(tool.listProfilesWithUpgrades(), [])
+        self.assertEqual(tool.listProfilesWithPendingUpgrades(), [])
+        self.assertEqual(tool.listUptodateProfiles(), [])
+        self.assertEqual(tool.hasPendingUpgrades(), False)
+
+        # register upgrade step
+        step1 = UpgradeStep("Upgrade 1",
+                            "GenericSetup:dummy_profile", '*', '1.1', '',
+                            dummy_upgrade,
+                            None, "1")
+        _registerUpgradeStep(step1)
+        self.assertEqual(tool.listProfilesWithUpgrades(),
+                         [u'GenericSetup:dummy_profile'])
+        self.assertEqual(tool.listProfilesWithPendingUpgrades(), [])
+        self.assertEqual(tool.listUptodateProfiles(), [])
+        self.assertEqual(tool.hasPendingUpgrades(), False)
+
+        # register another upgrade step
+        step2 = UpgradeStep("Upgrade 2",
+                            "GenericSetup:dummy_profile", '1.1', '1.2', '',
+                            dummy_upgrade,
+                            None, "1")
+        _registerUpgradeStep(step2)
+        self.assertEqual(tool.listProfilesWithUpgrades(),
+                         [u'GenericSetup:dummy_profile'])
+        self.assertEqual(tool.listProfilesWithPendingUpgrades(), [])
+        self.assertEqual(tool.listUptodateProfiles(), [])
+        self.assertEqual(tool.hasPendingUpgrades(), False)
+
+        # get full profile id
+        profile_id = ':'.join((product_name, profile_id))
+
+        # Pretend the profile was installed
+        tool.setLastVersionForProfile(profile_id, '1.0')
+        self.assertEqual(tool.listProfilesWithUpgrades(),
+                         [u'GenericSetup:dummy_profile'])
+        self.assertEqual(tool.listProfilesWithPendingUpgrades(),
+                         [u'GenericSetup:dummy_profile'])
+        self.assertEqual(tool.listUptodateProfiles(), [])
+        self.assertEqual(tool.hasPendingUpgrades(), True)
+
+        # run first upgrade step
+        request = site.REQUEST
+        request.form['profile_id'] = profile_id
+        steps = listUpgradeSteps(tool, profile_id, '1.0')
+        step_id = steps[0]['id']
+        request.form['upgrades'] = [step_id]
+        tool.manage_doUpgrades()
+        self.assertEqual(tool.getLastVersionForProfile(profile_id),
+                         ('1', '1'))
+        self.assertEqual(tool.listProfilesWithUpgrades(),
+                         [u'GenericSetup:dummy_profile'])
+        self.assertEqual(tool.listProfilesWithPendingUpgrades(),
+                         [u'GenericSetup:dummy_profile'])
+        self.assertEqual(tool.listUptodateProfiles(), [])
+        self.assertEqual(tool.hasPendingUpgrades(), True)
+
+        # run second upgrade step
+        request = site.REQUEST
+        request.form['profile_id'] = profile_id
+        steps = listUpgradeSteps(tool, profile_id, '1.1')
+        step_id = steps[0]['id']
+        request.form['upgrades'] = [step_id]
+        tool.manage_doUpgrades()
+        self.assertEqual(tool.getLastVersionForProfile(profile_id),
+                         ('1', '2'))
+        self.assertEqual(tool.listProfilesWithUpgrades(),
+                         [u'GenericSetup:dummy_profile'])
+        self.assertEqual(tool.listProfilesWithPendingUpgrades(), [])
+        self.assertEqual(tool.listUptodateProfiles(),
+                         [u'GenericSetup:dummy_profile'])
+        self.assertEqual(tool.hasPendingUpgrades(), False)
+
+        # Pretend the profile was never installed.
+        tool.unsetLastVersionForProfile(profile_id)
+        self.assertEqual(tool.listProfilesWithPendingUpgrades(), [])
+        self.assertEqual(tool.listUptodateProfiles(), [])
+        self.assertEqual(tool.hasPendingUpgrades(), False)
+
+    def test_hasPendingUpgrades(self):
+        site = self._makeSite()
+        site.setup_tool = self._makeOne('setup_tool')
+        tool = site.setup_tool
+        profile_id_1 = 'dummy_profile1'
+        profile_id_2 = 'dummy_profile2'
+        product_name = 'GenericSetup'
+        directory = os.path.split(__file__)[0]
+        path = os.path.join(directory, 'versioned_profile')
+
+        # register profiles
+        profile_registry.registerProfile(profile_id_1,
+                                         'Dummy Profile 1',
+                                         'This is dummy profile 1',
+                                         path,
+                                         product=product_name)
+        profile_registry.registerProfile(profile_id_2,
+                                         'Dummy Profile 2',
+                                         'This is dummy profile 2',
+                                         path,
+                                         product=product_name)
+
+        # get full profile ids
+        profile_id_1 = ':'.join((product_name, profile_id_1))
+        profile_id_2 = ':'.join((product_name, profile_id_2))
+
+        # test
+        self.assertEqual(tool.hasPendingUpgrades(), False)
+        self.assertEqual(tool.hasPendingUpgrades(profile_id_1), False)
+        self.assertEqual(tool.hasPendingUpgrades(profile_id_2), False)
+        self.assertEqual(tool.hasPendingUpgrades('non-existing'), False)
+
+        # register upgrade steps
+        step1 = UpgradeStep("Upgrade 1",
+                            profile_id_1, '*', '1.1', '',
+                            dummy_upgrade,
+                            None, "1")
+        _registerUpgradeStep(step1)
+        step2 = UpgradeStep("Upgrade 2",
+                            profile_id_2, '*', '2.2', '',
+                            dummy_upgrade,
+                            None, "2")
+        _registerUpgradeStep(step2)
+        # No profile has been applied, so no upgrade is pending.
+        self.assertEqual(tool.hasPendingUpgrades(), False)
+        self.assertEqual(tool.hasPendingUpgrades(profile_id_1), False)
+        self.assertEqual(tool.hasPendingUpgrades(profile_id_2), False)
+
+        # Pretend profile 1 was installed to an earlier version.
+        tool.setLastVersionForProfile(profile_id_1, '1.0')
+        self.assertEqual(tool.hasPendingUpgrades(), True)
+        self.assertEqual(tool.hasPendingUpgrades(profile_id_1), True)
+        self.assertEqual(tool.hasPendingUpgrades(profile_id_2), False)
+
+        # Pretend profile 2 was installed to an earlier version.
+        tool.setLastVersionForProfile(profile_id_2, '2.0')
+        self.assertEqual(tool.hasPendingUpgrades(), True)
+        self.assertEqual(tool.hasPendingUpgrades(profile_id_1), True)
+        self.assertEqual(tool.hasPendingUpgrades(profile_id_2), True)
+
+        # Pretend profile 1 was installed to the final version.
+        tool.setLastVersionForProfile(profile_id_1, '1.1')
+        self.assertEqual(tool.hasPendingUpgrades(), True)
+        self.assertEqual(tool.hasPendingUpgrades(profile_id_1), False)
+        self.assertEqual(tool.hasPendingUpgrades(profile_id_2), True)
+
+        # Pretend profile 2 was installed to the final version.
+        tool.setLastVersionForProfile(profile_id_2, '2.2')
+        self.assertEqual(tool.hasPendingUpgrades(), False)
+        self.assertEqual(tool.hasPendingUpgrades(profile_id_1), False)
+        self.assertEqual(tool.hasPendingUpgrades(profile_id_2), False)
+
     def test_manage_doUpgrades_no_profile_id_or_updates(self):
         site = self._makeSite()
         site.setup_tool = self._makeOne('setup_tool')

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -705,19 +705,21 @@ class SetupTool(Folder):
                 return 'extension'
             return 'unknown'
 
-        s_infos = [{'id': 'snapshot-%s' % info['id'],
-                    'title': info['title'],
-                    'sortable_title': info['title'].lower(),
-                    'type': 'snapshot',
-                    }
-                   for info in self.listSnapshotInfo()]
+        s_infos = [{
+            'id': 'snapshot-%s' % info['id'],
+            'sortable_id': info['id'].lower(),
+            'title': info['title'],
+            'sortable_title': info['title'].lower(),
+            'type': 'snapshot',
+            } for info in self.listSnapshotInfo()]
         s_infos.sort(key=itemgetter(order_by))
-        p_infos = [{'id': 'profile-%s' % info['id'],
-                    'title': info['title'],
-                    'sortable_title': info['title'].lower(),
-                    'type': readableType(info['type']),
-                    }
-                   for info in self.listProfileInfo()]
+        p_infos = [{
+            'id': 'profile-%s' % info['id'],
+            'sortable_id': info['id'].lower(),
+            'title': info['title'],
+            'sortable_title': info['title'].lower(),
+            'type': readableType(info['type']),
+            } for info in self.listProfileInfo()]
         p_infos.sort(key=itemgetter(order_by))
 
         return tuple(s_infos + p_infos)

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -938,7 +938,7 @@ class SetupTool(Folder):
                 res.append(self._massageUpgradeInfo(info))
         return res
 
-    security.declareProtected(ManagePortal, 'hasUpgradesAvailable')
+    security.declareProtected(ManagePortal, 'hasPendingUpgrades')
     def hasPendingUpgrades(self, profile_id=None):
         """Are upgrade steps pending?
 

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -695,7 +695,7 @@ class SetupTool(Folder):
         return base + ext
 
     security.declareProtected(ManagePortal, 'listContextInfos')
-    def listContextInfos(self):
+    def listContextInfos(self, order_by='sortable_title'):
         """ List registered profiles and snapshots.
         """
         def readableType(x):
@@ -711,14 +711,14 @@ class SetupTool(Folder):
                     'type': 'snapshot',
                     }
                    for info in self.listSnapshotInfo()]
-        s_infos.sort(key=itemgetter('sortable_title'))
+        s_infos.sort(key=itemgetter(order_by))
         p_infos = [{'id': 'profile-%s' % info['id'],
                     'title': info['title'],
                     'sortable_title': info['title'].lower(),
                     'type': readableType(info['type']),
                     }
                    for info in self.listProfileInfo()]
-        p_infos.sort(key=itemgetter('sortable_title'))
+        p_infos.sort(key=itemgetter(order_by))
 
         return tuple(s_infos + p_infos)
 

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -493,9 +493,11 @@ class SetupTool(Folder):
     manage_options = (
         Folder.manage_options[:1] +
         ({'label': 'Profiles', 'action': 'manage_tool'},
-         {'label': 'Import', 'action': 'manage_importSteps'},
+         {'label': 'Import', 'action': 'manage_fullImport'},
          {'label': 'Export', 'action': 'manage_exportSteps'},
          {'label': 'Upgrades', 'action': 'manage_upgrades'},
+         {'label': 'Advanced Import', 'action': 'manage_importSteps'},
+         {'label': 'Tarball Import', 'action': 'manage_tarballImport'},
          {'label': 'Snapshots', 'action': 'manage_snapshots'},
          {'label': 'Comparison', 'action': 'manage_showDiff'},
          {'label': 'Manage', 'action': 'manage_stepRegistry'}) +
@@ -519,6 +521,14 @@ class SetupTool(Folder):
 
     security.declareProtected(ManagePortal, 'manage_importSteps')
     manage_importSteps = PageTemplateFile('sutImportSteps', _wwwdir)
+
+    security.declareProtected(ManagePortal, 'manage_fullImport')
+    manage_fullImport = PageTemplateFile(
+        'sutFullImport', _wwwdir)
+
+    security.declareProtected(ManagePortal, 'manage_tarballImport')
+    manage_tarballImport = PageTemplateFile(
+        'sutTarballImport', _wwwdir)
 
     security.declareProtected(ManagePortal, 'manage_importSelectedSteps')
     def manage_importSelectedSteps(self, ids, run_dependencies,

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -570,8 +570,8 @@ class SetupTool(Folder):
 
         steps_run = 'Steps run: %s' % ', '.join(result['steps'])
 
-        return self.manage_importSteps(manage_tabs_message=steps_run,
-                                       messages=result['messages'])
+        return self.manage_fullImport(manage_tabs_message=steps_run,
+                                      messages=result['messages'])
 
     security.declareProtected(ManagePortal, 'manage_importExtensions')
     def manage_importExtensions(self, RESPONSE, profile_ids=()):
@@ -592,8 +592,8 @@ class SetupTool(Folder):
                 for k, v in result['messages'].items():
                     detail['%s:%s' % (profile_id, k)] = v
 
-            return self.manage_importSteps(manage_tabs_message=message,
-                                        messages=detail)
+            return self.manage_fullImport(manage_tabs_message=message,
+                                          messages=detail)
 
     security.declareProtected(ManagePortal, 'manage_importTarball')
     def manage_importTarball(self, tarball):
@@ -606,8 +606,8 @@ class SetupTool(Folder):
 
         steps_run = 'Steps run: %s' % ', '.join(result['steps'])
 
-        return self.manage_importSteps(manage_tabs_message=steps_run,
-                                       messages=result['messages'])
+        return self.manage_tarballImport(manage_tabs_message=steps_run,
+                                         messages=result['messages'])
 
     security.declareProtected(ManagePortal, 'manage_exportSteps')
     manage_exportSteps = PageTemplateFile('sutExportSteps', _wwwdir)

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -886,6 +886,8 @@ class SetupTool(Folder):
     security.declareProtected(ManagePortal, 'profileExists')
     def profileExists(self, profile_id):
         """Check if a profile exists."""
+        if profile_id is None:
+            return False
         try:
             self.getProfileInfo(profile_id)
         except KeyError:
@@ -899,6 +901,8 @@ class SetupTool(Folder):
 
     security.declareProtected(ManagePortal, 'getDependenciesForProfile')
     def getDependenciesForProfile(self, profile_id):
+        if profile_id is None:
+            return ()
         if profile_id.startswith("snapshot-"):
             return ()
 

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -706,17 +706,19 @@ class SetupTool(Folder):
             return 'unknown'
 
         s_infos = [{'id': 'snapshot-%s' % info['id'],
-                     'title': info['title'],
-                     'type': 'snapshot',
-                   }
-                    for info in self.listSnapshotInfo()]
-        s_infos.sort(key=itemgetter('title'))
+                    'title': info['title'],
+                    'sortable_title': info['title'].lower(),
+                    'type': 'snapshot',
+                    }
+                   for info in self.listSnapshotInfo()]
+        s_infos.sort(key=itemgetter('sortable_title'))
         p_infos = [{'id': 'profile-%s' % info['id'],
                     'title': info['title'],
+                    'sortable_title': info['title'].lower(),
                     'type': readableType(info['type']),
-                   }
+                    }
                    for info in self.listProfileInfo()]
-        p_infos.sort(key=itemgetter('title'))
+        p_infos.sort(key=itemgetter('sortable_title'))
 
         return tuple(s_infos + p_infos)
 

--- a/Products/GenericSetup/www/setup_upgrades.zpt
+++ b/Products/GenericSetup/www/setup_upgrades.zpt
@@ -1,5 +1,8 @@
 <html tal:define="profile_id request/saved | request/profile_id | nothing;
-                  prof_w_upgrades context/listProfilesWithUpgrades">
+                  prof_with_upgrades context/listProfilesWithUpgrades;
+                  prof_with_pending_upgrades context/listProfilesWithPendingUpgrades;
+                  prof_uptodate context/listUptodateProfiles;
+                  has_pending_upgrades context/hasPendingUpgrades">
 
 <h1 tal:replace="structure context/manage_page_header">PAGE HEADER</h1>
 <h2 tal:replace="structure context/manage_tabs">TABS</h2>
@@ -10,18 +13,38 @@
 
 <h3>Upgrades</h3>
 
-<tal:choose-profile condition="prof_w_upgrades">
+<tal:pending condition="has_pending_upgrades">
+  <strong>
+    These profiles have pending upgrades:
+  </strong>
+  <tal:choose-pending-profile condition="prof_with_pending_upgrades">
+    <form method="post" action="manage_upgrades">
+      <select name="profile_id">
+        <option tal:repeat="prof_id prof_with_pending_upgrades"
+                tal:content="prof_id"
+                tal:attributes="selected python:prof_id == profile_id"/>
+      </select>
+      <input type="submit" value="Choose Profile" />
+    </form>
+  </tal:choose-pending-profile>
+</tal:pending>
+
+<tal:choose-uptodate-profile condition="prof_uptodate">
+  <strong>
+    These profiles have no pending upgrades, but old steps are
+    available if needed:
+  </strong>
   <form method="post" action="manage_upgrades">
     <select name="profile_id">
-      <option tal:repeat="prof_id context/listProfilesWithUpgrades"
+      <option tal:repeat="prof_id prof_uptodate"
               tal:content="prof_id"
               tal:attributes="selected python:prof_id == profile_id"/>
     </select>
     <input type="submit" value="Choose Profile" />
   </form>
-</tal:choose-profile>
+</tal:choose-uptodate-profile>
 
-<strong tal:condition="not: prof_w_upgrades">
+<strong tal:condition="not: prof_with_upgrades">
   No profiles with registered upgrade steps.
 </strong>
 

--- a/Products/GenericSetup/www/sutExportSteps.zpt
+++ b/Products/GenericSetup/www/sutExportSteps.zpt
@@ -33,6 +33,7 @@ Download selected export steps as tarball.
                      repeat[ 'step_id' ].odd and 'row-normal' or 'row-hilite'" >
    <td class="list-item" width="16">
     <input type="checkbox" name="ids:list" value="STEP_ID"
+           class="step_checkbox"
            id="STEP_ID"
            tal:attributes="id step_id;
                            value step_id" />
@@ -48,6 +49,12 @@ Download selected export steps as tarball.
        tal:content="info/handler">DOTTED.NAME</td>
   </tr>
   </tal:loop>
+
+  <tr valign="top">
+    <td colspan="4">
+      <button type="button" onclick="inputs = document.querySelectorAll('.step_checkbox'); for (var index = 0; index &lt; inputs.length; index++) {inputs[index].checked = inputs[index].checked ? false : true}; return false;">Toggle selection</button>
+    </td>
+  </tr>
 
   <tr valign="top" class="list-header">
    <td colspan="4">&nbsp;</td>

--- a/Products/GenericSetup/www/sutFullImport.zpt
+++ b/Products/GenericSetup/www/sutFullImport.zpt
@@ -57,6 +57,12 @@ see the <a href="manage_importSteps">Advanced Import</a> tab.
 
 <div tal:condition="context_id|nothing">
 
+<p tal:condition="python:context_id == base_context_id"
+   style="color: red">
+You have selected the baseline profile.
+Reapplying these import steps is potentially a dangerous operation.
+</p>
+
 <h3>Import all steps of "<span tal:replace="context_title">Base profile</span>"</h3>
 
 <p class="form-help" tal:condition="python:context.hasPendingUpgrades(context_id)">

--- a/Products/GenericSetup/www/sutFullImport.zpt
+++ b/Products/GenericSetup/www/sutFullImport.zpt
@@ -27,10 +27,14 @@ see the <a href="manage_importSteps">Advanced Import</a> tab.
 <p class="form-help">
   After you have selected a profile, you will get some options.
 </p>
+<tal:title_or_id repeat="select_key python:['title', 'id']">
 <form action="." method="post" id="profileform"
-      tal:attributes="action string:${context/absolute_url}/manage_fullImport">
+      tal:attributes="action string:${context/absolute_url}/manage_fullImport;
+                      id string:profileform_${select_key}">
+  <p tal:condition="python:select_key == 'title'">You can select a profile by <strong>title</strong>:</p>
+  <p tal:condition="python:select_key == 'id'">or you can select a profile by <strong>id</strong>:</p>
 <select name="context_id"
-        onchange="document.getElementById('profileform').submit();">
+        tal:attributes="onchange string:document.getElementById('profileform_${select_key}').submit();">
  <option value=""
          tal:attributes="selected not:context_id">
  Please select an option</option>
@@ -41,7 +45,7 @@ see the <a href="manage_importSteps">Advanced Import</a> tab.
  <option value="context-CONTEXT_ID"
     tal:repeat="context extension_contexts"
     tal:attributes="value context/id; selected python:context_id==context['id']"
-    tal:content="context/title">CONTEXT_TITLE</option>
+    tal:content="python:context[select_key]">Context title or id</option>
 </select>
   <noscript>
     <input class="form-element" type="submit"
@@ -49,6 +53,7 @@ see the <a href="manage_importSteps">Advanced Import</a> tab.
            value="Switch profile" />
   </noscript>
 </form>
+</tal:title_or_id>
 
 <div tal:condition="context_id|nothing">
 

--- a/Products/GenericSetup/www/sutFullImport.zpt
+++ b/Products/GenericSetup/www/sutFullImport.zpt
@@ -11,14 +11,11 @@
 <h1 tal:replace="structure context/manage_page_header">PAGE HEADER</h1>
 <h2 tal:replace="structure context/manage_tabs">TABS</h2>
 
-<h3>Site Configuration Advanced Import Steps</h3>
+<h3>Site Configuration Full Import</h3>
 
 <p class="form-help">
-This tool allows one to re-run individual steps of the site setup
-procedure, in order to pick up changes since the site was created.
-</p>
-<p class="form-help">
-For a simpler form, see the <a href="manage_importSteps">Import</a> tab.
+For advanced options, like re-running individual steps,
+see the <a href="manage_advancedImportSteps">Advanced Import</a> tab.
 </p>
 <p class="form-help" tal:condition="has_pending_upgrades">
   <strong>
@@ -29,7 +26,7 @@ For a simpler form, see the <a href="manage_importSteps">Import</a> tab.
 <h3>Select Profile or Snapshot</h3>
 
 <form action="." method="post" id="profileform"
-      tal:attributes="action string:${context/absolute_url}/manage_importSteps">
+      tal:attributes="action string:${context/absolute_url}/manage_fullImport">
 <select name="context_id"
         onchange="document.getElementById('profileform').submit();">
  <option value=""
@@ -43,14 +40,14 @@ For a simpler form, see the <a href="manage_importSteps">Import</a> tab.
 </select>
   <noscript>
     <input class="form-element" type="submit"
-           name="manage_advancedImportSteps:method"
+           name="manage_importSteps:method"
            value="Switch profile" />
   </noscript>
 </form>
 
 <div tal:condition="context_id|nothing">
 
-<h3>Available Import Steps for "<span tal:replace="context_title">Base profile</span>"</h3>
+<h3>Import all steps of "<span tal:replace="context_title">Base profile</span>"</h3>
 
 <p class="form-help" tal:condition="python:context.hasPendingUpgrades(context_id)">
   <strong>
@@ -61,65 +58,34 @@ For a simpler form, see the <a href="manage_importSteps">Import</a> tab.
 <form action="." method="post" enctype="multipart/form-data"
       tal:attributes="action context/absolute_url">
 <tal:dummy define="dummy python:context.applyContextById(context_id)"/>
-<input type="hidden" name="ids:default:tokens" value="" />
+<input type="hidden" name="context_id" value="" tal:attributes="value context_id"/>
 
-<table cellspacing="0" cellpadding="4">
-
- <thead>
-  <tr class="list-header">
-   <td class="list-item">Sel.</td>
-   <td class="list-item">#</td>
-   <td class="list-item">Title / Description</td>
-   <td class="list-item">Handler</td>
-  </tr>
- </thead>
-
- <tbody tal:define="step_ids context/getSortedImportSteps;
-                   ">
-  <tal:loop tal:repeat="step_id step_ids">
-  <tr valign="top"
-      tal:define="info python: context.getImportStepMetadata( step_id );"
-      tal:attributes="class python:
-                     repeat[ 'step_id' ].odd and 'row-normal' or 'row-hilite';
-                     style python:info['invalid'] and 'background: red' or None" >
-   <td class="list-item" width="16">
-    <input type="checkbox" name="ids:list" value="STEP_ID"
-           tal:attributes="id step_id;
-                           value step_id" />
-   </td>
-   <td align="right" class="list-item"
-       tal:content="repeat/step_id/number">1</td>
-   <td class="list-item">
-    <label tal:content="info/title"
-           tal:attributes="for step_id">STEP TITLE</label><br />
-    <em tal:content="info/description">STEP DESCRIPTION</em>
-   </td>
-   <td class="list-item"
-       tal:content="info/handler">DOTTED.NAME</td>
-  </tr>
-  </tal:loop>
-
-  <tr valign="top" class="list-header">
-   <td colspan="4"><strong>Import selected steps</strong></td>
-  </tr>
-
-  <tr valign="top">
-   <td />
-   <td colspan="3">
-    <input type="hidden" name="context_id" value="" tal:attributes="value context_id"/>
-    <input type="hidden" name="run_dependencies:int:default" value="0" />
-    <input class="form-element" type="checkbox" id="run_dependencies"
-           name="run_dependencies:boolean" value="1" checked="checked" />
-    <label for="run_dependencies">Include dependencies of steps?</label>
+<p>What do you want to do with dependency profiles (listed in the <code>metadata.xml</code> of the chosen profile)?</p>
+<p>
+    <input class="form-element" type="radio" id="dependency_strategy_upgrade"
+           name="dependency_strategy" value="upgrade" checked="checked" />
+    <label for="dependency_strategy_upgrade">Apply new profiles. Run <strong>upgrade</strong> steps for already applied profiles. <strong>Recommended.</strong></label>
+</p>
+<p>
+    <input class="form-element" type="radio" id="dependency_strategy_reapply"
+           name="dependency_strategy" value="reapply" />
+    <label for="dependency_strategy_reapply"><strong>Apply</strong> all profiles. Already applied profiles are reapplied.</label>
+</p>
+<p>
+    <input class="form-element" type="radio" id="dependency_strategy_new"
+           name="dependency_strategy" value="new" />
+    <label for="dependency_strategy_new">Apply <strong>only new</strong> profiles. Already applied profiles are left as is.</label>
+</p>
+<p>
+    <input class="form-element" type="radio" id="dependency_strategy_ignore"
+           name="dependency_strategy" value="ignore" />
+    <label for="dependency_strategy_ignore"><strong>Ignore</strong> dependency profiles.</label>
+</p>
+<p>
     <input class="form-element" type="submit"
-           name="manage_importSelectedSteps:method"
-           value=" Import selected steps " />
-
-   </td>
-  </tr>
-
- </tbody>
-</table>
+           name="manage_importAllSteps:method"
+           value=" Import all steps " />
+</p>
 
 <table cellspacing="0" cellpadding="4"
        tal:condition="options/messages | nothing">

--- a/Products/GenericSetup/www/sutFullImport.zpt
+++ b/Products/GenericSetup/www/sutFullImport.zpt
@@ -6,7 +6,7 @@
                    context_title python:[c['title'] for c in contexts if c['id']==context_id];
                    context_title python:context_title and context_title[0] or 'UNKNOWN';
                    extension_contexts python:[c for c in contexts if c['type'] in ['extension','snapshot']];
-                   extension_contexts_ordered_by_id python:[c for c in context.listContextInfos(order_by='id') if c['type'] in ['extension','snapshot']];
+                   extension_contexts_ordered_by_id python:[c for c in context.listContextInfos(order_by='sortable_id') if c['type'] in ['extension','snapshot']];
                    has_pending_upgrades context/hasPendingUpgrades;
                    ">
 <h1 tal:replace="structure context/manage_page_header">PAGE HEADER</h1>

--- a/Products/GenericSetup/www/sutFullImport.zpt
+++ b/Products/GenericSetup/www/sutFullImport.zpt
@@ -15,7 +15,7 @@
 
 <p class="form-help">
 For advanced options, like re-running individual steps,
-see the <a href="manage_advancedImportSteps">Advanced Import</a> tab.
+see the <a href="manage_importSteps">Advanced Import</a> tab.
 </p>
 <p class="form-help" tal:condition="has_pending_upgrades">
   <strong>

--- a/Products/GenericSetup/www/sutFullImport.zpt
+++ b/Products/GenericSetup/www/sutFullImport.zpt
@@ -6,6 +6,7 @@
                    context_title python:[c['title'] for c in contexts if c['id']==context_id];
                    context_title python:context_title and context_title[0] or 'UNKNOWN';
                    extension_contexts python:[c for c in contexts if c['type'] in ['extension','snapshot']];
+                   extension_contexts_ordered_by_id python:[c for c in context.listContextInfos(order_by='id') if c['type'] in ['extension','snapshot']];
                    has_pending_upgrades context/hasPendingUpgrades;
                    ">
 <h1 tal:replace="structure context/manage_page_header">PAGE HEADER</h1>
@@ -41,9 +42,9 @@ see the <a href="manage_importSteps">Advanced Import</a> tab.
  <option value=""
          tal:attributes="value base_context_id;
                          selected python:context_id==base_context_id">
-   Current base profile (<span tal:replace="base_context_title"/>)</option>
+   Current base profile (<span tal:replace="python:base_context_title if select_key == 'title' else base_context_id"/>)</option>
  <option value="context-CONTEXT_ID"
-    tal:repeat="context extension_contexts"
+    tal:repeat="context python:extension_contexts if select_key == 'title' else extension_contexts_ordered_by_id"
     tal:attributes="value context/id; selected python:context_id==context['id']"
     tal:content="python:context[select_key]">Context title or id</option>
 </select>

--- a/Products/GenericSetup/www/sutFullImport.zpt
+++ b/Products/GenericSetup/www/sutFullImport.zpt
@@ -1,5 +1,5 @@
 <tal:block define="base_context_id context/getBaselineContextID;
-                   context_id request/context_id|base_context_id;
+                   context_id request/context_id|nothing;
                    contexts context/listContextInfos;
                    base_context_title python:[c['title'] for c in contexts if c['id']==base_context_id];
                    base_context_title python:base_context_title and base_context_title[0] or 'NOT SET';
@@ -24,11 +24,16 @@ see the <a href="manage_importSteps">Advanced Import</a> tab.
 </p>
 
 <h3>Select Profile or Snapshot</h3>
-
+<p class="form-help">
+  After you have selected a profile, you will get some options.
+</p>
 <form action="." method="post" id="profileform"
       tal:attributes="action string:${context/absolute_url}/manage_fullImport">
 <select name="context_id"
         onchange="document.getElementById('profileform').submit();">
+ <option value=""
+         tal:attributes="selected not:context_id">
+ Please select an option</option>
  <option value=""
          tal:attributes="value base_context_id;
                          selected python:context_id==base_context_id">
@@ -57,7 +62,6 @@ see the <a href="manage_importSteps">Advanced Import</a> tab.
 </p>
 <form action="." method="post" enctype="multipart/form-data"
       tal:attributes="action context/absolute_url">
-<tal:dummy define="dummy python:context.applyContextById(context_id)"/>
 <input type="hidden" name="context_id" value="" tal:attributes="value context_id"/>
 
 <p>What do you want to do with dependency profiles (listed in the <code>metadata.xml</code> of the chosen profile)?</p>

--- a/Products/GenericSetup/www/sutFullImport.zpt
+++ b/Products/GenericSetup/www/sutFullImport.zpt
@@ -64,6 +64,7 @@ see the <a href="manage_importSteps">Advanced Import</a> tab.
       tal:attributes="action context/absolute_url">
 <input type="hidden" name="context_id" value="" tal:attributes="value context_id"/>
 
+<tal:dependencies condition="python:len(context.getProfileDependencyChain(context_id)) &gt; 1">
 <p>What do you want to do with dependency profiles (listed in the <code>metadata.xml</code> of the chosen profile)?</p>
 <p>
     <input class="form-element" type="radio" id="dependency_strategy_upgrade"
@@ -85,6 +86,8 @@ see the <a href="manage_importSteps">Advanced Import</a> tab.
            name="dependency_strategy" value="ignore" />
     <label for="dependency_strategy_ignore"><strong>Ignore</strong> dependency profiles.</label>
 </p>
+</tal:dependencies>
+
 <p>
     <input class="form-element" type="submit"
            name="manage_importAllSteps:method"

--- a/Products/GenericSetup/www/sutImportSteps.zpt
+++ b/Products/GenericSetup/www/sutImportSteps.zpt
@@ -43,7 +43,7 @@ For a simpler form, see the <a href="manage_importSteps">Import</a> tab.
 </select>
   <noscript>
     <input class="form-element" type="submit"
-           name="manage_advancedImportSteps:method"
+           name="manage_importSteps:method"
            value="Switch profile" />
   </noscript>
 </form>

--- a/Products/GenericSetup/www/sutImportSteps.zpt
+++ b/Products/GenericSetup/www/sutImportSteps.zpt
@@ -100,7 +100,9 @@ For a simpler form, see the <a href="manage_importSteps">Import</a> tab.
   </tal:loop>
 
   <tr valign="top">
-   <td colspan="4"><strong onclick="inputs = document.getElementsByTagName('input'); for (var index = 0; index &lt; inputs.length; index++) {inputs[index].checked = inputs[index].checked ? false : true};">Toggle selection</strong></td>
+    <td colspan="4">
+      <button type="button" onclick="inputs = document.getElementsByTagName('input'); for (var index = 0; index &lt; inputs.length; index++) {inputs[index].checked = inputs[index].checked ? false : true}; return false;">Toggle selection</button>
+    </td>
   </tr>
 
 

--- a/Products/GenericSetup/www/sutImportSteps.zpt
+++ b/Products/GenericSetup/www/sutImportSteps.zpt
@@ -6,6 +6,7 @@
                    context_title python:[c['title'] for c in contexts if c['id']==context_id];
                    context_title python:context_title and context_title[0] or 'UNKNOWN';
                    extension_contexts python:[c for c in contexts if c['type'] in ['extension','snapshot']];
+                   has_pending_upgrades context/hasPendingUpgrades;
                    ">
 <h1 tal:replace="structure context/manage_page_header">PAGE HEADER</h1>
 <h2 tal:replace="structure context/manage_tabs">TABS</h2>
@@ -15,6 +16,11 @@
 <p class="form-help">
 This tool allows one to re-run individual steps of the site setup
 procedure, in order to pick up changes since the site was created.
+</p>
+<p class="form-help" tal:condition="has_pending_upgrades">
+  <strong>
+    Note: there are profiles with pending <a href="manage_upgrades">upgrades</a>.
+  </strong>
 </p>
 
 <h3>Select Profile or Snapshot</h3>
@@ -42,6 +48,12 @@ procedure, in order to pick up changes since the site was created.
 
 <h3>Available Import Steps for "<span tal:replace="context_title">Base profile</span>"</h3>
 
+<p class="form-help" tal:condition="python:context.hasPendingUpgrades(context_id)">
+  <strong>
+    Note: there are pending <a href="manage_upgrades" tal:attributes="href string:manage_upgrades?profile_id=${context_id}">upgrades</a> for
+    this profile.
+  </strong>
+</p>
 <form action="." method="post" enctype="multipart/form-data"
       tal:attributes="action context/absolute_url" >
 <tal:dummy define="dummy python:context.applyContextById(context_id)"/>

--- a/Products/GenericSetup/www/sutImportSteps.zpt
+++ b/Products/GenericSetup/www/sutImportSteps.zpt
@@ -84,6 +84,7 @@ For a simpler form, see the <a href="manage_importSteps">Import</a> tab.
                      style python:info['invalid'] and 'background: red' or None" >
    <td class="list-item" width="16">
     <input type="checkbox" name="ids:list" value="STEP_ID"
+           class="step_checkbox"
            tal:attributes="id step_id;
                            value step_id" />
    </td>
@@ -101,7 +102,7 @@ For a simpler form, see the <a href="manage_importSteps">Import</a> tab.
 
   <tr valign="top">
     <td colspan="4">
-      <button type="button" onclick="inputs = document.getElementsByTagName('input'); for (var index = 0; index &lt; inputs.length; index++) {inputs[index].checked = inputs[index].checked ? false : true}; return false;">Toggle selection</button>
+      <button type="button" onclick="inputs = document.querySelectorAll('.step_checkbox'); for (var index = 0; index &lt; inputs.length; index++) {inputs[index].checked = inputs[index].checked ? false : true}; return false;">Toggle selection</button>
     </td>
   </tr>
 

--- a/Products/GenericSetup/www/sutImportSteps.zpt
+++ b/Products/GenericSetup/www/sutImportSteps.zpt
@@ -6,6 +6,7 @@
                    context_title python:[c['title'] for c in contexts if c['id']==context_id];
                    context_title python:context_title and context_title[0] or 'UNKNOWN';
                    extension_contexts python:[c for c in contexts if c['type'] in ['extension','snapshot']];
+                   extension_contexts_ordered_by_id python:[c for c in context.listContextInfos(order_by='id') if c['type'] in ['extension','snapshot']];
                    has_pending_upgrades context/hasPendingUpgrades;
                    ">
 <h1 tal:replace="structure context/manage_page_header">PAGE HEADER</h1>
@@ -44,9 +45,9 @@ For a simpler form, see the <a href="manage_importSteps">Import</a> tab.
  <option value=""
          tal:attributes="value base_context_id;
                          selected python:context_id==base_context_id">
-   Current base profile (<span tal:replace="base_context_title"/>)</option>
+   Current base profile (<span tal:replace="python:base_context_title if select_key == 'title' else base_context_id"/>)</option>
  <option value="context-CONTEXT_ID"
-    tal:repeat="context extension_contexts"
+    tal:repeat="context python:extension_contexts if select_key == 'title' else extension_contexts_ordered_by_id"
     tal:attributes="value context/id; selected python:context_id==context['id']"
     tal:content="python:context[select_key]">Context title or id</option>
 </select>

--- a/Products/GenericSetup/www/sutImportSteps.zpt
+++ b/Products/GenericSetup/www/sutImportSteps.zpt
@@ -6,7 +6,7 @@
                    context_title python:[c['title'] for c in contexts if c['id']==context_id];
                    context_title python:context_title and context_title[0] or 'UNKNOWN';
                    extension_contexts python:[c for c in contexts if c['type'] in ['extension','snapshot']];
-                   extension_contexts_ordered_by_id python:[c for c in context.listContextInfos(order_by='id') if c['type'] in ['extension','snapshot']];
+                   extension_contexts_ordered_by_id python:[c for c in context.listContextInfos(order_by='sortable_id') if c['type'] in ['extension','snapshot']];
                    has_pending_upgrades context/hasPendingUpgrades;
                    ">
 <h1 tal:replace="structure context/manage_page_header">PAGE HEADER</h1>

--- a/Products/GenericSetup/www/sutImportSteps.zpt
+++ b/Products/GenericSetup/www/sutImportSteps.zpt
@@ -99,6 +99,11 @@ For a simpler form, see the <a href="manage_importSteps">Import</a> tab.
   </tr>
   </tal:loop>
 
+  <tr valign="top">
+   <td colspan="4"><strong onclick="inputs = document.getElementsByTagName('input'); for (var index = 0; index &lt; inputs.length; index++) {inputs[index].checked = inputs[index].checked ? false : true};">Toggle selection</strong></td>
+  </tr>
+
+
   <tr valign="top" class="list-header">
    <td colspan="4"><strong>Import selected steps</strong></td>
   </tr>

--- a/Products/GenericSetup/www/sutImportSteps.zpt
+++ b/Products/GenericSetup/www/sutImportSteps.zpt
@@ -60,6 +60,12 @@ For a simpler form, see the <a href="manage_importSteps">Import</a> tab.
 
 <div tal:condition="context_id|nothing">
 
+<p tal:condition="python:context_id == base_context_id"
+   style="color: red">
+You have selected the baseline profile.
+Reapplying these import steps is potentially a dangerous operation.
+</p>
+
 <h3>Available Import Steps for "<span tal:replace="context_title">Base profile</span>"</h3>
 
 <p class="form-help" tal:condition="python:context.hasPendingUpgrades(context_id)">

--- a/Products/GenericSetup/www/sutImportSteps.zpt
+++ b/Products/GenericSetup/www/sutImportSteps.zpt
@@ -1,5 +1,5 @@
 <tal:block define="base_context_id context/getBaselineContextID;
-                   context_id request/context_id|base_context_id;
+                   context_id request/context_id|nothing;
                    contexts context/listContextInfos;
                    base_context_title python:[c['title'] for c in contexts if c['id']==base_context_id];
                    base_context_title python:base_context_title and base_context_title[0] or 'NOT SET';
@@ -27,11 +27,16 @@ For a simpler form, see the <a href="manage_importSteps">Import</a> tab.
 </p>
 
 <h3>Select Profile or Snapshot</h3>
-
+<p class="form-help">
+  After you have selected a profile, you will get some options.
+</p>
 <form action="." method="post" id="profileform"
       tal:attributes="action string:${context/absolute_url}/manage_importSteps">
 <select name="context_id"
         onchange="document.getElementById('profileform').submit();">
+ <option value=""
+         tal:attributes="selected not:context_id">
+ Please select an option</option>
  <option value=""
          tal:attributes="value base_context_id;
                          selected python:context_id==base_context_id">

--- a/Products/GenericSetup/www/sutImportSteps.zpt
+++ b/Products/GenericSetup/www/sutImportSteps.zpt
@@ -30,10 +30,14 @@ For a simpler form, see the <a href="manage_importSteps">Import</a> tab.
 <p class="form-help">
   After you have selected a profile, you will get some options.
 </p>
+<tal:title_or_id repeat="select_key python:['title', 'id']">
 <form action="." method="post" id="profileform"
-      tal:attributes="action string:${context/absolute_url}/manage_importSteps">
+      tal:attributes="action string:${context/absolute_url}/manage_importSteps;
+                      id string:profileform_${select_key}">
+  <p tal:condition="python:select_key == 'title'">You can select a profile by <strong>title</strong>:</p>
+  <p tal:condition="python:select_key == 'id'">or you can select a profile by <strong>id</strong>:</p>
 <select name="context_id"
-        onchange="document.getElementById('profileform').submit();">
+        tal:attributes="onchange string:document.getElementById('profileform_${select_key}').submit();">
  <option value=""
          tal:attributes="selected not:context_id">
  Please select an option</option>
@@ -44,7 +48,7 @@ For a simpler form, see the <a href="manage_importSteps">Import</a> tab.
  <option value="context-CONTEXT_ID"
     tal:repeat="context extension_contexts"
     tal:attributes="value context/id; selected python:context_id==context['id']"
-    tal:content="context/title">CONTEXT_TITLE</option>
+    tal:content="python:context[select_key]">Context title or id</option>
 </select>
   <noscript>
     <input class="form-element" type="submit"
@@ -52,6 +56,7 @@ For a simpler form, see the <a href="manage_importSteps">Import</a> tab.
            value="Switch profile" />
   </noscript>
 </form>
+</tal:title_or_id>
 
 <div tal:condition="context_id|nothing">
 

--- a/Products/GenericSetup/www/sutTarballImport.zpt
+++ b/Products/GenericSetup/www/sutTarballImport.zpt
@@ -1,0 +1,35 @@
+<h1 tal:replace="structure context/manage_page_header">PAGE HEADER</h1>
+<h2 tal:replace="structure context/manage_tabs">TABS</h2>
+
+<h3>Import uploaded tarball</h3>
+
+<form action="." method="post" enctype="multipart/form-data"
+      tal:attributes="action context/absolute_url">
+
+<p>
+    <input class="form-element" type="file"
+           name="tarball" />
+    <input class="form-element" type="submit"
+           name="manage_importTarball:method"
+           value=" Import uploaded tarball " />
+</p>
+
+<table cellspacing="0" cellpadding="4"
+       tal:condition="options/messages | nothing">
+
+  <tr class="list-header">
+   <td colspan="4">Message Log</td>
+  </tr>
+
+  <tr valign="top"
+      tal:repeat="item options/messages/items">
+   <td tal:content="python: item[0]">STEP</td>
+   <td colspan="3"
+       tal:content="structure python: item[1].replace('\n', '&lt;br /&gt;')"
+       >MESSAGE</td>
+  </tr>
+
+</table>
+</form>
+
+<h1 tal:replace="structure context/manage_page_footer">PAGE FOOTER</h1>

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
+- Split overly complex Import tab into three tabs: Import (for
+  importing a full profile), Advanced Import (the original
+  ``manage_importSteps`` url leads to this tab), and Tarball Import.
+  [maurits]
+
 - Show note on import tab when there are pending upgrades.  Especially
   show this for the currently selected profile.
   [maurits]

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
+- Fixed importing a tarball.  This got an AttributeError: "'NoneType'
+  object has no attribute 'startswith'".
+  [maurits]
+
 - Split overly complex Import tab into three tabs: Import (for
   importing a full profile), Advanced Import (the original
   ``manage_importSteps`` url leads to this tab), and Tarball Import.

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,13 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Upgrades tab: show profiles with pending upgrades separately.  These
+  are the most important ones.  This avoids the need to manually go
+  through the whole list in order to find profiles that may need
+  action.  This uses new methods on the setup tool:
+  ``hasPendingUpgrades``, ``listProfilesWithPendingUpgrades``,
+  ``listUptodateProfiles``.
+  [maurits]
 
 
 1.8.1 (2015-12-16)

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
+- Show note on import tab when there are pending upgrades.  Especially
+  show this for the currently selected profile.
+  [maurits]
+
 - Upgrades tab: show profiles with pending upgrades separately.  These
   are the most important ones.  This avoids the need to manually go
   through the whole list in order to find profiles that may need

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
+- Added simple toggle for all steps on the advanced import tab.
+  [maurits]
+
 - Fixed importing a tarball.  This got an AttributeError: "'NoneType'
   object has no attribute 'startswith'".
   [maurits]

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,16 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
+- Sorted import profiles alphabetically lowercase.  Allow selecting a
+  profile by title or id.  [maurits]
+
+- Do not show dependency options on the full import tab when there are
+  no dependencies.  [maurits]
+
+- Do not select a profile by default in the import tabs.  [maurits]
+
 - Added simple toggle for all steps on the advanced import tab.
+  Also added this on the export tab.
   [maurits]
 
 - Fixed importing a tarball.  This got an AttributeError: "'NoneType'


### PR DESCRIPTION
The portal_setup UI for imports and upgrades could use some love. See some notes in this discussion of September, when I made it more complicated: http://permalink.gmane.org/gmane.comp.web.zope.cmf/19479

Changes are:

- Upgrades tab: show profiles with pending upgrades separately. These are the most important ones. This avoids the need to manually go through the whole list in order to find profiles that may need action.

- Show note on import tab when there are pending upgrades. Especially show this for the currently selected profile.

- Split overly complex Import tab into three tabs: Import (for importing a full profile), Advanced Import (the original manage_importSteps url leads to this tab), and Tarball Import.

- Fixed importing a tarball. This got an AttributeError: "'NoneType' object has no attribute 'startswith'". This is broken since 1.8.1, released last week. And I think I am the one who broke it...

Screen shots from the three Import tabs:

## Import tab (full import):

![screen shot 2015-12-23 at 01 38 00](https://cloud.githubusercontent.com/assets/210587/11969168/3a848272-a916-11e5-86a5-ac006ebdc9f4.png)

## Advanced import tab:

![screen shot 2015-12-23 at 01 38 38](https://cloud.githubusercontent.com/assets/210587/11969172/4cbf26c2-a916-11e5-98c3-61f056b42f2a.png)

## Tarball import tab:

![screen shot 2015-12-23 at 01 39 33](https://cloud.githubusercontent.com/assets/210587/11969190/7894c8e2-a916-11e5-907a-21b326a6ec63.png)

## Upgrades tab

This is the Upgrades tab when I use this in a Plone site that has pending upgrade steps:

![screen shot 2015-12-23 at 01 46 50](https://cloud.githubusercontent.com/assets/210587/11969252/417781c8-a917-11e5-9684-30583e8b112c.png)

