### PR TITLE
fix test that fails after SimpleItem inherits from PathReprProvider

### DIFF
--- a/Products/GenericSetup/tests/test_utils.py
+++ b/Products/GenericSetup/tests/test_utils.py
@@ -774,7 +774,7 @@ class MarkerInterfaceHelpersTests(unittest.TestCase):
 
     def _makeContext(self):
         from OFS.SimpleItem import Item
-        return Item('obj')
+        return Item()
 
     def _populate(self, obj):
         from zope.interface import directlyProvides


### PR DESCRIPTION
The change in SimpleItem is in https://github.com/zopefoundation/Zope/pull/387