### PR TITLE
Fixed pre/post handlers registered in zcml.

### DIFF
--- a/Products/GenericSetup/registry.py
+++ b/Products/GenericSetup/registry.py
@@ -39,6 +39,8 @@ from Products.GenericSetup.utils import _resolveDottedName
 from Products.GenericSetup.utils import _extractDocstring
 from Products.GenericSetup.utils import _computeTopologicalSort
 
+import types
+
 #
 #   XML parser
 #
@@ -700,11 +702,13 @@ class ProfileRegistry(Implicit):
 
         # Typos in pre/post handler should be caught on zope startup.
         if pre_handler:
-            if _resolveDottedName(pre_handler) is None:
+            if (not isinstance(pre_handler, types.FunctionType) and
+                    _resolveDottedName(pre_handler) is None):
                 raise ValueError('pre_handler points to non existing '
                                  'function: %s' % pre_handler)
         if post_handler:
-            if _resolveDottedName(post_handler) is None:
+            if (not isinstance(post_handler, types.FunctionType) and
+                    _resolveDottedName(post_handler) is None):
                 raise ValueError('post_handler points to non existing '
                                  'function: %s' % post_handler)
 

--- a/Products/GenericSetup/tests/test_tool.py
+++ b/Products/GenericSetup/tests/test_tool.py
@@ -803,13 +803,29 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
             'foo', 'Foo', '', self._PROFILE_PATH,
             post_handler='Products.GenericSetup.tests.test_tool.foo_handler')
 
-    def test_runAllImportStepsFromProfile_with_pre_post_handlers(self):
+    def test_runAllImportStepsFromProfile_with_pre_post_handlers_dotted_names(self):
         site = self._makeSite()
         tool = self._makeOne('setup_tool').__of__(site)
         profile_registry.registerProfile(
             'foo', 'Foo', '', self._PROFILE_PATH,
             pre_handler='Products.GenericSetup.tests.test_tool.pre_handler',
             post_handler='Products.GenericSetup.tests.test_tool.post_handler')
+        tool.runAllImportStepsFromProfile('profile-other:foo')
+        self.assertEqual(tool.pre_handler_called, 1)
+        self.assertEqual(tool.post_handler_called, 1)
+        tool.runAllImportStepsFromProfile('profile-other:foo')
+        self.assertEqual(tool.pre_handler_called, 2)
+        self.assertEqual(tool.post_handler_called, 2)
+
+    def test_runAllImportStepsFromProfile_with_pre_post_handlers_functions(self):
+        # When you register a profile with pre/post handlers in zcml, you do
+        # not get dotted names (strings) but an actual function.
+        site = self._makeSite()
+        tool = self._makeOne('setup_tool').__of__(site)
+        profile_registry.registerProfile(
+            'foo', 'Foo', '', self._PROFILE_PATH,
+            pre_handler=pre_handler,
+            post_handler=post_handler)
         tool.runAllImportStepsFromProfile('profile-other:foo')
         self.assertEqual(tool.pre_handler_called, 1)
         self.assertEqual(tool.post_handler_called, 1)

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -16,6 +16,7 @@
 import logging
 import os
 import time
+import types
 from cgi import escape
 from operator import itemgetter
 
@@ -1256,12 +1257,16 @@ class SetupTool(Folder):
     def _doRunHandler(self, handler):
         """Run a single handler.
 
-        This is expected to be a dotted name of a pre_handler or
-        post_handler of a profile.  It is passed the tool as context.
+        This is expected to be a function or a dotted name of a
+        pre_handler or post_handler of a profile.  It is passed the tool
+        as context.
         """
-        handler_function = _resolveDottedName(handler)
-        if handler_function is None:
-            raise ValueError('Invalid handler: %s' % handler)
+        if isinstance(handler, types.FunctionType):
+            handler_function = handler
+        else:
+            handler_function = _resolveDottedName(handler)
+            if handler_function is None:
+                raise ValueError('Invalid handler: %s' % handler)
         return handler_function(self)
 
     security.declareProtected(ManagePortal, 'getProfileDependencyChain')


### PR DESCRIPTION
We expected dotted names, but in zcml you actually get function objects.