### PR TITLE
Fix flake8-html setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ dist
 default.profraw
 downloads
 eggs
+flake8
 htmlcov
 local.cfg
 parts

--- a/tox.ini
+++ b/tox.ini
@@ -37,8 +37,10 @@ setenv =
 
 [testenv:flake8]
 basepython = python3.6
+whitelist_externals = mkdir
 commands =
-    - flake8 --format=html --htmldir={toxinidir}/parts/flake8 --doctests Products setup.py {posargs}
+    mkdir -p {toxinidir}/flake8
+    - flake8 --format=html --htmldir={toxinidir}/flake8 --doctests Products setup.py {posargs}
     flake8 --doctests Products setup.py {posargs}
 deps =
     flake8


### PR DESCRIPTION
flake8-html needs an output directory for its generated HTML.

The given `parts` directory is not present for this package.

The `parts` arg has been changed to `flake8`, which also gets used for
other packages.

modified:   .gitignore
modified:   tox.ini

This fixes #93 