### PR TITLE
Allow passing quiet=True to upgradeProfile.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.1.6 (unreleased)
 ------------------
 
-- *nothing changed yet*
+- Allow passing ``quiet=True`` to ``upgradeProfile``.
+  Then we do not complain when the profile is not installed or needs no upgrade.
 
 
 2.1.5 (2021-12-03)

--- a/src/Products/GenericSetup/tests/test_tool.py
+++ b/src/Products/GenericSetup/tests/test_tool.py
@@ -1575,6 +1575,13 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         tool.upgradeProfile('no.such.profile:default', dest='42')
         self.assertEqual(tool._profile_upgrade_versions, {})
 
+        # On Python 3.4+ we could use self.assertLogs to check that a warning
+        # message was logged, and on 3.10+ use self.assertNoLogs to test
+        # the opposite when called with quiet=True.  Since we still support
+        # Python 2.7, never mind.  Do quickly test that the quiet argument
+        # throws no error.
+        tool.upgradeProfile('no.such.profile:default', quiet=True)
+
     def test_persistent_profile_upgrade_versions(self):
         site = self._makeSite()
         site.setup_tool = self._makeOne('setup_tool')
@@ -1639,6 +1646,12 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         # Upgrade the profile one step to version 1.
         tool.upgradeProfile('foo', '1')
         self.assertEqual(tool.getLastVersionForProfile('foo'), ('1',))
+        # Do that again and you will get a warning, which you can choose
+        # to silence.  Note: we do not test if something really gets logged.
+        tool.upgradeProfile('foo', '1')
+        self.assertEqual(tool.getLastVersionForProfile('foo'), ('1',))
+        tool.upgradeProfile('foo', '1', quiet=True)
+        self.assertEqual(tool.getLastVersionForProfile('foo'), ('1',))
         # Upgrade the profile two steps to version 3.  This one has a
         # checker.  The profile version must be correctly updated.
         tool.upgradeProfile('foo', '3')
@@ -1646,6 +1659,10 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         # Upgrade the profile to a non existing version.  Nothing
         # should happen.
         tool.upgradeProfile('foo', '5')
+        self.assertEqual(tool.getLastVersionForProfile('foo'), ('3',))
+        # It throws a warning which you can choose to ignore.
+        # The effect is the same.
+        tool.upgradeProfile('foo', '5', quiet=True)
         self.assertEqual(tool.getLastVersionForProfile('foo'), ('3',))
         # Upgrade the profile to the latest version.
         tool.upgradeProfile('foo')

--- a/src/Products/GenericSetup/tool.py
+++ b/src/Products/GenericSetup/tool.py
@@ -1118,7 +1118,7 @@ class SetupTool(Folder):
                                   % (url, profile_id))
 
     @security.protected(ManagePortal)
-    def upgradeProfile(self, profile_id, dest=None):
+    def upgradeProfile(self, profile_id, dest=None, quiet=False):
         """Upgrade a profile.
 
         Apply all upgrade steps.
@@ -1126,21 +1126,25 @@ class SetupTool(Folder):
         When 'dest' is given, only update to that version.  If the
         version is not found, give a warning and do nothing.
 
+        When 'quiet' is True, we do not complain when we cannot do anything.
+
         If the profile was not applied previously (last version for
         profile is unknown) we do nothing.
         """
         if self.getLastVersionForProfile(profile_id) == UNKNOWN:
-            generic_logger.warning('Version of profile %s is unknown, '
-                                   'refusing to upgrade.', profile_id)
+            if not quiet:
+                generic_logger.warning('Version of profile %s is unknown, '
+                                       'refusing to upgrade.', profile_id)
             return
         if dest is not None:
             # Upgrade to a specific destination version, if found.
             if isinstance(dest, six.string_types):
                 dest = tuple(dest.split('.'))
             if self.getLastVersionForProfile(profile_id) == dest:
-                generic_logger.warning('Profile %s is already at wanted '
-                                       'destination %r.', profile_id,
-                                       _version_for_print(dest))
+                if not quiet:
+                    generic_logger.warning('Profile %s is already at wanted '
+                                           'destination %r.', profile_id,
+                                           _version_for_print(dest))
                 return
         upgrades = self.listUpgrades(profile_id)
         # First get a list of single steps to apply.  This may be
@@ -1180,7 +1184,7 @@ class SetupTool(Folder):
                     profile_id,
                     _version_for_print(
                         self.getLastVersionForProfile(profile_id)))
-        else:
+        elif not quiet:
             generic_logger.info(
                 'No upgrades available for profile %s. '
                 'Profile stays at version %r.', profile_id,


### PR DESCRIPTION
Then we do not complain when the profile is not installed or needs no upgrade.
Default value is False, so when you do not use this option, the behavior and output is the same as before.

Use case in Plone is that we have a list of profiles that we try to upgrade.
But when a profile is not installed yet, we do not want to run upgrade steps.
And when a profile is already upgraded to the latest version, we do not need to do anything either.
This works fine with the current `upgradeProfile` code, but various warnings and info messages are printed that we are not interested in, and that may drown out the interesting output about real changes that happened.
Current sample output:

```
INFO     No upgrades available for profile Products.CMFEditions:CMFEditions. Profile stays at version '11'.
WARNING  Version of profile Products.CMFPlacefulWorkflow:CMFPlacefulWorkflow is unknown, refusing to upgrade.
INFO     No upgrades available for profile Products.PlonePAS:PlonePAS. Profile stays at version '5'.
INFO     No upgrades available for profile plone.app.caching:default. Profile stays at version '3'.
INFO     No upgrades available for profile plone.app.contenttypes:default. Profile stays at version '3000'.
INFO     No upgrades available for profile plone.app.dexterity:default. Profile stays at version '2006'.
INFO     No upgrades available for profile plone.app.discussion:default. Profile stays at version '1004'.
INFO     No upgrades available for profile plone.app.event:default. Profile stays at version '15'.
INFO     No upgrades available for profile plone.app.iterate:default. Profile stays at version '121'.
WARNING  Version of profile plone.app.multilingual:default is unknown, refusing to upgrade.
INFO     No upgrades available for profile plone.app.querystring:default. Profile stays at version '13'.
INFO     No upgrades available for profile plone.app.theming:default. Profile stays at version '1002'.
INFO     No upgrades available for profile plone.app.users:default. Profile stays at version '1'.
INFO     No upgrades available for profile plone.restapi:default. Profile stays at version '0006'.
WARNING  Version of profile plone.session:default is unknown, refusing to upgrade.
INFO     No upgrades available for profile plone.staticresources:default. Profile stays at version '208'.
WARNING  Version of profile plone.volto:default is unknown, refusing to upgrade.
```