### PR TITLE
remove use of formlib to render the components tab

### DIFF
--- a/Products/GenericSetup/browser/components.pt
+++ b/Products/GenericSetup/browser/components.pt
@@ -1,20 +1,6 @@
 <h1 tal:replace="structure context/manage_page_header">PAGE HEADER</h1>
 <h2 tal:replace="structure context/manage_tabs">TABS</h2>
 
-<!-- not valid in the body, but works -->
-<style type="text/css">
- td.label {
-   color: #333333;
-   font-family: Verdana,Helvetica,sans-serif;
-   font-size: 10pt;
-   font-weight: bold;
-   vertical-align: top;
- }
-.widget textarea {
-   width: 600px;
- }
-</style>
+<tal:block replace="structure view/form_template" />
 
-<br />
-<metal:macro metal:use-macro="view/base_template/macros/form" />
 <h1 tal:replace="structure context/manage_page_footer">PAGE FOOTER</h1>

--- a/Products/GenericSetup/browser/components_form.pt
+++ b/Products/GenericSetup/browser/components_form.pt
@@ -1,0 +1,13 @@
+<div tal:content="view/status" />
+
+<form action="." method="post"
+      tal:attributes="action request/ACTUAL_URL">
+
+  <textarea name="body" cols="60" rows="24" style="width: 600px;"
+            tal:content="view/adapter/body"></textarea>
+
+  <div>
+    <input type="submit" name="apply" value="Apply" />
+  </div>
+
+</form>

--- a/Products/GenericSetup/configure.zcml
+++ b/Products/GenericSetup/configure.zcml
@@ -4,11 +4,6 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="genericsetup">
 
-  <include
-      zcml:condition="not-installed five.formlib"
-      package="zope.formlib"
-      />
-
   <include package=".browser"/>
 
   <include package=".MailHost"/>

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,8 +4,7 @@ Changelog
 1.8.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Stopped using a form library to render the components form.
 
 1.8.4 (2016-09-21)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setup(
         'five.localsitemanager',
         # 'Products.MailHost', # BBB: disabled for Zope 2.12
         # 'Products.PythonScripts', # BBB: disabled for Zope 2.12
-        'zope.formlib',
         ],
     tests_require=[
         'zope.testrunner',


### PR DESCRIPTION
This is an alternate option to #33; it stops using a form library entirely instead of switching from formlib to z3c.form.