### PR TITLE
When metadata.xml parsing fails, show the filename in the ExpatError. [1.8]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- When ``metadata.xml`` parsing fails, show the filename in the ``ExpatError``.
+  Fixes `Plone issue 2303 <https://github.com/plone/Products.CMFPlone/issues/2303>`_.
+
 - Require five.localsitemanager less than version 3.
   Version 3 requires a too new Zope2 version.
 

--- a/Products/GenericSetup/metadata.py
+++ b/Products/GenericSetup/metadata.py
@@ -14,6 +14,7 @@
 """
 
 import os
+from xml.parsers.expat import ExpatError
 
 from Products.GenericSetup.utils import _getProductPath
 from Products.GenericSetup.utils import CONVERTER
@@ -53,7 +54,10 @@ class ProfileMetadata( ImportConfiguratorBase ):
             return {}
 
         file = open( full_path, 'r' )
-        return self.parseXML( file.read() )
+        try:
+            return self.parseXML( file.read() )
+        except ExpatError as e:
+            raise ExpatError('%s: %s' % (full_path, e))
 
     def _getImportMapping( self ):
 


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/2303. For details see there.

This is for branch 1.8. I already saw that Travis would break, so I started PR #54 for that.
The current PR should be rebased once Travis works again.
