### PR TITLE
Fix  create object by type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,10 @@ Changelog
 
 Bug fixes:
 
-- proper string/bytes handling for _createObjectByType
+- Proper string/bytes handling for _createObjectByType.
+  In Python2 everything is written as bytes,
+  while on Python3 everything is written as text except files and images
+  which are stored as bytes
   [ale-rt]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 2.0b2 (unreleased)
 ------------------
 
+Bug fixes:
+
+- proper string/bytes handling for _createObjectByType
+  [ale-rt]
+
 
 2.0b1 (2018-05-16)
 ------------------


### PR DESCRIPTION
This PR tries to fix the string/bytes handling for _createObjectByType.
In Python2 everything is written as bytes but it seems to me that on Python3 evertyhing (Python Scripts, DTML files, Page Templates, ...) should be written as text except files and images that should be stored as bytes.