### PR TITLE
Test with latest Zope2 2.13, and fix Travis. [1.8]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.6"
   - "2.7"
 install:
-    - python bootstrap.py
+    - python bootstrap.py --buildout-version=2.5.3 --setuptools-version=33.1.1
     - bin/buildout
 script:
     - bin/test -pvc

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = http://download.zope.org/Zope2/index/2.13.19/versions.cfg
+extends = http://download.zope.org/Zope2/index/2.13.26/versions.cfg
 develop = .
 parts =
     test
@@ -27,3 +27,8 @@ scripts = zopepy
 [docs]
 recipe = zc.recipe.egg
 eggs = Sphinx
+
+
+[versions]
+setuptools = 33.1.1
+zc.buildout = 2.5.3


### PR DESCRIPTION
It failed on Python 2.6.