### PR TITLE
Allowed overriding required and forbidden tools in ``toolset.xml``.

### DIFF
--- a/Products/GenericSetup/registry.py
+++ b/Products/GenericSetup/registry.py
@@ -83,10 +83,12 @@ class _ToolsetParser(_HandlerBase):
         tool_id = self._extract(attrs, 'tool_id')
         remove = self._extract(attrs, 'remove')
         if remove is not None:
+            opposite = 'required' if name == 'forbidden' else 'forbidden'
             raise ValueError(
                 "The 'remove' keyword is not supported in toolset.xml. "
-                "Failed to remove {0} from {1} tools".format(
-                    tool_id, name))
+                "Failed to remove '{0}' from {1} tools. "
+                "Use an element '{2}' instead.".format(
+                    tool_id, name, opposite))
 
         if name == 'forbidden':
             if tool_id not in self._forbidden:

--- a/Products/GenericSetup/registry.py
+++ b/Products/GenericSetup/registry.py
@@ -78,16 +78,21 @@ class _ToolsetParser(_HandlerBase):
 
     def startElement(self, name, attrs):
         if name == 'tool-setup':
-            pass
+            return
 
-        elif name == 'forbidden':
-            tool_id = self._extract(attrs, 'tool_id')
+        tool_id = self._extract(attrs, 'tool_id')
+        remove = self._extract(attrs, 'remove')
+        if remove is not None:
+            raise ValueError(
+                "The 'remove' keyword is not supported in toolset.xml. "
+                "Failed to remove {0} from {1} tools".format(
+                    tool_id, name))
 
+        if name == 'forbidden':
             if tool_id not in self._forbidden:
                 self._forbidden.append(tool_id)
 
         elif name == 'required':
-            tool_id = self._extract(attrs, 'tool_id')
             dotted_name = self._extract(attrs, 'class')
             self._required[tool_id] = dotted_name
 

--- a/Products/GenericSetup/registry.py
+++ b/Products/GenericSetup/registry.py
@@ -552,11 +552,10 @@ class ToolsetRegistry(Implicit):
     def addForbiddenTool(self, tool_id):
         """ See IToolsetRegistry.
         """
+        self._required.pop(tool_id, None)
+
         if tool_id in self._forbidden:
             return
-
-        if self._required.get(tool_id) is not None:
-            raise ValueError('Tool %s is required!' % tool_id)
 
         self._forbidden.append(tool_id)
 
@@ -586,7 +585,7 @@ class ToolsetRegistry(Implicit):
         """ See IToolsetRegistry.
         """
         if tool_id in self._forbidden:
-            raise ValueError("Forbidden tool ID: %s" % tool_id)
+            self._forbidden.remove(tool_id)
 
         self._required[tool_id] = {'id': tool_id, 'class': dotted_name}
 

--- a/Products/GenericSetup/registry.py
+++ b/Products/GenericSetup/registry.py
@@ -559,7 +559,8 @@ class ToolsetRegistry(Implicit):
     def addForbiddenTool(self, tool_id):
         """ See IToolsetRegistry.
         """
-        self._required.pop(tool_id, None)
+        if tool_id in self._required:
+            del self._required[tool_id]
 
         if tool_id in self._forbidden:
             return

--- a/Products/GenericSetup/tests/test_registry.py
+++ b/Products/GenericSetup/tests/test_registry.py
@@ -714,9 +714,12 @@ class ToolsetRegistryTests(BaseRegistryTests, ConformsToIToolsetRegistry
         configurator = self._makeOne().__of__(site)
 
         configurator.addRequiredTool('required', 'some.dotted.name')
+        self.assertEqual(len(configurator.listRequiredToolInfo()), 1)
+        self.assertEqual(len(configurator.listForbiddenTools()), 0)
 
-        self.assertRaises(
-            ValueError, configurator.addForbiddenTool, 'required')
+        configurator.addForbiddenTool('required')
+        self.assertEqual(len(configurator.listRequiredToolInfo()), 0)
+        self.assertEqual(len(configurator.listForbiddenTools()), 1)
 
     def test_addRequiredTool_multiple(self):
 
@@ -760,9 +763,12 @@ class ToolsetRegistryTests(BaseRegistryTests, ConformsToIToolsetRegistry
         configurator = self._makeOne().__of__(site)
 
         configurator.addForbiddenTool('forbidden')
+        self.assertEqual(len(configurator.listRequiredToolInfo()), 0)
+        self.assertEqual(len(configurator.listForbiddenTools()), 1)
 
-        self.assertRaises(ValueError, configurator.addRequiredTool, 'forbidden', 'a.name'
-                          )
+        configurator.addRequiredTool('forbidden', 'a.name')
+        self.assertEqual(len(configurator.listRequiredToolInfo()), 1)
+        self.assertEqual(len(configurator.listForbiddenTools()), 0)
 
     def test_generateXML_empty(self):
 
@@ -817,8 +823,9 @@ class ToolsetRegistryTests(BaseRegistryTests, ConformsToIToolsetRegistry
         site = self._initSite()
         configurator = self._makeOne().__of__(site)
 
-        self.assertRaises(ValueError, configurator.parseXML,
-                          _CONFUSED_TOOLSET_XML)
+        configurator.parseXML(_CONFUSED_TOOLSET_XML)
+        self.assertEqual(len(configurator.listForbiddenTools()), 0)
+        self.assertEqual(len(configurator.listRequiredToolInfo()), 1)
 
 
 _EMPTY_TOOLSET_XML = """\

--- a/Products/GenericSetup/tests/test_registry.py
+++ b/Products/GenericSetup/tests/test_registry.py
@@ -827,6 +827,15 @@ class ToolsetRegistryTests(BaseRegistryTests, ConformsToIToolsetRegistry
         self.assertEqual(len(configurator.listForbiddenTools()), 0)
         self.assertEqual(len(configurator.listRequiredToolInfo()), 1)
 
+    def test_parseXML_wrong(self):
+
+        site = self._initSite()
+        configurator = self._makeOne().__of__(site)
+
+        # The 'remove' keyword is explicitly not supported.
+        self.assertRaises(
+            ValueError, configurator.parseXML, _WRONG_TOOLSET_XML)
+
 
 _EMPTY_TOOLSET_XML = """\
 <?xml version="1.0"?>
@@ -848,6 +857,13 @@ _CONFUSED_TOOLSET_XML = """\
 <tool-setup>
  <forbidden tool_id="confused" />
  <required tool_id="confused" class="path.to.one" />
+</tool-setup>
+"""
+
+_WRONG_TOOLSET_XML = """\
+<?xml version="1.0"?>
+<tool-setup>
+ <required tool_id="confused" class="path.to.one" remove="" />
 </tool-setup>
 """
 

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -6,7 +6,12 @@ Changelog
 
 New:
 
-- *add item here*
+- Allowed overriding required and forbidden tools in ``toolset.xml``.
+  If a tool is currently required and you import a ``toolset.xml``
+  where it is forbidden, we remove the tool from the required list and
+  add it to the forbidden list.  And the other way around.  The
+  previous behavior was to raise an exception, which left no way in
+  xml to remove a tool.  [maurits]
 
 Fixes:
 

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -11,7 +11,8 @@ New:
   where it is forbidden, we remove the tool from the required list and
   add it to the forbidden list.  And the other way around.  The
   previous behavior was to raise an exception, which left no way in
-  xml to remove a tool.  [maurits]
+  xml to remove a tool.  Fail with a ValueError when the ``remove``
+  keyword is used.  The expected behavior is unclear.  [maurits]
 
 Fixes:
 


### PR DESCRIPTION
If a tool is currently required and you import a ``toolset.xml`` where it is forbidden, we remove the tool from the required list and add it to the forbidden list.  And the other way around.

The previous behavior was to raise an exception, which left no way in xml to remove a tool.

I can imagine an alternative: start supporting the remove keyword in this xml file.  Then we can say: use 'remove' to remove a required tool and then register a forbidden tool with the same name so this tool is removed from the site if it is there.