### PR TITLE
Add options dest and simple to listUpgrades, and add hasUpgrades

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 2.1.6 (unreleased)
 ------------------
 
+- Add method ``tool.hasUpgrades``.
+  This is more efficient than checking if ``tool.listUpgrades`` returns a non-empty list.
+
+- Add options ``dest`` and ``simple`` to ``tool.listUpgrades``.
+  Use this to simplify the ``upgradeProfile`` method.
+
 - Fix #118: Import handler not found .
   (`#118 <https://github.com/zopefoundation/Products.GenericSetup/issues/118>`_)
 

--- a/src/Products/GenericSetup/upgrade.py
+++ b/src/Products/GenericSetup/upgrade.py
@@ -37,23 +37,35 @@ def _version_matches_all(version):
     return version in (None, 'unknown', 'all')
 
 
-def _version_matches(source, step_source, step_dest, strict=False):
-    if _version_matches_all(source):
-        return True
+def _version_matches(source, step_source, step_dest, strict=False, dest=None):
     # Step source and destination must match.
+    source_matches_all = _version_matches_all(source)
+    dest_matches_all = _version_matches_all(dest)
+    if source_matches_all and dest_matches_all:
+        return True
     source = normalize_version(source)
-    # Check step source.
-    if not _version_matches_all(step_source):
-        start = normalize_version(step_source)
-        if strict:
-            if start != source:
+    if not source_matches_all:
+        # Check step source.
+        if not _version_matches_all(step_source):
+            start = normalize_version(step_source)
+            if strict:
+                if start != source:
+                    return False
+            elif start < source:
                 return False
-        elif start < source:
-            return False
     # Step source is okay. Now check step destination.
     if _version_matches_all(step_dest):
         return True
     stop = normalize_version(step_dest)
+    # Check maximum or strictly wanted destination.
+    if not dest_matches_all:
+        dest = normalize_version(dest)
+        if strict:
+            if stop != dest:
+                return False
+        elif stop > dest:
+            return False
+
     return stop > source
 
 
@@ -141,19 +153,23 @@ class UpgradeEntity(object):
         self.sortkey = sortkey
         self.profile = profile
 
-    def versionMatch(self, source):
-        return _version_matches(source, self.source, self.dest, strict=True)
+    def versionMatch(self, source, dest=None):
+        return _version_matches(
+            source, self.source, self.dest, strict=True, dest=dest
+        )
 
-    def isProposed(self, tool, source):
+    def isProposed(self, tool, source, dest=None):
         """Check if a step can be applied.
 
         False means already applied or does not apply.
         True means can be applied.
         """
+        if not self.versionMatch(source, dest=dest):
+            return False
         checker = self.checker
         if checker is None:
-            return self.versionMatch(source)
-        return self.versionMatch(source) and checker(tool)
+            return True
+        return checker(tool)
 
 
 class UpgradeStep(UpgradeEntity):
@@ -218,11 +234,13 @@ def _registerNestedUpgradeStep(step, outer_id):
     profile_steps[outer_id] = nested_steps
 
 
-def _extractStepInfo(tool, id, step, source):
+def _extractStepInfo(tool, id, step, source, dest=None):
     """Returns the info data structure for a given step.
     """
-    proposed = step.isProposed(tool, source)
-    if not proposed and not _version_matches(source, step.source, step.dest):
+    proposed = step.isProposed(tool, source, dest=dest)
+    if not proposed and not _version_matches(
+            source, step.source, step.dest, dest=dest
+            ):
         return
     info = {
         'id': id,
@@ -241,26 +259,40 @@ def listProfilesWithUpgrades():
     return _upgrade_registry.keys()
 
 
-def listUpgradeSteps(tool, profile_id, source):
+def listUpgradeSteps(tool, profile_id, source, dest=None, quick=False):
     """Lists upgrade steps available from a given version, for a given
     profile id.
+
+    If 'quick' is True, we return a simple boolean True when we have found the
+    first matching upgrade step.  This is useful when you only want to know
+    if there is at least one upgrade step.  This is used by
+    tool.hasUpgradeSteps.
     """
     res = []
     profile_steps = _upgrade_registry.getUpgradeStepsForProfile(profile_id)
+    # Optionally limit to a maximum destination.
+    if isinstance(dest, six.string_types):
+        dest = tuple(dest.split('.'))
     for id, step in profile_steps.items():
         if isinstance(step, UpgradeEntity):
-            info = _extractStepInfo(tool, id, step, source)
+            info = _extractStepInfo(tool, id, step, source, dest=dest)
             if info is None:
                 continue
+            if quick:
+                return True
             normsrc = normalize_version(step.source)
             res.append(((normsrc, step.sortkey, info['proposed']), info))
         else:  # nested steps
             nested = []
             outer_proposed = False
             for inner_id, inner_step in step:
-                info = _extractStepInfo(tool, inner_id, inner_step, source)
+                info = _extractStepInfo(
+                    tool, inner_id, inner_step, source, dest=dest
+                )
                 if info is None:
                     continue
+                if quick:
+                    return True
                 nested.append(info)
                 outer_proposed = outer_proposed or info['proposed']
             if nested:


### PR DESCRIPTION
Use the new options to simplify the `upgradeProfile` method, where most if this code lived until now.
You can now also pass `dest` to `listUpgradeSteps` and several of its helper methods.
That is where the checks are easiest.

`Products.CMFPlone.MigrationTool` has similar code, so it seemed good to make `listUpgrades` a bit smarter.
See also a long discussion in https://github.com/plone/Products.CMFPlone/issues/3453, but that is mostly internal Plone details.

New method `tool.hasUpgrades` is more efficient than checking if `tool.listUpgrades` returns a non-empty list.

I think I added a good bunch of tests.