### PR TITLE
Force saving unpersisted changes in toolset registry. [1.8]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Force saving unpersisted changes in toolset registry.
+  Fixes `issue 86 <https://github.com/zopefoundation/Products.GenericSetup/issues/86>`_.
+
 - No longer test on Python 2.6.
 
 

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -112,6 +112,9 @@ def importToolset(context):
     toolset = setup_tool.getToolsetRegistry()
 
     toolset.parseXML(xml, encoding)
+    # Force a safe so changes in simple lists and dicts are persisted.
+    # https://github.com/zopefoundation/Products.GenericSetup/issues/86
+    setup_tool._p_changed = True
 
     existing_ids = site.objectIds()
 


### PR DESCRIPTION
Fixes https://github.com/zopefoundation/Products.GenericSetup/issues/86 for 1.8.

It seems impractical to add a test for this. I could test that without this fix `setup_tool._p_changed` is False, and with the fix it is True. I tried, but it even fails, probably because these tests use a `DummyImportContext` which is too much unlike a real context.