### PR TITLE
Fix malformed docstring for rolemap.importRolemap

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 - Move package metadata from setup.py to pyproject.toml.
 
+- Fix malformed docstring in ``rolemap.importRolemap``.
+
 
 5.1.0 (2025-11-19)
 ------------------

--- a/src/Products/GenericSetup/rolemap.py
+++ b/src/Products/GenericSetup/rolemap.py
@@ -55,7 +55,8 @@ def importRolemap(context):
                   version="20040518-01"
                   handler="Products.GenericSetup.rolemap.importRolemap"
                   title="Role / Permission import"
-            >Import additional roles, and map roles to permissions.</setup-step>
+                >Import additional roles, and map roles to permissions.
+            </setup-step>
 
     """
     site = context.getSite()

--- a/src/Products/GenericSetup/rolemap.py
+++ b/src/Products/GenericSetup/rolemap.py
@@ -34,25 +34,28 @@ _FILENAME = 'rolemap.xml'
 
 
 def importRolemap(context):
-    """ Import roles / permission map from an XML file.
+    """Import roles / permission map from an XML file.
 
-    o 'context' must implement IImportContext.
+    -   'context' must implement ``IImportContext``.
+    -   Register via Python.
 
-    o Register via Python:
+        ..  code-block:: python
 
-      registry = site.setup_tool.setup_steps
-      registry.registerStep('importRolemap', '20040518-01',
-                            Products.GenericSetup.rolemap.importRolemap,
-                            (), 'Role / Permission import',
-                            'Import roles and map roles to permissions')
+            registry = site.setup_tool.setup_steps
+            registry.registerStep('importRolemap', '20040518-01',
+                                Products.GenericSetup.rolemap.importRolemap,
+                                (), 'Role / Permission import',
+                                'Import roles and map roles to permissions')
 
-    o Register via XML:
+    -   Register via XML.
 
-      <setup-step id="importRolemap"
+        ..  code-block:: xml
+
+            <setup-step id="importRolemap"
                   version="20040518-01"
                   handler="Products.GenericSetup.rolemap.importRolemap"
                   title="Role / Permission import"
-      >Import additional roles, and map roles to permissions.</setup-step>
+            >Import additional roles, and map roles to permissions.</setup-step>
 
     """
     site = context.getSite()


### PR DESCRIPTION
The docstring was malformed and invalid, resulting in Sphinx build errors in the main Plone documentation.

```
Plone/documentation/venv/lib/python3.13/site-packages/Products/GenericSetup/rolemap.py:docstring of Products.GenericSetup.rolemap.importRolemap:9: ERROR: Unexpected indentation. [docutils]
Plone/documentation/venv/lib/python3.13/site-packages/Products/GenericSetup/rolemap.py:docstring of Products.GenericSetup.rolemap.importRolemap:19: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
```

This PR fixes the docstrings, adding proper lexers. Now it looks purty.

See screenshot.

<img width="826" height="602" alt="Screenshot 2026-05-13 at 4 19 30 AM" src="https://github.com/user-attachments/assets/339ad649-aaf2-466f-855f-29265bd0058f" />

- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added documentation for my changes.
- [x] I included a change log entry in my commits.

Refs: https://github.com/plone/documentation/pull/2083#pullrequestreview-4279947721

When merged, and docs are rebuilt in that PR, then preview the final result at https://plone6--2083.org.readthedocs.build/backend/generic-setup.html#Products.GenericSetup.rolemap.importRolemap