### PR TITLE
Enforce access control on setup tool log files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Enforce access control on setup tool log files
+  (`#101 <https://github.com/zopefoundation/Products.GenericSetup/issues/101>`_)
 
 
 2.1.0 (2021-01-26)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Enforce access control on setup tool log files
+- Enforce access control on setup tool log files and snapshot files and folders.
   (`#101 <https://github.com/zopefoundation/Products.GenericSetup/issues/101>`_)
 
 

--- a/src/Products/GenericSetup/context.py
+++ b/src/Products/GenericSetup/context.py
@@ -26,6 +26,7 @@ from tarfile import TarInfo
 import six
 
 from AccessControl.class_init import InitializeClass
+from AccessControl.Permissions import view
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from Acquisition import Implicit
 from Acquisition import aq_base
@@ -499,6 +500,10 @@ class SnapshotExportContext(BaseContext):
         # MISSING: switch on content_type
         ob = self._createObjectByType(filename, text, content_type)
         folder._setObject(str(filename), ob)  # No Unicode IDs!
+        # Tighten the View permission on the new object.
+        # Only the owner and Manager users may view the log.
+        # file_ob = self._getOb(name)
+        ob.manage_permission(view, ('Manager', 'Owner'), 0)
 
     @security.protected(ManagePortal)
     def getSnapshotURL(self):
@@ -559,8 +564,10 @@ class SnapshotExportContext(BaseContext):
             if element not in current.objectIds():
                 # No Unicode IDs!
                 current._setObject(str(element), Folder(element))
-
-            current = current._getOb(element)
+                current = current._getOb(element)
+                current.manage_permission(view, ('Manager', 'Owner'), 0)
+            else:
+                current = current._getOb(element)
 
         return current
 

--- a/src/Products/GenericSetup/tests/test_tool.py
+++ b/src/Products/GenericSetup/tests/test_tool.py
@@ -23,6 +23,7 @@ from six import BytesIO
 import transaction
 from AccessControl.Permissions import view
 from AccessControl.SecurityManagement import newSecurityManager
+from AccessControl.SecurityManagement import noSecurityManager
 from AccessControl.users import UnrestrictedUser
 from Acquisition import aq_base
 from OFS.Folder import Folder
@@ -133,6 +134,7 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         from ..upgrade import _upgrade_registry
         profile_registry.clear()
         _upgrade_registry.clear()
+        noSecurityManager()
 
     def _getTargetClass(self):
         from ..tool import SetupTool
@@ -146,6 +148,8 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         site.title = title
 
         self.app._setObject('site', site)
+        self.app.acl_users.userFolderAddUser('admin', '', ['Manager'], [])
+        newSecurityManager(None, self.app.acl_users.getUser('admin'))
         return self.app._getOb('site')
 
     def test_empty(self):

--- a/src/Products/GenericSetup/tool.py
+++ b/src/Products/GenericSetup/tool.py
@@ -27,6 +27,7 @@ from operator import itemgetter
 import six
 
 from AccessControl.class_init import InitializeClass
+from AccessControl.Permissions import view
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from Acquisition import aq_base
 from OFS.Folder import Folder
@@ -1556,6 +1557,11 @@ class SetupTool(Folder):
                     content_type='text/plain')
 
         self._setObject(name, file)
+
+        # Tighten the View permission on the log file. Only the owner and
+        # Manager users may view the log.
+        file_ob = self._getOb(name)
+        file_ob.manage_permission(view, ('Manager', 'Owner'), 0)
 
 
 InitializeClass(SetupTool)

--- a/src/Products/GenericSetup/tool.py
+++ b/src/Products/GenericSetup/tool.py
@@ -28,6 +28,7 @@ import six
 
 from AccessControl.class_init import InitializeClass
 from AccessControl.Permissions import view
+from AccessControl.Permissions import view_management_screens
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from Acquisition import aq_base
 from OFS.Folder import Folder
@@ -201,6 +202,9 @@ class SetupTool(Folder):
     _exclude_global_steps = False
 
     security = ClassSecurityInfo()
+
+    # Make sure anonymous users cannot access anything inside the tool
+    security.declareObjectProtected(view_management_screens)
 
     def __init__(self, id):
         self.id = str(id)


### PR DESCRIPTION
Fixes #101 

The issue was pointed out by a submission to the Plone security list. Once done/released I will create a security advisory including a quick manual workaround here.
