### PR TITLE
Fix 126: Handle legacy versions in upgrades also with setuptools 66+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
+- Fix 126: Handle legacy versions in upgrades also with setuptools 66 or higher.
+  (`#126 <https://github.com/zopefoundation/Products.GenericSetup/issues/126>`_)
+
 
 3.0.0 (2023-02-01)
 ------------------

--- a/src/Products/GenericSetup/tests/upgrade.txt
+++ b/src/Products/GenericSetup/tests/upgrade.txt
@@ -34,6 +34,26 @@ normalize_version
     >>> normalize_version(('1', '1')) == normalize_version('1.1')
     True
 
+With setuptools 66+, parse_version fails for versions that would previously have been seen as LegacyVersion.
+Check that we can handle this.  We treat empty or unknown versions as zero.
+
+    >>> normalize_version('unknown') == normalize_version('0')
+    True
+    >>> normalize_version('') == normalize_version('0')
+    True
+    >>> normalize_version(None) == normalize_version('0')
+    True
+    >>> normalize_version('unknown') < normalize_version('1')
+    True
+
+We treat bad versions as '0+badversion'.
+That is harder to check here, as we want the tests to also pass for older setuptools versions.
+
+    >>> normalize_version('bad') < normalize_version('1')
+    True
+    >>> normalize_version('0+bad') < normalize_version('1')
+    True
+
 
 _version_matches_all
 -------------------

--- a/src/Products/GenericSetup/upgrade.py
+++ b/src/Products/GenericSetup/upgrade.py
@@ -25,9 +25,19 @@ from Products.GenericSetup.utils import _getHash
 def normalize_version(version):
     if isinstance(version, tuple):
         version = '.'.join(version)
-    elif version is None:
-        version = ''
-    return parse_version(version)
+    elif not version or version == 'unknown':
+        version = '0'
+    try:
+        return parse_version(version)
+    except Exception:
+        # Likely setuptools 66+ raises
+        # pkg_resources.extern.packaging.version.InvalidVersion
+        # but it does not feel safe to import it from that path.
+        # Older setuptools versions created a LegacyVersion when parsing to a
+        # proper number fails.  Let's use local version segments to have a
+        # strict version and still have a sort order.  See
+        # https://github.com/zopefoundation/Products.GenericSetup/issues/126
+        return parse_version(f'0+{version}')
 
 
 def _version_matches_all(version):


### PR DESCRIPTION
With setuptools 66+, when parsing fails, we retry with `0+<legacy version>` With earlier setuptools we still get a LegacyVersion if the version cannot be strictly parsed, so this part does not change.

In all cases, if we get an empty version or the special version `unknown`, we treat it as zero.

Fixes #126.