### PR TITLE
Allow importing a context by path, without real profile

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.2.1 (unreleased)
+2.3.0 (unreleased)
 ------------------
 
 - Add method ``tool.runImportStepFromText``.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add ``path`` keyword argument to ``tool.runAllImportStepsFromProfile``.
+  This avoids the need to register a full profile, when you only need
+  to import a few files once in an upgrade step.
+  It is best to use an absolute path.
+  Note that ``metadata.xml`` is never read, so you cannot use dependencies.
 
 
 2.2.0 (2022-04-04)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
+- Add method ``tool.runImportStepFromText``.
+  Pass it a filename, for example ``rolemap.xml`` or ``types/Document.xml`` and some text.
+  This gets saved in a temporary profile which is then applied.
+
 - Add ``path`` keyword argument to ``tool.runAllImportStepsFromProfile``.
   This avoids the need to register a full profile, when you only need
   to import a few files once in an upgrade step.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- You can refer to ``module:path`` as profile.
+  This profile then exists on-the-fly, without registering it.
+  This is useful for profiles that are used only in upgrades,
+  for example: ``my.package:profiles/upgrades/to_42``.
+  You can use this as ``import_profile`` in an ``upgradeDepends`` directive.
+
 - Add method ``tool.runImportStepFromText``.
   Pass it a filename, for example ``rolemap.xml`` or ``types/Document.xml`` and some text.
   This gets saved in a temporary profile which is then applied.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ _BOUNDARY = '\n' + ('-' * 60) + '\n\n'
 
 setup(
     name='Products.GenericSetup',
-    version='2.2.1.dev0',
+    version='2.3.0.dev0',
     description='Read Zope configuration state from profile dirs / tarballs',
     long_description=README + _BOUNDARY + CHANGES,
     classifiers=[

--- a/src/Products/GenericSetup/interfaces.py
+++ b/src/Products/GenericSetup/interfaces.py
@@ -520,9 +520,14 @@ class ISetupTool(Interface):
             step
         """
 
-    def runAllImportStepsFromProfile(profile_id, purge_old=None,
+    def runAllImportStepsFromProfile(profile_id,
+                                     purge_old=None,
                                      ignore_dependencies=False,
-                                     blacklisted_steps=None):
+                                     archive=None,
+                                     blacklisted_steps=None,
+                                     dependency_strategy=None,
+                                     path=None):
+
         """ Run all setup steps for the given profile in dependency order.
 
         o 'profile_id' must be a valid ID of a registered profile;
@@ -535,8 +540,26 @@ class ISetupTool(Interface):
         o Unless 'ignore_dependencies' is true this will also import
           all profiles this profile depends on.
 
+        o 'archive' is a tarball with files to import.
+          Note that metadata.xml is never read, so you cannot use dependencies.
+
         o 'blacklisted_steps' can be a list of step-names that won't be
           executed. Use with special care and only for special cases.
+
+        o 'dependency_strategy' is an integer describing what do we do with
+          already applied dependency profiles.  The default is to apply new
+          profiles (of course), and upgrade outdated ones.
+          See 'DEFAULT_DEPENDENCY_STRATEGY' in 'tool.py'
+
+        o 'path' is the path to a directory with files to import.
+          This avoids the need to register a full profile, when you only need
+          to import a few files once in an upgrade step.
+          It is best to use an absolute path.
+          Note that metadata.xml is never read, so you cannot use dependencies.
+
+        o First the code should find a profile via the 'profile_id'.
+          If nothing is found, the 'archive' is tried.
+          If nothing is found, the 'path' is tried.
 
 
         o Return a mapping, with keys:

--- a/src/Products/GenericSetup/registry.py
+++ b/src/Products/GenericSetup/registry.py
@@ -15,6 +15,7 @@
 
 
 import logging
+import os
 import types
 from xml.sax import parseString
 from xml.sax.handler import ContentHandler
@@ -699,6 +700,22 @@ class ProfileRegistry(Implicit):
 
         result = self._registered.get(profile_id)
         if result is None:
+            if profile_id.count(":") == 1:
+                # Try one alternative: module:path
+                module_name, path = profile_id.split(":")
+                module = _resolveDottedName(module_name)
+                if module is not None:
+                    if os.path.exists(os.path.join(module.__path__[0], path)):
+                        # directory import
+                        info = {'id': profile_id,
+                                'title': u'',
+                                'description': u'',
+                                'path': path,
+                                'product': module_name,
+                                'type': None,
+                                'for': None}
+                        return info
+
             raise KeyError(profile_id)
         if for_ is not None:
             if not issubclass(for_, result['for']):

--- a/src/Products/GenericSetup/tests/test_registry.py
+++ b/src/Products/GenericSetup/tests/test_registry.py
@@ -1036,7 +1036,26 @@ class ProfileRegistryTests(BaseRegistryTests, ConformsToIProfileRegistry):
                           'path': u'',
                           'product': u'',
                           'title': u'',
-                         'type': None})
+                          'type': None})
+
+    def test_getProfileInfo_directory_exists(self):
+        # Since GenericSetup 2.3.0 you can refer to module:path as profile.
+        # This profile then exists on-the-fly, without registering it.
+        registry = self._makeOne()
+        profile_id = 'Products.GenericSetup:tests/default_profile'
+        self.assertEqual(registry.getProfileInfo(profile_id),
+                         {'description': u'',
+                          'for': None,
+                          'id': profile_id,
+                          'path': u'tests/default_profile',
+                          'product': u'Products.GenericSetup',
+                          'title': u'',
+                          'type': None})
+
+    def test_getProfileInfo_directory_non_existing(self):
+        registry = self._makeOne()
+        with self.assertRaises(KeyError):
+            registry.getProfileInfo('Products.GenericSetup:foobar')
 
 
 def test_suite():

--- a/src/Products/GenericSetup/tests/test_tool.py
+++ b/src/Products/GenericSetup/tests/test_tool.py
@@ -871,6 +871,104 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self.assertEqual(tool.pre_handler_called, 2)
         self.assertEqual(tool.post_handler_called, 2)
 
+    def test_runAllImportStepsFromProfile_with_path_simple(self):
+        site = self._makeSite()
+        tool = self._makeOne('setup_tool').__of__(site)
+        _imported = []
+
+        def applyContext(context):
+            _imported.append(context._profile_path)
+
+        tool.applyContext = applyContext
+        tool.runAllImportStepsFromProfile(None, path=self._PROFILE_PATH)
+        self.assertEqual(_imported, [self._PROFILE_PATH])
+        tool.runAllImportStepsFromProfile(None, path=self._PROFILE_PATH2)
+        self.assertEqual(_imported, [self._PROFILE_PATH, self._PROFILE_PATH2])
+
+    def test_runAllImportStepsFromProfile_with_path_no_dependencies(self):
+        # When importing a path, the metadata.xml is never read, so
+        # dependencies are ignored.  Same will be true for archives/tarballs.
+        # Theoretically this could be fixed.  But if you need this, then you
+        # might as well just register an actual profile.
+        from ..metadata import METADATA_XML
+
+        # Add metadata with dependencies in the directory and register the
+        # dependency profile.
+        self._makeFile(METADATA_XML, _METADATA_XML)
+        site = self._makeSite()
+        tool = self._makeOne('setup_tool').__of__(site)
+        profile_registry.registerProfile('bar', 'Bar', '', self._PROFILE_PATH2)
+
+        _imported = []
+
+        def applyContext(context):
+            _imported.append(context._profile_path)
+
+        tool.applyContext = applyContext
+        tool.runAllImportStepsFromProfile(
+            None, path=self._PROFILE_PATH)
+        # Only the path of the directory will have been imported,
+        # not the dependency profile.
+        self.assertEqual(_imported, [self._PROFILE_PATH])
+
+    def test_runAllImportStepsFromProfile_with_path_purging(self):
+        # Tests for importing a directory with GenericSetup files.
+        # We are especially interested to see if old settings get purged.
+        # This is adapted from test_manage_importTarball.
+        # Note that purging is handled differently for tarballs and
+        # directories.
+        site = self._makeSite()
+        site.setup_tool = self._makeOne('setup_tool')
+        tool = site.setup_tool
+        # We need to be Manager to see the result of calling
+        # manage_importTarball.
+        newSecurityManager(None, UnrestrictedUser('root', '', ['Manager'], ''))
+
+        ROLEMAP_XML = """<?xml version="1.0"?>
+<rolemap>
+  <roles>
+    <role name="%s" />
+  </roles>
+  <permissions />
+</rolemap>
+"""
+
+        def add_rolemap_to_dir(name):
+            # Create a file rolemap.xml containing 'name' as role.
+            # Put this in the directory on the profile path.
+            contents = ROLEMAP_XML % name
+            if isinstance(contents, six.text_type):
+                contents = contents.encode('utf-8')
+            self._makeFile('rolemap.xml', contents)
+
+        # Import first role.
+        add_rolemap_to_dir('First')
+        tool.runAllImportStepsFromProfile(None, path=self._PROFILE_PATH)
+        self.assertTrue('First' in site.valid_roles())
+
+        # Import second role.
+        add_rolemap_to_dir('Second')
+        tool.runAllImportStepsFromProfile(None, path=self._PROFILE_PATH)
+        self.assertTrue('Second' in site.valid_roles())
+        # The first role is still there, because by default we do not purge.
+        self.assertTrue('First' in site.valid_roles())
+
+        # Import third role in purge mode.
+        add_rolemap_to_dir('Third')
+        tool.runAllImportStepsFromProfile(None, path=self._PROFILE_PATH,
+                                          purge_old=True)
+        self.assertTrue('Third' in site.valid_roles())
+        # The other roles are gone.
+        self.assertFalse('First' in site.valid_roles())
+        self.assertFalse('Second' in site.valid_roles())
+
+        # A few standard roles are never removed, probably because they are
+        # defined one level higher.
+        self.assertTrue('Anonymous' in site.valid_roles())
+        self.assertTrue('Authenticated' in site.valid_roles())
+        self.assertTrue('Manager' in site.valid_roles())
+        self.assertTrue('Owner' in site.valid_roles())
+
     def test_runExportStep_nonesuch(self):
         site = self._makeSite()
         tool = self._makeOne('setup_tool').__of__(site)

--- a/src/Products/GenericSetup/tests/test_tool.py
+++ b/src/Products/GenericSetup/tests/test_tool.py
@@ -2125,6 +2125,15 @@ class SetupToolTests(FilesystemTestBase, TarballTester, ConformsToISetupTool):
         self.assertFalse(tool.profileExists(None))
         self.assertFalse(tool.profileExists('nonesuch'))
 
+        # Since GenericSetup 2.3.0 you can refer to module:path as profile.
+        # This profile then exists on-the-fly, without registering it.
+        self.assertTrue(
+            tool.profileExists('Products.GenericSetup:tests/default_profile'))
+        self.assertTrue(
+            tool.profileExists('Products.GenericSetup.tests:default_profile'))
+        self.assertTrue(tool.profileExists('Products.GenericSetup:browser'))
+        self.assertFalse(tool.profileExists('Products.GenericSetup:foobar'))
+
     def test_getDependenciesForProfile(self):
         from ..interfaces import EXTENSION
         from ..metadata import METADATA_XML

--- a/src/Products/GenericSetup/tool.py
+++ b/src/Products/GenericSetup/tool.py
@@ -428,9 +428,13 @@ class SetupTool(Folder):
             if path is None:
                 prefix = 'import-all-from-tar'
             else:
+                # We could add the actual path, but that shows the full path
+                # in the report id, which gets ugly, for example:
+                # 'import-all-from-path-home_username_.cached-eggs...'
                 prefix = 'import-all-from-path'
         else:
-            prefix = 'import-all-%s' % profile_id.replace(':', '_')
+            prefix = 'import-all-%s' % profile_id.replace(
+                ':', '_').replace('/', '_')
         name = self._mangleTimestampName(prefix, 'log')
         self._createReport(name, result['steps'], result['messages'])
 

--- a/src/Products/GenericSetup/tool.py
+++ b/src/Products/GenericSetup/tool.py
@@ -62,6 +62,7 @@ from .upgrade import listProfilesWithUpgrades
 from .upgrade import listUpgradeSteps
 from .utils import _computeTopologicalSort
 from .utils import _getProductPath
+from .utils import _profile_directory_with_one_file
 from .utils import _resolveDottedName
 from .utils import _version_for_print
 from .utils import _wwwdir
@@ -338,6 +339,24 @@ class SetupTool(Folder):
         """ See ISetupTool.
         """
         return self._toolset_registry
+
+    @security.protected(ManagePortal)
+    def runImportStepFromText(self, filename, contents, purge_old=False):
+        """Create an import context on-the-fly to run one import step.
+
+        Note that all import steps will be run, but normally only one step
+        will match the filename and actually do something.
+
+        'filename' may contain one slash to indicate a sub directory.
+
+        Example calls:
+
+        runImportStepFromText('rolemap.xml', '<xml />')
+        runImportStepFromText('types/Document.xml', '<xml />')
+        """
+        with _profile_directory_with_one_file(filename, contents) as path:
+            self.runAllImportStepsFromProfile(None, path=path,
+                                              purge_old=purge_old)
 
     @security.protected(ManagePortal)
     def runImportStepFromProfile(self, profile_id, step_id,


### PR DESCRIPTION
In this PR are some new features to make upgrades simpler.

In Plone (core and add-ons) we often create so called "upgrade profiles". These are basically the same as standard extension profiles, just with the specific goal of being used once to upgrade the default profile.  Along with this upgrade profile, the package ships an upgrade step to apply the upgrade profile. For example, `plone.app.mosaic` has a `default` profile and then this for upgrades:

```
  <genericsetup:registerProfile
      name="to_6000"
      title="Upgrade profile to 6000"
      description=""
      provides="Products.GenericSetup.interfaces.EXTENSION"
      for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
      directory="profiles/upgrades/to_6000"
      />

   <genericsetup:upgradeStep
      title="Upgrade registry configuration"
      profile="plone.app.mosaic:default"
      source="5030"
      destination="6000"
      handler=".upgrades.upgrade_to_6000"
      />
------
PROFILE_ID = "profile-plone.app.mosaic:default"

def upgrade_to_6000(context):
    context.runImportStepFromProfile(
        PROFILE_ID.replace("default", "to_6000"), "plone.app.registry"
    )

```

The first commit in this PR changes `runAllImportStepsFromProfile` to accept a `path` argument. It then becomes a bit simpler, because the upgrade profile no longer has to be registered:

```
   <genericsetup:upgradeStep
      title="Upgrade registry configuration"
      profile="plone.app.mosaic:default"
      source="5030"
      destination="6000"
      handler=".upgrades.upgrade_to_6000"
      />
----------
def _profile_path(name):
    return os.path.join(os.path.dirname(__file__), "profiles", "upgrades", name)

def upgrade_to_6000(context):
    context.runAllImportStepsFromProfile(None, path=_profile_path("to_6000"))
```

The last commit makes it even simpler, by allowing to use `module:sub/path` as profile id. Now you only need one zcml snippet and no Python:

```
  <genericsetup:upgradeDepends
      title="Upgrade registry configuration 2"
      profile="plone.app.mosaic:default"
      source="5030"
      destination="6000"
      import_profile="plone.app.mosaic:profiles/upgrades/to_6000"
      />
```

One other, separate improvement is in the second commit. The setup tool gains a method `runImportStepFromText`. This is useful if you have an xml snippet that would do what you want, but you need to do this in Python code instead. You could search for the import step handler and copy the relevant code from there, which can be very tricky. Or you could register a profile and create a directory and a file, and call this profile, but that seems overkill.
Instead you can now do this:

```
runImportStepFromText('rolemap.xml', '<xml />')
```

Technically, despite the name, this runs not one but _all_ import steps, but only the one that reads `rolemap.xml` will actually do anything.

Two important notes for these on-the-fly profiles:
- The `metadata.xml` is not read, so you cannot use this to install dependencies. I think the same is already true for the tarball imports. There should be a way around this, but it needs changes in lots of methods. I don't think this is really needed.
- The `pre_handler` and `post_handler` are not available.

Together, these three improvements offer ways to avoid creating upgrade profiles, which often feels like overkill to me, and which leads to lots of profiles:

![Screenshot 2022-08-20 at 00 55 59](https://user-images.githubusercontent.com/210587/185717140-10ab9dae-e879-4cc0-84db-5a9ab7842c0b.png)
