### PR TITLE
Fix RuntimeError: dictionary changed size during iteration

### DIFF
--- a/Products/GenericSetup/ZCatalog/exportimport.py
+++ b/Products/GenericSetup/ZCatalog/exportimport.py
@@ -83,7 +83,8 @@ class ZCatalogXMLAdapter(XMLAdapterBase, ObjectManagerHelpers,
         return fragment
 
     def _purgeIndexes(self):
-        for idx_id in self.context.indexes():
+        indexes = set(self.context.indexes())
+        for idx_id in indexes:
             self.context.delIndex(idx_id)
 
     def _initIndexes(self, node):


### PR DESCRIPTION
Fixes this error happening testing Products.CMFCore with Python3:
```
Error in test test_normal_purge (Products.CMFCore.exportimport.tests.test_catalog.importCatalogToolTests)
Traceback (most recent call last):
  File "/usr/lib/python3.6/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/lib/python3.6/unittest/case.py", line 605, in run
    testMethod()
  File "/home/ale/Code/plone/plone3/src/Products.CMFCore/Products/CMFCore/exportimport/tests/test_catalog.py", line 187, in test_normal_purge
    importCatalogTool(context)
  File "/home/ale/Code/plone/plone3/src/Products.CMFCore/Products/CMFCore/exportimport/catalog.py", line 34, in importCatalogTool
    importObjects(tool, '', context)
  File "/home/ale/Code/plone/plone3/src/Products.CMFCore/src/Products.GenericSetup/Products/GenericSetup/utils.py", line 861, in importObjects
    importer.body = body
   - __traceback_info__: portal_catalog
  File "/home/ale/Code/plone/plone3/src/Products.CMFCore/src/Products.GenericSetup/Products/GenericSetup/utils.py", line 518, in _importBody
    self._importNode(dom.documentElement)
  File "/home/ale/Code/plone/plone3/src/Products.CMFCore/src/Products.GenericSetup/Products/GenericSetup/ZCatalog/exportimport.py", line 65, in _importNode
    self._purgeIndexes()
  File "/home/ale/Code/plone/plone3/src/Products.CMFCore/src/Products.GenericSetup/Products/GenericSetup/ZCatalog/exportimport.py", line 86, in _purgeIndexes
    for idx_id in self.context.indexes():
RuntimeError: dictionary changed size during iteration
```