### PR TITLE
Use correct version configuration

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,6 +1,7 @@
 [buildout]
 extends =
-    https://zopefoundation.github.io/Zope/releases/master/versions-prod.cfg
+    https://zopefoundation.github.io/Zope/releases/4.x/versions-prod.cfg
+    https://zopefoundation.github.io/Zope/releases/4.x/versions.cfg
 develop = .
 parts =
     test


### PR DESCRIPTION
... so package can be built with Python 2.7.

modified:   buildout.cfg

P.S.: possible build failures because of `flake8-html` are unrelated and will solve itself once a new release was made
https://github.com/lordmauve/flake8-html/issues/17