### PR TITLE
Remove accidentially added css-class where it not belongs to

### DIFF
--- a/src/Products/GenericSetup/www/sutImportSteps.zpt
+++ b/src/Products/GenericSetup/www/sutImportSteps.zpt
@@ -93,7 +93,6 @@ Reapplying these import steps is potentially a dangerous operation.
 <input type="hidden" name="ids:default:tokens" value="" />
 
 <table cellspacing="0" cellpadding="4" class="table table-hover">
- class="text-center"
  <thead>
   <tr>
    <td class="text-center">


### PR DESCRIPTION
This was added by me as an accident in an earlier commit.