### PR TITLE
Prefer `component` (over  `factory`) in the serialization of utility registrations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 3.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use ``component`` in the serialization of utility registrations
+  if the registered component is a "global object".
+  Fixes
+  `#6 <https://github.com/zopefoundation/Products.GenericSetup/issues/6>_`.
 
 
 3.0.1 (2023-03-03)

--- a/src/Products/GenericSetup/components.py
+++ b/src/Products/GenericSetup/components.py
@@ -29,6 +29,7 @@ from .interfaces import IComponentsHandlerBlacklist
 from .interfaces import ISetupEnviron
 from .utils import XMLAdapterBase
 from .utils import _getDottedName
+from .utils import _isGlobalObject
 from .utils import _resolveDottedName
 
 
@@ -495,7 +496,7 @@ class ComponentRegistryXMLAdapter(XMLAdapterBase):
                         # This is a five.localsitemanager wrapped utility
                         factory = _getDottedName(type(aq_base(comp)))
                         child.setAttribute('factory', factory)
-                elif comp is _resolveDottedName(_getDottedName(comp)):
+                elif _isGlobalObject(comp):
                     child.setAttribute('component', _getDottedName(comp))
                 else:
                     factory = _getDottedName(type(comp))

--- a/src/Products/GenericSetup/components.py
+++ b/src/Products/GenericSetup/components.py
@@ -495,6 +495,8 @@ class ComponentRegistryXMLAdapter(XMLAdapterBase):
                         # This is a five.localsitemanager wrapped utility
                         factory = _getDottedName(type(aq_base(comp)))
                         child.setAttribute('factory', factory)
+                elif comp is _resolveDottedName(_getDottedName(comp)):
+                    child.setAttribute('component', _getDottedName(comp))
                 else:
                     factory = _getDottedName(type(comp))
                     child.setAttribute('factory', factory)

--- a/src/Products/GenericSetup/tests/test_components.py
+++ b/src/Products/GenericSetup/tests/test_components.py
@@ -239,6 +239,20 @@ _REMOVE_IMPORT = b"""\
 """
 
 
+_INTERFACE_COMPONENT = b"""\
+<?xml version="1.0" encoding="utf-8"?>
+<componentregistry>
+ <adapters/>
+ <subscribers/>
+ <utilities>
+  <utility name="test_interface"
+     component="Products.GenericSetup.tests.test_components.ITestInterface"
+     interface="Products.GenericSetup.tests.test_components.ITestInterfaceType"/>
+ </utilities>
+</componentregistry>
+"""
+
+
 class ComponentRegistryXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
 
     layer = ExportImportZCMLLayer
@@ -434,6 +448,27 @@ class ComponentRegistryXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
         util = queryUtility(IDummyInterface2, name='dummy tool name2')
         self.assertFalse(util is None)
 
+    def test_export_interface_component(self):
+        sm = self._obj
+        sm.registerUtility(ITestInterface,
+                           ITestInterfaceType,
+                           "test_interface")
+        context = DummySetupEnviron()
+        adapted = getMultiAdapter((sm, context), IBody)
+        body = adapted.body
+        self.assertEqual(body, _INTERFACE_COMPONENT)
+
+    def test_import_interface_component(self):
+        from ..components import importComponentRegistry
+        sm = self._obj
+        context = DummyImportContext(sm, False)
+        context._files['componentregistry.xml'] = _INTERFACE_COMPONENT
+        importComponentRegistry(context)
+        self.assertIs(
+            sm.queryUtility(ITestInterfaceType, name="test_interface"),
+            ITestInterface)
+
+
     def setUp(self):
         # Create and enable a local component registry
         site = Folder()
@@ -457,6 +492,14 @@ class ComponentRegistryXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
         gsm = getGlobalSiteManager()
         gsm.unregisterUtility(provided=IComponentsHandlerBlacklist,
                               name='dummy')
+
+
+class ITestInterface(Interface):
+    """interface registered as utility."""
+
+
+class ITestInterfaceType(Interface):
+    """interface provided by ``ITestInterface``."""
 
 
 if PersistentComponents is not None:

--- a/src/Products/GenericSetup/tests/test_components.py
+++ b/src/Products/GenericSetup/tests/test_components.py
@@ -468,7 +468,6 @@ class ComponentRegistryXMLAdapterTests(BodyAdapterTestCase, unittest.TestCase):
             sm.queryUtility(ITestInterfaceType, name="test_interface"),
             ITestInterface)
 
-
     def setUp(self):
         # Create and enable a local component registry
         site = Folder()

--- a/src/Products/GenericSetup/utils.py
+++ b/src/Products/GenericSetup/utils.py
@@ -115,6 +115,15 @@ def _resolveDottedName(dotted):
         return
 
 
+def _isGlobalObject(obj):
+    """Is *obj* identified by a dotted name?"""
+    try:
+        dn = _getDottedName(obj)
+        return obj is _resolveDottedName(dn)
+    except Exception:
+        return False
+
+
 def _extractDocstring(func, default_title, default_description):
     try:
         doc = getdoc(func)


### PR DESCRIPTION
 if the registered component is a "global object". A "global object" is an object identified by a dotted name. Typical global objects are functions and classes defined at module level.

Fixes #6.