### PR TITLE
When logging an upgrade, print the version tuple joined by dots

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
+- When logging an upgrade, print the version tuple joined by dots.
+
 - Renamed ``xml`` dir to ``xml_templates``.
   This avoids an import warning on Python 2.7.
 

--- a/Products/GenericSetup/tests/test_utils.py
+++ b/Products/GenericSetup/tests/test_utils.py
@@ -401,6 +401,16 @@ class UtilsTests(unittest.TestCase):
         doh = Doh()
         self.assertRaises(ValueError, _getDottedName, doh)
 
+    def test__version_for_print(self):
+        from ..utils import _version_for_print as vfp
+
+        self.assertEqual(vfp('1000'), '1000')
+        self.assertEqual(vfp(('1000',)), '1000')
+        self.assertEqual(vfp(('1', '2', '3')), '1.2.3')
+        self.assertEqual(vfp((42)), '42')
+        self.assertEqual(vfp(('unknown')), 'unknown')
+        self.assertEqual(vfp((None)), 'None')
+
 
 class PropertyManagerHelpersTests(unittest.TestCase):
 

--- a/Products/GenericSetup/tool.py
+++ b/Products/GenericSetup/tool.py
@@ -61,6 +61,7 @@ from .upgrade import listUpgradeSteps
 from .utils import _computeTopologicalSort
 from .utils import _getProductPath
 from .utils import _resolveDottedName
+from .utils import _version_for_print
 from .utils import _wwwdir
 
 
@@ -1129,7 +1130,8 @@ class SetupTool(Folder):
                 dest = tuple(dest.split('.'))
             if self.getLastVersionForProfile(profile_id) == dest:
                 generic_logger.warning('Profile %s is already at wanted '
-                                       'destination %r.', profile_id, dest)
+                                       'destination %r.', profile_id,
+                                       _version_for_print(dest))
                 return
         upgrades = self.listUpgrades(profile_id)
         # First get a list of single steps to apply.  This may be
@@ -1153,8 +1155,9 @@ class SetupTool(Folder):
         if dest is not None and not dest_found:
             generic_logger.warning(
                 'No route found to destination version %r for profile %s. '
-                'Profile stays at current version, %r', dest, profile_id,
-                self.getLastVersionForProfile(profile_id))
+                'Profile stays at current version, %r',
+                _version_for_print(dest), profile_id,
+                _version_for_print(self.getLastVersionForProfile(profile_id)))
             return
         if to_apply:
             for step in to_apply:
@@ -1165,12 +1168,14 @@ class SetupTool(Folder):
                 self.setLastVersionForProfile(profile_id, step.dest)
                 generic_logger.info(
                     'Profile %s upgraded to version %r.',
-                    profile_id, self.getLastVersionForProfile(profile_id))
+                    profile_id,
+                    _version_for_print(
+                        self.getLastVersionForProfile(profile_id)))
         else:
             generic_logger.info(
                 'No upgrades available for profile %s. '
                 'Profile stays at version %r.', profile_id,
-                self.getLastVersionForProfile(profile_id))
+                _version_for_print(self.getLastVersionForProfile(profile_id)))
 
     #
     #   Helper methods

--- a/Products/GenericSetup/utils.py
+++ b/Products/GenericSetup/utils.py
@@ -156,6 +156,21 @@ def _extractDocstring(func, default_title, default_description):
     return title, description
 
 
+def _version_for_print(version):
+    """Return a version suitable for printing/logging.
+
+    Versions of profiles and destinations of upgrade steps
+    are likely tuples.  We join them with dots.
+
+    Used internally when logging.
+    """
+    if isinstance(version, six.string_types):
+        return version
+    if isinstance(version, tuple):
+        return ".".join(version)
+    return str(version)
+
+
 ##############################################################################
 # WARNING: PLEASE DON'T USE THE CONFIGURATOR PATTERN. THE RELATED BASE CLASSES
 # WILL BECOME DEPRECATED AS SOON AS GENERICSETUP ITSELF NO LONGER USES THEM.


### PR DESCRIPTION
Sample output of a Plone upgrade without this change:

```
INFO    No upgrades available for profile Products.CMFEditions:CMFEditions. Profile stays at version ('4',).
WARNING Version of profile Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow is unknown, refusing to upgrade.
INFO    No upgrades available for profile plone.app.contenttypes:default. Profile stays at version ('1106',).
INFO    No upgrades available for profile plone.app.dexterity:default. Profile stays at version ('2005',).
INFO    No upgrades available for profile plone.app.discussion:default. Profile stays at version ('1002',).
INFO    No upgrades available for profile plone.app.event:default. Profile stays at version ('15',).
WARNING Version of profile plone.app.iterate:plone.app.iterate is unknown, refusing to upgrade.
WARNING Version of profile plone.app.multilingual:default is unknown, refusing to upgrade.
INFO    No upgrades available for profile plone.app.querystring:default. Profile stays at version ('13',).
INFO    No upgrades available for profile plone.app.theming:default. Profile stays at version ('1002',).
INFO    No upgrades available for profile plone.app.users:default. Profile stays at version ('1',).
INFO    No upgrades available for profile plone.staticresources:default. Profile stays at version ('10',).
```

This has a minor annoyance for me since a few years. :-)

After this PR it looks like this:

```
INFO    No upgrades available for profile Products.CMFEditions:CMFEditions. Profile stays at version '4'.
WARNING Version of profile Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow is unknown, refusing to upgrade.
INFO    No upgrades available for profile plone.app.contenttypes:default. Profile stays at version '1106'.
INFO    No upgrades available for profile plone.app.dexterity:default. Profile stays at version '2005'.
INFO    No upgrades available for profile plone.app.discussion:default. Profile stays at version '1002'.
INFO    No upgrades available for profile plone.app.event:default. Profile stays at version '15'.
WARNING Version of profile plone.app.iterate:plone.app.iterate is unknown, refusing to upgrade.
WARNING Version of profile plone.app.multilingual:default is unknown, refusing to upgrade.
INFO    No upgrades available for profile plone.app.querystring:default. Profile stays at version '13'.
INFO    No upgrades available for profile plone.app.theming:default. Profile stays at version '1002'.
INFO    No upgrades available for profile plone.app.users:default. Profile stays at version '1'.
INFO    No upgrades available for profile plone.staticresources:default. Profile stays at version '10'.
```

Note that in this case the profile versions are single strings, so they don't actually get a dot.