### PR TITLE
Made _profile_upgrade_versions a PersistentMapping.

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 1.8.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Made ``_profile_upgrade_versions`` a PersistentMapping.  When
+  ``(un)setLastVersionForProfile`` is called, we migrate the original
+  Python dictionary.  This makes some code easier and plays nicer with
+  transactions, which may especially help during tests.  [maurits]
 
 
 1.8.3 (2016-04-28)


### PR DESCRIPTION
When `(un)setLastVersionForProfile` is called, we migrate the original Python dictionary.  This makes some code easier and plays nicer with transactions, which may especially help during tests.

Care is taken to not break existing tools, which might still have the original dictionary class attribute.

I ran into this when making a pull request for plone.app.testing. A site was setup in a base test layer, a few versions were added in `_profile_upgrade_versions` in a second test layer, the second test layer was torn down (presumably internally with a transaction abort), but the versions remained on the tool.  See https://github.com/plone/plone.app.testing/pull/29/commits/cb90010d6ee2c20c8015957dade4f1c59c9a4594

Also, by setting the `_profile_upgrade_versions` attribute in the `__init__` method instead of only as a class attribute, we avoid sharing state between two instances of the tool, although this would only happen if someone modifies this attribute directly instead of via `(un)setLastVersionForProfile`.