### PR TITLE
Require five.localsitemanager less than version 3. [1.8]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Require five.localsitemanager less than version 3.
+  Version 3 requires a too new Zope2 version.
 
 
 1.8.8 (2017-05-06)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple
 extends = http://download.zope.org/Zope2/index/2.13.26/versions.cfg
 develop = .
 parts =

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     install_requires=[
         'setuptools',
         'Zope2 >= 2.12.3',
-        'five.localsitemanager',
+        'five.localsitemanager < 3',
         # 'Products.MailHost', # BBB: disabled for Zope 2.12
         # 'Products.PythonScripts', # BBB: disabled for Zope 2.12
         ],


### PR DESCRIPTION
Version 3 requires a too new Zope2 version and breaks the build on Travis.
Or at least it breaks locally for me.
Alternative: pin a version in the buildout.