### PR TITLE
Prevent AttributeError 'NoneType' object has no attribute 'decode'.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Prevent AttributeError 'NoneType' object has no attribute 'decode'.
+  [maurits]
 
 
 1.10.0 (2017-12-07)

--- a/Products/GenericSetup/tests/test_utils.py
+++ b/Products/GenericSetup/tests/test_utils.py
@@ -69,6 +69,30 @@ _EMPTY_PROPERTY_EXPORT = """\
 </dummy>
 """
 
+_NONE_PROPERTY_EXPORT = """\
+<?xml version="1.0"?>
+<dummy>
+ <property name="foo_boolean" type="boolean">False</property>
+ <property name="foo_date" type="date">1970/01/01 00:00:00 UTC</property>
+ <property name="foo_float" type="float">0.0</property>
+ <property name="foo_int" type="int">0</property>
+ <property name="foo_lines" type="lines"/>
+ <property name="foo_long" type="long">0</property>
+ <property name="foo_string" type="string"></property>
+ <property name="foo_tokens" type="tokens"/>
+ <property name="foo_selection" select_variable="foobarbaz"
+    type="selection"></property>
+ <property name="foo_mselection" select_variable="foobarbaz"
+    type="multiple selection"/>
+ <property name="foo_boolean0" type="boolean">False</property>
+ <property name="foo_date_naive" type="date">1970/01/01 00:00:00</property>
+ <property name="foo_boolean_nodel">False</property>
+ <property name="foo_date_nodel">1970/01/01 00:00:00 UTC</property>
+ <property name="foo_float_nodel">0.0</property>
+ <property name="foo_int_nodel">0</property>
+</dummy>
+"""
+
 _NORMAL_PROPERTY_EXPORT = u"""\
 <?xml version="1.0"?>
 <dummy>
@@ -379,6 +403,20 @@ class PropertyManagerHelpersTests(unittest.TestCase):
         doc.appendChild(node)
 
         self.assertEqual(doc.toprettyxml(' '), _EMPTY_PROPERTY_EXPORT)
+
+    def test__extractProperties_none(self):
+        from Products.GenericSetup.utils import PrettyDocument
+        context = self._makeContext()
+        # When a text property is None, in 1.10.0 you get an AttributeError:
+        # 'NoneType' object has no attribute 'decode'
+        context.foo_text = None
+        helpers = self._makeOne(context=context)
+        doc = helpers._doc = PrettyDocument()
+        node = doc.createElement('dummy')
+        node.appendChild(helpers._extractProperties())
+        doc.appendChild(node)
+
+        self.assertEqual(doc.toprettyxml(' '), _NONE_PROPERTY_EXPORT)
 
     def test__extractProperties_normal(self):
         from Products.GenericSetup.utils import PrettyDocument

--- a/Products/GenericSetup/utils.py
+++ b/Products/GenericSetup/utils.py
@@ -657,6 +657,8 @@ class PropertyManagerHelpers(object):
             node.setAttribute('name', prop_id)
 
             prop = self.context.getProperty(prop_id)
+            if prop is None:
+                continue
             if isinstance(prop, (tuple, list)):
                 for value in prop:
                     if isinstance(value, six.binary_type):


### PR DESCRIPTION
Sample traceback is in Plone coredev branch 5.2 in the `plone.app.dexterity` tests when we use Products.GenericSetup 1.10.0. See [Jenkins](http://jenkins.plone.org/view/All/job/plone-5.2-python-2.7/310/testReport/junit/plone.app.dexterity/tests/editing_txt/). There is a description which is `None`. In earlier GenericSetup versions this was converted to the string `'None'`, which hid the problem. Now you get a traceback:
 
```
File "/home/jenkins/workspace/plone-5.2-python-2.7/src/plone.app.dexterity/plone/app/dexterity/tests/editing.txt", line 475, in editing.txt
Failed example:
    browser.getControl('Export Type Profiles').click()
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python2.7/doctest.py", line 1315, in __run
        compileflags, 1) in test.globs
      File "<doctest editing.txt[181]>", line 1, in <module>
        browser.getControl('Export Type Profiles').click()
      File "/home/jenkins/.buildout/eggs/zope.testbrowser-5.2.4-py2.7.egg/zope/testbrowser/browser.py", line 778, in click
        self.browser._clickSubmit(self._form, self._control)
      File "/home/jenkins/.buildout/eggs/zope.testbrowser-5.2.4-py2.7.egg/zope/testbrowser/browser.py", line 275, in _clickSubmit
        self._processRequest(url, make_request)
      File "/home/jenkins/.buildout/eggs/zope.testbrowser-5.2.4-py2.7.egg/zope/testbrowser/browser.py", line 286, in _processRequest
        resp = self.testapp.get(url, **reqargs)
      File "/home/jenkins/.buildout/eggs/WebTest-2.0.28-py2.7.egg/webtest/app.py", line 331, in get
        expect_errors=expect_errors)
      File "/home/jenkins/.buildout/eggs/zope.testbrowser-5.2.4-py2.7.egg/zope/testbrowser/browser.py", line 94, in do_request
        expect_errors)
      File "/home/jenkins/.buildout/eggs/WebTest-2.0.28-py2.7.egg/webtest/app.py", line 625, in do_request
        res = req.get_response(app, catch_exc_info=True)
      File "/home/jenkins/.buildout/eggs/WebOb-1.7.3-py2.7.egg/webob/request.py", line 1312, in send
        application, catch_exc_info=True)
      File "/home/jenkins/.buildout/eggs/WebOb-1.7.3-py2.7.egg/webob/request.py", line 1280, in call_application
        app_iter = application(self.environ, start_response)
      File "/home/jenkins/.buildout/eggs/WebTest-2.0.28-py2.7.egg/webtest/lint.py", line 199, in lint_app
        iterator = application(environ, start_response_wrapper)
      File "/home/jenkins/workspace/plone-5.2-python-2.7/src/plone.testing/src/plone/testing/_z2_testbrowser.py", line 36, in wrapped_func
        return func(*args, **kw)
      File "/home/jenkins/workspace/plone-5.2-python-2.7/src/plone.testing/src/plone/testing/_z2_testbrowser.py", line 63, in __call__
        wsgi_result = publish(environ, start_response)
      File "/home/jenkins/workspace/plone-5.2-python-2.7/src/Zope/src/ZPublisher/WSGIPublisher.py", line 256, in publish_module
        response = _publish(request, new_mod_info)
      File "/home/jenkins/workspace/plone-5.2-python-2.7/src/Zope/src/ZPublisher/WSGIPublisher.py", line 209, in publish
        bind=1)
      File "/home/jenkins/workspace/plone-5.2-python-2.7/src/Zope/src/ZPublisher/mapply.py", line 85, in mapply
        return debug(object, args, context)
      File "/home/jenkins/workspace/plone-5.2-python-2.7/src/Zope/src/ZPublisher/WSGIPublisher.py", line 56, in call_object
        return obj(*args)
      File "/home/jenkins/workspace/plone-5.2-python-2.7/src/plone.app.dexterity/plone/app/dexterity/browser/export.py", line 73, in __call__
        handler(context)
      File "/home/jenkins/workspace/plone-5.2-python-2.7/src/Products.CMFCore/Products/CMFCore/exportimport/typeinfo.py", line 234, in exportTypesTool
        exportObjects(tool, '', context)
      File "/home/jenkins/.buildout/eggs/Products.GenericSetup-1.10.0-py2.7.egg/Products/GenericSetup/utils.py", line 840, in exportObjects
        exportObjects(sub, path + '/', context)
      File "/home/jenkins/.buildout/eggs/Products.GenericSetup-1.10.0-py2.7.egg/Products/GenericSetup/utils.py", line 834, in exportObjects
        body = exporter.body
      File "/home/jenkins/.buildout/eggs/Products.GenericSetup-1.10.0-py2.7.egg/Products/GenericSetup/utils.py", line 497, in _exportBody
        self._doc.appendChild(self._exportNode())
      File "/home/jenkins/workspace/plone-5.2-python-2.7/src/Products.CMFCore/Products/CMFCore/exportimport/typeinfo.py", line 45, in _exportNode
        node.appendChild(self._extractProperties())
      File "/home/jenkins/.buildout/eggs/Products.GenericSetup-1.10.0-py2.7.egg/Products/GenericSetup/utils.py", line 680, in _extractProperties
        prop = prop.decode(self._encoding)
    AttributeError: 'NoneType' object has no attribute 'decode'
```

Solution is to ignore such a property when exporting.