### PR TITLE
Test with Zope 4.0b4.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
+- Fixed tests with ``Products.ZCatalog 4.1``.  [maurits]
+
 - When ``metadata.xml`` parsing fails, show the filename in the ``ExpatError``.
   Fixes `Plone issue 2303 <https://github.com/plone/Products.CMFPlone/issues/2303>`_.
 

--- a/Products/GenericSetup/PluginIndexes/tests/test_exportimport.py
+++ b/Products/GenericSetup/PluginIndexes/tests/test_exportimport.py
@@ -21,6 +21,7 @@ from Products.GenericSetup.testing import ExportImportZCMLLayer
 _DATE_XML = """\
 <index name="foo_date" meta_type="DateIndex">
  <property name="index_naive_time_as_local">True</property>
+ <property name="precision">1</property>
 </index>
 """
 

--- a/Products/GenericSetup/ZCatalog/tests/test_exportimport.py
+++ b/Products/GenericSetup/ZCatalog/tests/test_exportimport.py
@@ -42,6 +42,7 @@ _CATALOG_BODY = """\
  </object>
 %s <index name="foo_date" meta_type="DateIndex">
   <property name="index_naive_time_as_local">True</property>
+  <property name="precision">1</property>
  </index>
  <index name="foo_daterange" meta_type="DateRangeIndex" since_field="bar"
     until_field="baz"/>

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = https://zopefoundation.github.io/Zope/releases/4.0a6/versions-prod.cfg
+extends = https://zopefoundation.github.io/Zope/releases/4.0b4/versions-prod.cfg
 develop = .
 parts =
     test


### PR DESCRIPTION
Current master `buildout.cfg` uses Zope 4.0a6 and the tests pass. I tried 4.0b3 and tests pass too, although we have lots of `PendingDeprecationWarnings`.
Zope 4.0b4 was released earlier this week. With that, a 7 tests fail, for example:

```
Failure in test test_node_get 
(Products.GenericSetup.PluginIndexes.tests.test_exportimport.DateIndexNodeAdapterTests)
Traceback (most recent call last):
  File "/usr/local/Cellar/python@2/2.7.14_3/Frameworks/Python.framework/Versions
/2.7/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/Users/maurits/community/plone-coredev/5.2/src/Products.GenericSetup/Products/GenericSetup/testing.py", line 117, in test_node_get
    self.assertEqual(adapted.node.toprettyxml(' '), self._XML)
  File "/usr/local/Cellar/python@2/2.7.14_3/Frameworks/Python.framework/Versions
/2.7/lib/python2.7/unittest/case.py", line 513, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/usr/local/Cellar/python@2/2.7.14_3/Frameworks/Python.framework/Versions
/2.7/lib/python2.7/unittest/case.py", line 506, in _baseAssertEqual
    raise self.failureException(msg)
AssertionError:
'<index name="foo_date" meta_type="DateIndex">\n <property name="index_naive_time_as_local">True</property>\n <property name="precision">1</property>\n</index>\n'
!=
'<index name="foo_date" meta_type="DateIndex">\n <property name="index_naive_time_as_local">True</property>\n</index>\n'
```

So the first one has an extra property `precision`. Does anyone know why that is? I don't yet know whether the test should be changed or that this is a real problem.

For now, this PR simply updates the versions to Zope 4.0b4, showing that there are problems. See also https://github.com/plone/buildout.coredev/pull/464.
