### PR TITLE
More Python 3  fixes for Plone

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,17 @@ Changelog
 2.0b3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not turn ulines and multiple selection into bytes.
+  [davisagli]
+
+- Set body of PythonScripts as text in py3.
+  [pbauer]
+
+- Compare encodings so that UTF-8 and utf-8 are the same.
+  [pbauer]
+
+- Compare DOM as text in py3.
+  [pbauer]
 
 
 2.0b2 (2018-10-17)

--- a/Products/GenericSetup/PythonScripts/exportimport.py
+++ b/Products/GenericSetup/PythonScripts/exportimport.py
@@ -38,7 +38,7 @@ class PythonScriptBodyAdapter(BodyAdapterBase):
     def _importBody(self, body):
         """Import the object from the file body.
         """
-        if six.PY3:
+        if six.PY3 and isinstance(body, six.binary_type):
             body = body.decode('utf-8')
         body = body.replace('\r\n', '\n').replace('\r', '\n')
         self.context.write(body)

--- a/Products/GenericSetup/tests/common.py
+++ b/Products/GenericSetup/tests/common.py
@@ -32,6 +32,12 @@ class DOMComparator:
 
     def _compareDOM(self, found_text, expected_text, debug=False):
 
+        if six.PY3:
+            if isinstance(found_text, bytes):
+                found_text = found_text.decode('utf8')
+            if isinstance(expected_text, bytes):
+                expected_text = expected_text.decode('utf8')
+
         found_lines = [x.strip() for x in found_text.splitlines()]
         found_text = '\n'.join([i for i in found_lines if i])
 

--- a/Products/GenericSetup/utils.py
+++ b/Products/GenericSetup/utils.py
@@ -765,7 +765,8 @@ class PropertyManagerHelpers(object):
             for sub in child.childNodes:
                 if sub.nodeName == 'element':
                     value = sub.getAttribute('value')
-                    if prop_map.get('type') != 'ulines':
+                    if prop_map.get('type') not in (
+                            'ulines', 'multiple selection'):
                         value = value.encode(self._encoding)
                     if self._convertToBoolean(sub.getAttribute('remove')
                                               or 'False'):

--- a/Products/GenericSetup/utils.py
+++ b/Products/GenericSetup/utils.py
@@ -799,12 +799,12 @@ class PropertyManagerHelpers(object):
                                          p not in remove_elements]) +
                                   tuple(prop_value))
 
-            if isinstance(prop_value, (six.binary_type, str)):
+            if isinstance(prop_value, (six.binary_type, six.text_type)):
                 prop_type = obj.getPropertyType(prop_id) or 'string'
                 if prop_type in type_converters:
                     # The type_converters use the ZPublisher default_encoding
                     # for decoding bytes!
-                    if self._encoding != default_encoding:
+                    if self._encoding.lower() != default_encoding:
                         u_prop_value = prop_value.decode(self._encoding)
                         prop_value = u_prop_value.encode(default_encoding)
                         prop_value = type_converters[prop_type](prop_value)

--- a/Products/GenericSetup/utils.py
+++ b/Products/GenericSetup/utils.py
@@ -764,7 +764,9 @@ class PropertyManagerHelpers(object):
             remove_elements = []
             for sub in child.childNodes:
                 if sub.nodeName == 'element':
-                    value = sub.getAttribute('value').encode(self._encoding)
+                    value = sub.getAttribute('value')
+                    if six.PY2 and isinstance(value, six.text_type):
+                        value = value.encode(self._encoding)
                     if self._convertToBoolean(sub.getAttribute('remove')
                                               or 'False'):
                         remove_elements.append(value)
@@ -775,7 +777,7 @@ class PropertyManagerHelpers(object):
                         if value in remove_elements:
                             remove_elements.remove(value)
 
-            if prop_map.get('type') in ('lines', 'tokens',
+            if prop_map.get('type') in ('lines', 'tokens', 'ulines',
                                         'multiple selection'):
                 prop_value = tuple(new_elements) or ()
             elif prop_map.get('type') == 'boolean':
@@ -783,7 +785,9 @@ class PropertyManagerHelpers(object):
             else:
                 # if we pass a *string* to _updateProperty, all other values
                 # are converted to the right type
-                prop_value = self._getNodeText(child).encode(self._encoding)
+                prop_value = self._getNodeText(child)
+                if six.PY2 and isinstance(prop_value, six.text_type):
+                    prop_value = prop_value.encode(self._encoding)
 
             if not self._convertToBoolean(child.getAttribute('purge')
                                           or 'True'):

--- a/Products/GenericSetup/utils.py
+++ b/Products/GenericSetup/utils.py
@@ -765,7 +765,7 @@ class PropertyManagerHelpers(object):
             for sub in child.childNodes:
                 if sub.nodeName == 'element':
                     value = sub.getAttribute('value')
-                    if six.PY2 and isinstance(value, six.text_type):
+                    if prop_map.get('type') != 'ulines':
                         value = value.encode(self._encoding)
                     if self._convertToBoolean(sub.getAttribute('remove')
                                               or 'False'):


### PR DESCRIPTION
Fixes:
* do not turn ulines and multiple selection into bytes
* set body of PythonScripts as text in py3
* fix comparison of encodings so that UTF-8 and utf-8 are the same
* compare DOM as text in py3