### PR TITLE
Added optional pre_handler and post_handler to registerProfile.

### DIFF
--- a/Products/GenericSetup/registry.py
+++ b/Products/GenericSetup/registry.py
@@ -690,12 +690,23 @@ class ProfileRegistry(Implicit):
 
     security.declareProtected(ManagePortal, 'registerProfile')
     def registerProfile(self, name, title, description, path, product=None,
-                        profile_type=BASE, for_=None):
+                        profile_type=BASE, for_=None, pre_handler=None,
+                        post_handler=None):
         """ See IProfileRegistry.
         """
         profile_id = self._computeProfileId(name, product)
         if self._registered.get(profile_id) is not None:
             raise KeyError('Duplicate profile ID: %s' % profile_id)
+
+        # Typos in pre/post handler should be caught on zope startup.
+        if pre_handler:
+            if _resolveDottedName(pre_handler) is None:
+                raise ValueError('pre_handler points to non existing '
+                                 'function: %s' % pre_handler)
+        if post_handler:
+            if _resolveDottedName(post_handler) is None:
+                raise ValueError('post_handler points to non existing '
+                                 'function: %s' % post_handler)
 
         info = {'id': profile_id,
                 'title': title,
@@ -703,7 +714,10 @@ class ProfileRegistry(Implicit):
                 'path': path,
                 'product': product,
                 'type': profile_type,
-                'for': for_}
+                'for': for_,
+                'pre_handler': pre_handler,
+                'post_handler': post_handler,
+                }
 
         metadata = ProfileMetadata(path, product=product)()
 

--- a/Products/GenericSetup/tests/test_registry.py
+++ b/Products/GenericSetup/tests/test_registry.py
@@ -899,6 +899,8 @@ class ProfileRegistryTests(BaseRegistryTests, ConformsToIProfileRegistry
         self.assertEqual(info['product'], PRODUCT)
         self.assertEqual(info['type'], PROFILE_TYPE)
         self.assertEqual(info['for'], None)
+        self.assertEqual(info['pre_handler'], None)
+        self.assertEqual(info['post_handler'], None)
 
         # We strip off any 'profile-' or 'snapshot-' at the beginning
         # of the profile id.

--- a/Products/GenericSetup/zcml.py
+++ b/Products/GenericSetup/zcml.py
@@ -67,9 +67,22 @@ class IRegisterProfileDirective(Interface):
         default=None,
         required=False)
 
+    pre_handler = GlobalObject(
+        title=u'Pre handler',
+        description=(u'Function called before applying all steps. '
+                     'It gets passed the setup tool as context.'),
+        required=False)
+
+    post_handler = GlobalObject(
+        title=u'Post handler',
+        description=(u'Function called after applying all steps. '
+                     'It gets passed the setup tool as context.'),
+        required=False)
+
 
 def registerProfile(_context, name=u'default', title=None, description=None,
-                    directory=None, provides=BASE, for_=None):
+                    directory=None, provides=BASE, for_=None,
+                    pre_handler=None, post_handler=None):
     """ Add a new profile to the registry.
     """
     product = _context.package.__name__
@@ -85,7 +98,8 @@ def registerProfile(_context, name=u'default', title=None, description=None,
     _context.action(
         discriminator=('registerProfile', product, name),
         callable=_profile_registry.registerProfile,
-        args=(name, title, description, directory, product, provides, for_)
+        args=(name, title, description, directory, product, provides, for_,
+              pre_handler, post_handler)
         )
 
 

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
+- Added optional ``pre_handler`` and ``post_handler`` to
+  ``registerProfile`` directive.  When set, these dotted names are
+  resolved to a function and are passed the setup tool as single
+  argument.  They are called before and after applying all import
+  steps of the profile they are registered for.  [maurits]
+
 - Sorted import profiles alphabetically lowercase.  Allow selecting a
   profile by title or id.  [maurits]
 


### PR DESCRIPTION
When set, these dotted names are resolved to a function and are passed the setup tool as single argument. They are called before and after applying all import steps of the profile they are registered for.

This is an alternative for writing an import step that reads a txt 'flag' file so it only runs for a single profile. This is a common scenario in Plone add-ons and also in my client projects, and I guess in the wider CMF community. It works, but may be perceived as an ugly hack, as in this issue: https://github.com/plone/Products.CMFPlone/issues/1070
The code from this pull request is based on one of the options I mentioned in that issue.

Heh, that reminds me of a blog post by myself in 2007 when I discovered how this part of GenericSetup worked: http://maurits.vanrees.org/weblog/archive/2007/06/discovering-genericsetup