### PR TITLE
Add import_path to upgradeDepends directive.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,17 @@
 Changelog
 =========
 
-2.2.1 (unreleased)
+2.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add ``import_path`` to ``upgradeDepends`` directive.
+  This avoids the need to register a full profile, when you only need
+  to import a few files once in an upgrade step.
+  The path must be within the path of a package.
+  By default this is the path of the profile for which this is an upgrade.
+  You can also specify a path in a different package: ``other.package:profile/path``.
+  You can combine this with ``import_steps``, but not with ``import_profile``.
+  Note that ``metadata.xml`` is never read, so you cannot use dependencies.
 
 
 2.2.0 (2022-04-04)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ _BOUNDARY = '\n' + ('-' * 60) + '\n\n'
 
 setup(
     name='Products.GenericSetup',
-    version='2.2.1.dev0',
+    version='2.3.0.dev0',
     description='Read Zope configuration state from profile dirs / tarballs',
     long_description=README + _BOUNDARY + CHANGES,
     classifiers=[

--- a/src/Products/GenericSetup/interfaces.py
+++ b/src/Products/GenericSetup/interfaces.py
@@ -497,11 +497,13 @@ class ISetupTool(Interface):
         """
 
     def runImportStepFromProfile(profile_id, step_id,
-                                 run_dependencies=True, purge_old=None):
+                                 run_dependencies=True, purge_old=None,
+                                 path=None):
         """ Execute a given setup step from the given profile.
 
         o 'profile_id' must be a valid ID of a registered profile;
            otherwise, raise KeyError.
+           But if it is None, we look at the 'path' argument.
 
         o 'step_id' is the ID of the step to run.
 
@@ -512,6 +514,13 @@ class ISetupTool(Interface):
         o If 'run_dependencies' is True, then run any out-of-date
           dependency steps first.
 
+        o 'path' is the path to a directory with files to import.
+          This avoids the need to register a full profile, when you only need
+          to import a few files once in an upgrade step.
+          It is best to use an absolute path, otherwise it would depend on
+          your working directory.
+          Note that metadata.xml is never read, so you cannot use dependencies.
+
         o Return a mapping, with keys:
 
           'steps' -- a sequence of IDs of the steps run.
@@ -520,13 +529,19 @@ class ISetupTool(Interface):
             step
         """
 
-    def runAllImportStepsFromProfile(profile_id, purge_old=None,
+    def runAllImportStepsFromProfile(profile_id,
+                                     purge_old=None,
                                      ignore_dependencies=False,
-                                     blacklisted_steps=None):
+                                     archive=None,
+                                     blacklisted_steps=None,
+                                     dependency_strategy=None,
+                                     path=None):
+
         """ Run all setup steps for the given profile in dependency order.
 
         o 'profile_id' must be a valid ID of a registered profile;
            otherwise, raise KeyError.
+           But if it is None, we look at the 'archive' and 'path' arguments.
 
         o If 'purge_old' is True, then run each step after purging any
           "old" setup first (this is the responsibility of the step,
@@ -535,9 +550,27 @@ class ISetupTool(Interface):
         o Unless 'ignore_dependencies' is true this will also import
           all profiles this profile depends on.
 
+        o 'archive' is a tarball with files to import.
+          Note that metadata.xml is never read, so you cannot use dependencies.
+
         o 'blacklisted_steps' can be a list of step-names that won't be
           executed. Use with special care and only for special cases.
 
+        o 'dependency_strategy' is an integer describing what do we do with
+          already applied dependency profiles.  The default is to apply new
+          profiles (of course), and upgrade outdated ones.
+          See 'DEFAULT_DEPENDENCY_STRATEGY' in 'tool.py'
+
+        o 'path' is the path to a directory with files to import.
+          This avoids the need to register a full profile, when you only need
+          to import a few files once in an upgrade step.
+          It is best to use an absolute path, otherwise it would depend on
+          your working directory.
+          Note that metadata.xml is never read, so you cannot use dependencies.
+
+        o First the code should find a profile via the 'profile_id'.
+          If nothing is found, the 'archive' is tried.
+          If nothing is found, the 'path' is tried.
 
         o Return a mapping, with keys:
 

--- a/src/Products/GenericSetup/tests/test_zcml.py
+++ b/src/Products/GenericSetup/tests/test_zcml.py
@@ -289,6 +289,10 @@ def test_registerUpgradeSteps(self):
       ...       run_deps="True"
       ...       purge="True"
       ...       />
+      ...   <genericsetup:upgradeDepends
+      ...       title="Bar Upgrade dependency profile import steps"
+      ...       import_path="dummy-path"
+      ...       />
       ...  </genericsetup:upgradeSteps>
       ... </configure>'''
       >>> zcml.load_config('meta.zcml', Products.GenericSetup)
@@ -306,11 +310,13 @@ def test_registerUpgradeSteps(self):
       >>> isinstance(steps, list)
       True
       >>> len(steps)
-      3
-      >>> step1, step2, step3 = steps
-      >>> step1['source'] == step2['source'] == step3['source'] == ('1', '0')
+      4
+      >>> step1, step2, step3, step4 = steps
+      >>> step1['source'] == step2['source'] == step3['source'] \
+              == step4['source'] == ('1', '0')
       True
-      >>> step1['dest'] == step2['dest'] == step3['dest'] == ('1', '1')
+      >>> step1['dest'] == step2['dest'] == step3['dest'] \
+              == step4['dest'] == ('1', '1')
       True
       >>> step1['step'].handler
       <function b_dummy_upgrade at ...>
@@ -328,6 +334,8 @@ def test_registerUpgradeSteps(self):
       True
       >>> step3['step'].purge
       True
+      >>> str(step4['step'].import_path)
+      'dummy-path'
 
     First one listed should be second in the registry due to sortkey:
 

--- a/src/Products/GenericSetup/tool.py
+++ b/src/Products/GenericSetup/tool.py
@@ -341,10 +341,11 @@ class SetupTool(Folder):
 
     @security.protected(ManagePortal)
     def runImportStepFromProfile(self, profile_id, step_id,
-                                 run_dependencies=True, purge_old=None):
+                                 run_dependencies=True, purge_old=None,
+                                 path=None):
         """ See ISetupTool.
         """
-        context = self._getImportContext(profile_id, purge_old)
+        context = self._getImportContext(profile_id, purge_old, path=path)
 
         self.applyContext(context)
 
@@ -391,7 +392,8 @@ class SetupTool(Folder):
                                      ignore_dependencies=False,
                                      archive=None,
                                      blacklisted_steps=None,
-                                     dependency_strategy=None):
+                                     dependency_strategy=None,
+                                     path=None):
         """ See ISetupTool.
         """
         __traceback_info__ = profile_id
@@ -402,11 +404,19 @@ class SetupTool(Folder):
                             archive=archive,
                             ignore_dependencies=ignore_dependencies,
                             blacklisted_steps=blacklisted_steps,
-                            dependency_strategy=dependency_strategy)
+                            dependency_strategy=dependency_strategy,
+                            path=path)
         if profile_id is None:
-            prefix = 'import-all-from-tar'
+            if path is None:
+                prefix = 'import-all-from-tar'
+            else:
+                # We could add the actual path, but that shows the full path
+                # in the report id, which gets ugly, for example:
+                # 'import-all-from-path-home_username_.cached-eggs...'
+                prefix = 'import-all-from-path'
         else:
-            prefix = 'import-all-%s' % profile_id.replace(':', '_')
+            prefix = 'import-all-%s' % profile_id.replace(
+                ':', '_').replace('/', '_')
         name = self._mangleTimestampName(prefix, 'log')
         self._createReport(name, result['steps'], result['messages'])
 
@@ -1214,13 +1224,17 @@ class SetupTool(Folder):
     #   Helper methods
     #
     @security.private
-    def _getImportContext(self, context_id, should_purge=None, archive=None):
+    def _getImportContext(self,
+                          context_id,
+                          should_purge=None,
+                          archive=None,
+                          path=None):
         """ Crack ID and generate appropriate import context.
 
-        Note: it seems context_id (profile id) and archive (tarball)
-        are mutually exclusive.  Exactly one of the two should be
-        None.  There seems to be no use case for a different
-        combination.
+        Note: context_id (profile id), archive (tarball) and path (directory)
+        are mutually exclusive.  Exactly one of these should be set.
+        The others should be None.  There seems to be no use case for a
+        different combination.
         """
         encoding = self.getEncoding()
 
@@ -1251,6 +1265,12 @@ class SetupTool(Folder):
                                         archive_bits=archive,
                                         encoding='UTF8',
                                         should_purge=should_purge)
+
+        if path is not None:
+            if should_purge is None:
+                should_purge = False
+            return DirectoryImportContext(self, path, should_purge,
+                                          encoding)
 
         raise KeyError('Unknown context "%s"' % context_id)
 
@@ -1391,7 +1411,8 @@ class SetupTool(Folder):
                                    archive=None,
                                    ignore_dependencies=False,
                                    blacklisted_steps=None,
-                                   dependency_strategy=None):
+                                   dependency_strategy=None,
+                                   path=None):
 
         # 1. Determine upgrade strategy.
         #    What do we do with already applied dependency profiles?
@@ -1425,9 +1446,10 @@ class SetupTool(Folder):
         else:
             raise ValueError('Unknown dependency_strategy %r.' %
                              dependency_strategy)
+        main_profile_id = profile_id or path or 'archive'
         generic_logger.info(
             'Importing profile %s with dependency strategy %s.',
-            profile_id, dependency_strategy)
+            main_profile_id, dependency_strategy)
 
         # 2. Gather a list of profiles to handle.
 
@@ -1441,7 +1463,8 @@ class SetupTool(Folder):
         else:
             # Two possibilities:
             # - We ignore dependencies, so we have a single profile id.
-            # - Profile id is None and we import a tarball (in the archive).
+            # - Profile id is None and we import a tarball (in the archive)
+            #   or a profile from a path.
             chain = [profile_id]
 
         # 3. For each profile, depending on the keyword arguments, either:
@@ -1460,13 +1483,14 @@ class SetupTool(Folder):
             try:
                 profile_info = self.getProfileInfo(profile_id)
             except KeyError:
-                # this will be a snapshot profile
+                # this will be a snapshot profile or a path
                 profile_info = {}
                 profile_type = None
             else:
                 profile_type = profile_info.get('type')
             if num == last_num:
-                generic_logger.info('Applying main profile %s', profile_id)
+                generic_logger.info('Applying main profile %s',
+                                    main_profile_id)
             else:
                 # This is a dependency profile.  This means we are not
                 # completely ignoring them, otherwise it would not
@@ -1488,7 +1512,8 @@ class SetupTool(Folder):
             # The next lines are done at least for the main profile.
             # Possibly also for dependency profiles, depending on the
             # condition above.  It applies the profile.
-            context = self._getImportContext(profile_id, purge_old, archive)
+            context = self._getImportContext(
+                profile_id, purge_old, archive, path)
             self.applyContext(context)
             if detect_steps:
                 steps = self.getSortedImportSteps()


### PR DESCRIPTION
This avoids the need to register a full profile, when you only need to import a few files once in an upgrade step.

The path must be within the path of a package.
By default this is the path of the profile for which this is an upgrade.
You can also specify a path in a different package: ``other.package:profile/path``.
This is to avoid easy information leaks, like trying to read password files, although the user running the zope process should not have access to sensitive files anyway.

You can combine this with ``import_steps``, but not with ``import_profile``.
Note that ``metadata.xml`` is never read, so you cannot use dependencies.

This adds the path keyword argument to several methods, like ``tool.runAllImportStepsFromProfile`` and ``tool.runImportStepFromProfile``.