### PR TITLE
Added a `purge_old` option to the tarball import form.

### DIFF
--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -606,13 +606,25 @@ class SetupTool(Folder):
                                           messages=detail)
 
     security.declareProtected(ManagePortal, 'manage_importTarball')
-    def manage_importTarball(self, tarball):
+    def manage_importTarball(self, tarball, submitted=None, purge_old=None):
         """ Import steps from the uploaded tarball.
         """
         if getattr(tarball, 'read', None) is not None:
             tarball = tarball.read()
 
-        result = self.runAllImportStepsFromProfile(None, True, archive=tarball)
+        if purge_old is None:
+            if submitted:
+                # The form was submitted, and the purge_old checkbox was not
+                # checked, which means it does not end up in the method call.
+                # So we must set it to False here.
+                purge_old = False
+            else:
+                # No form was submitted: the method was called manually.
+                # To avoid surprises, use the previous default.
+                purge_old = True
+
+        result = self.runAllImportStepsFromProfile(
+            None, purge_old=purge_old, archive=tarball)
 
         steps_run = 'Steps run: %s' % ', '.join(result['steps'])
 

--- a/Products/GenericSetup/www/sutTarballImport.zpt
+++ b/Products/GenericSetup/www/sutTarballImport.zpt
@@ -9,6 +9,12 @@
 <p>
     <input class="form-element" type="file"
            name="tarball" />
+    <input type="hidden" name="submitted" value="yes" />
+    <label>
+    <input class="form-element" type="checkbox" checked="checked"
+           name="purge_old" />
+    Purge existing settings
+    </label>
     <input class="form-element" type="submit"
            name="manage_importTarball:method"
            value=" Import uploaded tarball " />

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 1.8.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added a ``purge_old`` option to the tarball import form.
+  By default this option is checked, which matches the previous behavior.
+  If you uncheck it, this avoids purging old settings for any import step
+  that is run.  [maurits]
 
 
 1.8.5 (2016-11-01)


### PR DESCRIPTION
By default this option is checked, which matches the previous behavior.
If you uncheck it, this avoids purging old settings for any import step that is run.

The form then looks like this:
![screen shot 2016-12-21 at 14 48 55](https://cloud.githubusercontent.com/assets/210587/21391589/a6087270-c78c-11e6-8272-ca6eb18a79ad.png)

There were no tests yet for importing tarballs, so I have added one.