### PR TITLE
When metadata.xml parsing fails, show the filename in the ExpatError. [master]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
+- When ``metadata.xml`` parsing fails, show the filename in the ``ExpatError``.
+  Fixes `Plone issue 2303 <https://github.com/plone/Products.CMFPlone/issues/2303>`_.
+
 - Prevent AttributeError 'NoneType' object has no attribute 'decode'.
   [maurits]
 

--- a/Products/GenericSetup/metadata.py
+++ b/Products/GenericSetup/metadata.py
@@ -14,6 +14,7 @@
 """
 
 import os
+from xml.parsers.expat import ExpatError
 
 from Products.GenericSetup.utils import _getProductPath
 from Products.GenericSetup.utils import CONVERTER
@@ -53,7 +54,10 @@ class ProfileMetadata( ImportConfiguratorBase ):
             return {}
 
         file = open( full_path, 'r' )
-        return self.parseXML( file.read() )
+        try:
+            return self.parseXML( file.read() )
+        except ExpatError as e:
+            raise ExpatError('%s: %s' % (full_path, e))
 
     def _getImportMapping( self ):
 


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/2303.

Forward port of https://github.com/zopefoundation/Products.GenericSetup/pull/55 to master.